### PR TITLE
feat: comparative baseline metrics (AI vs non-AI)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ Desktop.ini
 .cursorrules
 
 .todo
+ANALYSIS.md
+
+# Blog drafts (local only)
+blog/

--- a/packages/cli/src/commands/report.ts
+++ b/packages/cli/src/commands/report.ts
@@ -5,8 +5,15 @@ import { join } from 'path';
 import { promises as fs } from 'fs';
 import { CLIConfig } from '../schema/config.js';
 
+function formatDelta(value: number, suffix: string): string {
+  const sign = value > 0 ? '+' : '';
+  return `${sign}${value}${suffix}`;
+}
+
 function generateMarkdownReport(metrics: Metrics): string {
   const mergeRatioPct = (metrics.mergeRatio.mergeRatio * 100).toFixed(1);
+  const baselineMergeRatioPct = (metrics.baseline.mergeRatio.mergeRatio * 100).toFixed(1);
+  const deltaMergeRatioPp = Math.round(metrics.delta.mergeRatio * 1000) / 10;
 
   return `# AIDA Report
 
@@ -14,6 +21,15 @@ function generateMarkdownReport(metrics: Metrics): string {
 **Default branch:** ${metrics.defaultBranch}  
 **Window:** ${metrics.window.since || 'beginning'} → ${metrics.window.until || 'now'}  
 **Generated:** ${metrics.generatedAt}
+
+## AI vs Baseline
+
+| Metric | AI commits | Non-AI baseline | Delta |
+|---|---:|---:|---:|
+| Commits | ${metrics.mergeRatio.aiCommitsTotal} | ${metrics.baseline.mergeRatio.commitsTotal} | — |
+| Merge ratio | ${mergeRatioPct}% | ${baselineMergeRatioPct}% | ${formatDelta(deltaMergeRatioPp, ' pp')} |
+| Avg persistence (days) | ${metrics.persistence.avgDays} | ${metrics.baseline.persistence.avgDays} | ${formatDelta(metrics.delta.avgPersistenceDays, '')} |
+| Median persistence (days) | ${metrics.persistence.medianDays} | ${metrics.baseline.persistence.medianDays} | ${formatDelta(metrics.delta.medianPersistenceDays, '')} |
 
 ## Merge Ratio
 - AI-tagged commits (total): ${metrics.mergeRatio.aiCommitsTotal}
@@ -28,6 +44,12 @@ function generateMarkdownReport(metrics: Metrics): string {
 | 0–1d | 2–7d | 8–30d | 31–90d | 90d+ |
 |---:|---:|---:|---:|---:|
 | ${metrics.persistence.buckets.d0_1} | ${metrics.persistence.buckets.d2_7} | ${metrics.persistence.buckets.d8_30} | ${metrics.persistence.buckets.d31_90} | ${metrics.persistence.buckets.d90_plus} |
+
+## Baseline (non-AI commits)
+- Commits (total): ${metrics.baseline.mergeRatio.commitsTotal}
+- Commits merged: ${metrics.baseline.mergeRatio.commitsMerged}
+- **Merge Ratio:** ${baselineMergeRatioPct}%
+- Persistence — commits considered: ${metrics.baseline.persistence.commitsConsidered}, avg: ${metrics.baseline.persistence.avgDays}d, median: ${metrics.baseline.persistence.medianDays}d
 
 ### Caveats
 ${metrics.caveats.map((caveat) => `- ${caveat}`).join('\n')}

--- a/packages/metrics/src/index.ts
+++ b/packages/metrics/src/index.ts
@@ -1,20 +1,34 @@
 import { CommitStream, formatISODate } from '@aida-dev/core';
-import { calculateMergeRatio } from './merge-ratio.js';
-import { calculatePersistence } from './persistence.js';
+import { calculateBaselineMergeRatio, calculateMergeRatio } from './merge-ratio.js';
+import { calculateBaselinePersistence, calculatePersistence } from './persistence.js';
 import { Metrics } from './schema/metrics.js';
 
 export * from './schema/metrics.js';
 export * from './merge-ratio.js';
 export * from './persistence.js';
 
+function round(value: number, decimals: number): number {
+  const factor = 10 ** decimals;
+  return Math.round(value * factor) / factor;
+}
+
 export function calculateMetrics(commitStream: CommitStream): Metrics {
   const mergeRatio = calculateMergeRatio(commitStream);
   const persistence = calculatePersistence(commitStream);
+  const baselineMergeRatio = calculateBaselineMergeRatio(commitStream);
+  const baselinePersistence = calculateBaselinePersistence(commitStream);
+
+  const delta = {
+    mergeRatio: round(mergeRatio.mergeRatio - baselineMergeRatio.mergeRatio, 4),
+    avgPersistenceDays: round(persistence.avgDays - baselinePersistence.avgDays, 2),
+    medianPersistenceDays: round(persistence.medianDays - baselinePersistence.medianDays, 2),
+  };
 
   const caveats = [
     'Persistence is file-level, not line-level.',
     'Merge ratio: commits from all branches checked against default branch ancestry. Squash merges may undercount unmerged commits.',
     'AI tagging uses heuristic patterns; false positives/negatives possible.',
+    'Baseline covers all non-AI-tagged commits; undetected AI usage may leak into the baseline.',
   ];
 
   return {
@@ -27,6 +41,11 @@ export function calculateMetrics(commitStream: CommitStream): Metrics {
     defaultBranch: commitStream.defaultBranch,
     mergeRatio,
     persistence,
+    baseline: {
+      mergeRatio: baselineMergeRatio,
+      persistence: baselinePersistence,
+    },
+    delta,
     caveats,
   };
 }

--- a/packages/metrics/src/merge-ratio.test.ts
+++ b/packages/metrics/src/merge-ratio.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { calculateMergeRatio } from './merge-ratio.js';
+import { calculateBaselineMergeRatio, calculateMergeRatio } from './merge-ratio.js';
 import { CommitStream } from '@aida-dev/core';
 
 describe('Merge Ratio Calculation', () => {
@@ -61,6 +61,81 @@ describe('Merge Ratio Calculation', () => {
 
     expect(result.aiCommitsTotal).toBe(0);
     expect(result.aiCommitsMerged).toBe(0);
+    expect(result.mergeRatio).toBe(0);
+  });
+});
+
+describe('Baseline Merge Ratio Calculation', () => {
+  const baseCommit = {
+    authorName: 'Test User',
+    authorEmail: 'test@example.com',
+    authorDate: '2025-01-01T00:00:00.000Z',
+    committerName: 'Test User',
+    committerEmail: 'test@example.com',
+    committerDate: '2025-01-01T00:00:00.000Z',
+    parents: [],
+    stats: { totalAdditions: 1, totalDeletions: 0, files: [] },
+  };
+
+  it('should calculate baseline merge ratio over non-AI commits only', () => {
+    const mockCommitStream: CommitStream = {
+      repoPath: '/test/repo',
+      defaultBranch: 'main',
+      generatedAt: '2025-01-01T00:00:00.000Z',
+      aiPatterns: [],
+      commits: [
+        {
+          ...baseCommit,
+          hash: 'ai1',
+          message: 'AI: automated commit',
+          inDefaultBranchAncestry: true,
+          tags: { ai: true, level: 'explicit' as const, sources: ['trailer:AI: true'] },
+        },
+        {
+          ...baseCommit,
+          hash: 'human1',
+          message: 'regular commit merged',
+          inDefaultBranchAncestry: true,
+          tags: { ai: false, level: 'none' as const, sources: [] },
+        },
+        {
+          ...baseCommit,
+          hash: 'human2',
+          message: 'regular commit unmerged',
+          inDefaultBranchAncestry: false,
+          tags: { ai: false, level: 'none' as const, sources: [] },
+        },
+      ],
+    };
+
+    const result = calculateBaselineMergeRatio(mockCommitStream);
+
+    expect(result.commitsTotal).toBe(2);
+    expect(result.commitsMerged).toBe(1);
+    expect(result.mergeRatio).toBe(0.5);
+  });
+
+  it('should handle stream with only AI commits', () => {
+    const mockCommitStream: CommitStream = {
+      repoPath: '/test/repo',
+      defaultBranch: 'main',
+      generatedAt: '2025-01-01T00:00:00.000Z',
+      aiPatterns: [],
+      commits: [
+        {
+          ...baseCommit,
+          hash: 'ai1',
+          message: 'AI: automated commit',
+          inDefaultBranchAncestry: true,
+          tags: { ai: true, level: 'explicit' as const, sources: ['trailer:AI: true'] },
+        },
+      ],
+    };
+
+    const result = calculateBaselineMergeRatio(mockCommitStream);
+
+    expect(result.commitsTotal).toBe(0);
+    expect(result.commitsMerged).toBe(0);
     expect(result.mergeRatio).toBe(0);
   });
 });

--- a/packages/metrics/src/merge-ratio.ts
+++ b/packages/metrics/src/merge-ratio.ts
@@ -1,19 +1,28 @@
-import { CommitStream } from '@aida-dev/core';
-import { MergeRatio } from './schema/metrics.js';
+import { Commit, CommitStream } from '@aida-dev/core';
+import { CohortMergeRatio, MergeRatio } from './schema/metrics.js';
+
+function computeMergeRatio(commits: Commit[]): CohortMergeRatio {
+  const merged = commits.filter((commit) => commit.inDefaultBranchAncestry);
+
+  return {
+    commitsTotal: commits.length,
+    commitsMerged: merged.length,
+    mergeRatio: commits.length > 0 ? merged.length / commits.length : 0,
+  };
+}
 
 export function calculateMergeRatio(commitStream: CommitStream): MergeRatio {
   const aiCommits = commitStream.commits.filter((commit) => commit.tags.ai);
-  const aiCommitsMerged = aiCommits.filter((commit) => commit.inDefaultBranchAncestry);
-
-  const aiCommitsTotal = aiCommits.length;
-  const aiCommitsMergedCount = aiCommitsMerged.length;
-
-  // For MVP, since we're only scanning default branch, merged count equals total
-  const mergeRatio = aiCommitsTotal > 0 ? aiCommitsMergedCount / aiCommitsTotal : 0;
+  const result = computeMergeRatio(aiCommits);
 
   return {
-    aiCommitsTotal,
-    aiCommitsMerged: aiCommitsMergedCount,
-    mergeRatio,
+    aiCommitsTotal: result.commitsTotal,
+    aiCommitsMerged: result.commitsMerged,
+    mergeRatio: result.mergeRatio,
   };
+}
+
+export function calculateBaselineMergeRatio(commitStream: CommitStream): CohortMergeRatio {
+  const nonAICommits = commitStream.commits.filter((commit) => !commit.tags.ai);
+  return computeMergeRatio(nonAICommits);
 }

--- a/packages/metrics/src/persistence.test.ts
+++ b/packages/metrics/src/persistence.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { calculatePersistence } from './persistence.js';
+import { calculateBaselinePersistence, calculatePersistence } from './persistence.js';
 import type { CommitStream } from '@aida-dev/core';
 
 function makeCommit(overrides: Partial<CommitStream['commits'][0]>): CommitStream['commits'][0] {
@@ -151,6 +151,42 @@ describe('calculatePersistence', () => {
     ]);
     const result = calculatePersistence(stream);
     // File was deleted, so persistence should be 0 days (only the first AI commit date)
+    expect(result.avgDays).toBe(0);
+  });
+});
+
+describe('calculateBaselinePersistence', () => {
+  it('measures persistence over non-AI commits only, ignoring AI commits', () => {
+    const stream = makeStream([
+      makeCommit({
+        hash: 'h1',
+        authorDate: '2024-01-01T00:00:00.000Z',
+        tags: { ai: false, level: 'none', sources: [] },
+        stats: { totalAdditions: 5, totalDeletions: 0, files: [{ path: 'foo.ts', additions: 5, deletions: 0 }] },
+      }),
+      makeCommit({
+        hash: 'ai1',
+        authorDate: '2024-01-06T00:00:00.000Z',
+        tags: { ai: true, level: 'explicit', sources: ['tag:[ai]'] },
+        stats: { totalAdditions: 2, totalDeletions: 0, files: [{ path: 'foo.ts', additions: 2, deletions: 0, status: 'modified' }] },
+      }),
+    ]);
+    const result = calculateBaselinePersistence(stream);
+    // 1 non-AI commit; foo.ts first seen at h1 (Jan 1), last seen at ai1 (Jan 6) → 5 days
+    expect(result.commitsConsidered).toBe(1);
+    expect(result.avgDays).toBe(5);
+  });
+
+  it('returns zeros when there are no non-AI commits', () => {
+    const stream = makeStream([
+      makeCommit({
+        hash: 'ai1',
+        tags: { ai: true, level: 'explicit', sources: ['tag:[ai]'] },
+        stats: { totalAdditions: 1, totalDeletions: 0, files: [{ path: 'x.ts', additions: 1, deletions: 0 }] },
+      }),
+    ]);
+    const result = calculateBaselinePersistence(stream);
+    expect(result.commitsConsidered).toBe(0);
     expect(result.avgDays).toBe(0);
   });
 });

--- a/packages/metrics/src/persistence.ts
+++ b/packages/metrics/src/persistence.ts
@@ -1,17 +1,20 @@
-import { CommitStream, daysBetween } from '@aida-dev/core';
+import { Commit, CommitStream, daysBetween } from '@aida-dev/core';
 import { Persistence } from './schema/metrics.js';
 
 interface FileLifecycle {
   path: string;
-  firstAICommitDate: Date;
+  firstTargetCommitDate: Date;
   lastSeenDate: Date;
   persistenceDays: number;
 }
 
-export function calculatePersistence(commitStream: CommitStream): Persistence {
-  const aiCommits = commitStream.commits.filter((commit) => commit.tags.ai);
+export function calculatePersistence(
+  commitStream: CommitStream,
+  isTarget: (commit: Commit) => boolean = (commit) => commit.tags.ai
+): Persistence {
+  const targetCommits = commitStream.commits.filter(isTarget);
 
-  if (aiCommits.length === 0) {
+  if (targetCommits.length === 0) {
     return {
       commitsConsidered: 0,
       avgDays: 0,
@@ -34,16 +37,16 @@ export function calculatePersistence(commitStream: CommitStream): Persistence {
     (a, b) => new Date(a.authorDate).getTime() - new Date(b.authorDate).getTime()
   );
 
-  // Track first AI commit per file
+  // Track first target commit per file
   for (const commit of sortedCommits) {
-    if (commit.tags.ai) {
+    if (isTarget(commit)) {
       const commitDate = new Date(commit.authorDate);
 
       for (const file of commit.stats.files) {
         if (!fileLifecycles.has(file.path)) {
           fileLifecycles.set(file.path, {
             path: file.path,
-            firstAICommitDate: commitDate,
+            firstTargetCommitDate: commitDate,
             lastSeenDate: commitDate,
             persistenceDays: 0,
           });
@@ -71,7 +74,7 @@ export function calculatePersistence(commitStream: CommitStream): Persistence {
   const persistenceDays: number[] = [];
 
   for (const lifecycle of fileLifecycles.values()) {
-    lifecycle.persistenceDays = daysBetween(lifecycle.firstAICommitDate, lifecycle.lastSeenDate);
+    lifecycle.persistenceDays = daysBetween(lifecycle.firstTargetCommitDate, lifecycle.lastSeenDate);
     persistenceDays.push(lifecycle.persistenceDays);
   }
 
@@ -99,9 +102,13 @@ export function calculatePersistence(commitStream: CommitStream): Persistence {
   };
 
   return {
-    commitsConsidered: aiCommits.length,
+    commitsConsidered: targetCommits.length,
     avgDays: Math.round(avgDays * 100) / 100, // Round to 2 decimal places
     medianDays: Math.round(medianDays * 100) / 100,
     buckets,
   };
+}
+
+export function calculateBaselinePersistence(commitStream: CommitStream): Persistence {
+  return calculatePersistence(commitStream, (commit) => !commit.tags.ai);
 }

--- a/packages/metrics/src/schema/metrics.ts
+++ b/packages/metrics/src/schema/metrics.ts
@@ -19,6 +19,23 @@ export const Persistence = z.object({
   }),
 });
 
+export const CohortMergeRatio = z.object({
+  commitsTotal: z.number().int().nonnegative(),
+  commitsMerged: z.number().int().nonnegative(),
+  mergeRatio: z.number().min(0).max(1),
+});
+
+export const Baseline = z.object({
+  mergeRatio: CohortMergeRatio,
+  persistence: Persistence,
+});
+
+export const Delta = z.object({
+  mergeRatio: z.number(),
+  avgPersistenceDays: z.number(),
+  medianPersistenceDays: z.number(),
+});
+
 export const Metrics = z.object({
   generatedAt: z.string().datetime(),
   window: z.object({
@@ -29,9 +46,14 @@ export const Metrics = z.object({
   defaultBranch: z.string(),
   mergeRatio: MergeRatio,
   persistence: Persistence,
+  baseline: Baseline,
+  delta: Delta,
   caveats: z.array(z.string()),
 });
 
 export type MergeRatio = z.infer<typeof MergeRatio>;
 export type Persistence = z.infer<typeof Persistence>;
+export type CohortMergeRatio = z.infer<typeof CohortMergeRatio>;
+export type Baseline = z.infer<typeof Baseline>;
+export type Delta = z.infer<typeof Delta>;
 export type Metrics = z.infer<typeof Metrics>;


### PR DESCRIPTION
## Summary

- Adds `baseline` (non-AI cohort) and `delta` fields to `metrics.json` via new `CohortMergeRatio`, `Baseline`, and `Delta` Zod schemas
- `calculatePersistence` refactored to accept an `isTarget` predicate; `calculateBaselineMergeRatio` and `calculateBaselinePersistence` added as thin wrappers
- CLI report now renders an **AI vs Baseline** comparison table at the top of `report.md` (commits, merge ratio with pp delta, avg/median persistence with day delta)
- 11 tests passing, build clean, no breaking changes

## Why

Without a baseline, metrics like "73% merge ratio" or "45 days persistence" are uninterpretable — there is no way to know if that is good or bad. The delta turns them into actionable signal: "AI code is rewritten 17 days sooner than human code in the same repo."

This also provides the audit-friendly framing needed to defend AI cost capitalisation: code with low persistence or merge ratio has a weaker case for being treated as long-lived asset.

## Test plan

- [ ] `pnpm --filter @aida-dev/metrics test` — all 11 tests pass
- [ ] `pnpm build` — clean build for both `@aida-dev/metrics` and `@aida-dev/cli`
- [ ] Run `aida collect && aida report` on a real repo and verify the comparison table appears in `report.md`
- [ ] Verify `metrics.json` contains `baseline` and `delta` sections

Closes #19