### PR TITLE
fix: git data accuracy — real committer data, batched log, drop branch field (#24)

### DIFF
--- a/.changeset/git-data-accuracy.md
+++ b/.changeset/git-data-accuracy.md
@@ -1,0 +1,11 @@
+---
+'@aida-dev/core': minor
+'@aida-dev/metrics': patch
+---
+
+Git data accuracy (#24):
+
+- Real committer name/email/date are now collected via a custom `git log --format` (previously duplicated from author fields, wrong after rebase/squash).
+- Commit metadata, parents, and diff stats are fetched in two batched `git log` passes instead of two git processes per commit — collection is dramatically faster on large repos.
+- Removed the misleading `branch` field from the `Commit` schema: it was always set to the default branch, even for commits collected from other branches.
+- New caveat documents that time-windowed collection (`--since`) also windows the ancestry check.

--- a/.github/workflows/aida-analyze.yml
+++ b/.github/workflows/aida-analyze.yml
@@ -20,8 +20,6 @@ jobs:
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - uses: actions/setup-node@v5
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,8 +21,6 @@ jobs:
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - uses: actions/setup-node@v5
         with:

--- a/README.md
+++ b/README.md
@@ -362,11 +362,21 @@ aida_analysis:
 - **v0.4** ✅ PR comment integration for GitHub Actions.  
 - **v0.5** ✅ PR-scoped analysis with `--pr` and `--diff-base` flags ([#18](https://github.com/ceccode/AIDA-Metrics/issues/18)).  
 - **v0.6** ✅ Comparative baseline — AI vs non-AI metrics with delta ([#19](https://github.com/ceccode/AIDA-Metrics/issues/19)).  
-- **Next** → Fix squash-merge merge ratio ([#20](https://github.com/ceccode/AIDA-Metrics/issues/20)), exclude non-AI bots from detection ([#21](https://github.com/ceccode/AIDA-Metrics/issues/21)).  
+- **v0.7** ✅ Exclude non-AI bots (dependabot, renovate, …) from trailer matching, with configurable blocklist ([#21](https://github.com/ceccode/AIDA-Metrics/issues/21)).  
+- **Next** → Fix squash-merge merge ratio ([#20](https://github.com/ceccode/AIDA-Metrics/issues/20)), git data accuracy ([#24](https://github.com/ceccode/AIDA-Metrics/issues/24)).  
 - **Next** → Rework rate ([#22](https://github.com/ceccode/AIDA-Metrics/issues/22)), line-level persistence via blame ([#23](https://github.com/ceccode/AIDA-Metrics/issues/23)), attribution manifest ([#10](https://github.com/ceccode/AIDA-Metrics/issues/10)).  
 - **Next** → Autonomy levels — autocomplete vs assisted vs agent ([#25](https://github.com/ceccode/AIDA-Metrics/issues/25)), outcome correlation ([#26](https://github.com/ceccode/AIDA-Metrics/issues/26)), cost metrics ([#27](https://github.com/ceccode/AIDA-Metrics/issues/27)).  
 - **Next** → GitLab ([#16](https://github.com/ceccode/AIDA-Metrics/issues/16)) and Bitbucket ([#17](https://github.com/ceccode/AIDA-Metrics/issues/17)) PR comment providers.  
 - **v1.0** → Dashboard / GitHub Action for continuous tracking.  
+
+### Direction: from AI detection to AI accountability
+
+In an AI-first world, "was this commit written by AI?" is becoming the wrong question — the honest answer trends toward "yes, mostly". AIDA's direction reflects that:
+
+- **Three-state attribution** — `ai` / `human` / `unknown` instead of forcing unattributed commits into a binary bucket. Attribution **coverage** becomes a first-class metric ("62% attributed · 38% unknown" is a data-quality signal, not something to hide inside a default). A configurable `defaultAttribution` prior will let AI-first teams opt into "AI unless stated otherwise" — consciously, instead of the tool silently assuming either way.
+- **Quality over adoption** — the durable question is not "how much code is AI?" but "does AI code hold up?": rework rate ([#22](https://github.com/ceccode/AIDA-Metrics/issues/22)), line-level survival ([#23](https://github.com/ceccode/AIDA-Metrics/issues/23)), outcome correlation ([#26](https://github.com/ceccode/AIDA-Metrics/issues/26)).
+- **Autonomy over the binary** — autocomplete vs assisted vs agent ([#25](https://github.com/ceccode/AIDA-Metrics/issues/25)) is the axis that will replace AI/non-AI.
+- **Shrink the unknown at the source** — commit-time stamping via git hooks and the attribution manifest ([#10](https://github.com/ceccode/AIDA-Metrics/issues/10)) make attribution deterministic instead of heuristic.
 
 ## Contributing
 

--- a/packages/core/src/git/collect.test.ts
+++ b/packages/core/src/git/collect.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execSync } from 'child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { collectCommits } from './collect.js';
+
+const AUTHOR = { name: 'Alice Author', email: 'alice@example.com', date: '2026-01-01T10:00:00Z' };
+const COMMITTER = { name: 'Bob Committer', email: 'bob@example.com', date: '2026-01-05T10:00:00Z' };
+
+let repoPath: string;
+
+function run(cmd: string, env: Record<string, string> = {}) {
+  execSync(cmd, { cwd: repoPath, env: { ...process.env, ...env } });
+}
+
+function commit(message: string) {
+  const escaped = message.replace(/"/g, '\\"');
+  run(`git commit -q -m "${escaped}"`, {
+    GIT_AUTHOR_NAME: AUTHOR.name,
+    GIT_AUTHOR_EMAIL: AUTHOR.email,
+    GIT_AUTHOR_DATE: AUTHOR.date,
+    GIT_COMMITTER_NAME: COMMITTER.name,
+    GIT_COMMITTER_EMAIL: COMMITTER.email,
+    GIT_COMMITTER_DATE: COMMITTER.date,
+  });
+}
+
+beforeAll(() => {
+  repoPath = mkdtempSync(join(tmpdir(), 'aida-collect-test-'));
+  run('git init -q -b main');
+  run('git config user.name test && git config user.email test@example.com');
+
+  writeFileSync(join(repoPath, 'a.txt'), 'line1\nline2\n');
+  writeFileSync(join(repoPath, 'b.txt'), 'temp\n');
+  run('git add .');
+  commit('feat: initial commit');
+
+  writeFileSync(join(repoPath, 'a.txt'), 'line1\nline2\nline3\n');
+  rmSync(join(repoPath, 'b.txt'));
+  run('git add -A');
+  commit('fix: multi-line message\n\nSome body text.\n\nCo-Authored-By: Claude <noreply@anthropic.com>');
+});
+
+afterAll(() => {
+  rmSync(repoPath, { recursive: true, force: true });
+});
+
+describe('collectCommits', () => {
+  it('collects real author and committer identities and dates', async () => {
+    const stream = await collectCommits({ repoPath });
+    expect(stream.commits).toHaveLength(2);
+
+    const head = stream.commits[0];
+    expect(head.authorName).toBe(AUTHOR.name);
+    expect(head.authorEmail).toBe(AUTHOR.email);
+    expect(head.committerName).toBe(COMMITTER.name);
+    expect(head.committerEmail).toBe(COMMITTER.email);
+    expect(head.authorDate).toBe('2026-01-01T10:00:00.000Z');
+    expect(head.committerDate).toBe('2026-01-05T10:00:00.000Z');
+    expect(head.committerDate).not.toBe(head.authorDate);
+  });
+
+  it('computes diff stats with file statuses from batched log', async () => {
+    const stream = await collectCommits({ repoPath });
+    const [head, initial] = stream.commits;
+
+    expect(initial.stats.totalAdditions).toBe(3); // 2 lines a.txt + 1 line b.txt
+    expect(initial.stats.files.map((f) => f.status)).toEqual(['added', 'added']);
+
+    expect(head.stats.totalAdditions).toBe(1); // line3 in a.txt
+    expect(head.stats.totalDeletions).toBe(1); // b.txt removed
+    const byPath = Object.fromEntries(head.stats.files.map((f) => [f.path, f.status]));
+    expect(byPath['a.txt']).toBe('modified');
+    expect(byPath['b.txt']).toBe('deleted');
+  });
+
+  it('populates parents and ancestry, without the removed branch field', async () => {
+    const stream = await collectCommits({ repoPath });
+    const [head, initial] = stream.commits;
+
+    expect(initial.parents).toEqual([]);
+    expect(head.parents).toEqual([initial.hash]);
+    expect(head.inDefaultBranchAncestry).toBe(true);
+    expect(head).not.toHaveProperty('branch');
+  });
+
+  it('tags AI from trailers in the full message body, storing the subject only', async () => {
+    const stream = await collectCommits({ repoPath });
+    const head = stream.commits[0];
+
+    expect(head.message).toBe('fix: multi-line message');
+    expect(head.tags.ai).toBe(true);
+    expect(head.tags.level).toBe('explicit');
+  });
+});

--- a/packages/core/src/git/collect.ts
+++ b/packages/core/src/git/collect.ts
@@ -1,7 +1,7 @@
 import { simpleGit, SimpleGit } from 'simple-git';
 import { Commit, CommitStream } from '../schema/commit.js';
 import { createAITagger } from '../tags/ai-tags.js';
-import { getDiffStats } from './diff.js';
+import { logWithStats } from './log.js';
 import { parseRelativeDate, formatISODate } from '../utils/dates.js';
 import { Logger } from '../utils/log.js';
 
@@ -68,28 +68,27 @@ export async function collectCommits(options: CollectOptions): Promise<CommitStr
   const sinceDate = since ? parseRelativeDate(since) : undefined;
   const untilDate = until ? parseRelativeDate(until) : new Date();
 
-  let logResult;
+  let rangeArgs: string[];
 
   if (diffBase) {
     // PR-scoped mode: collect only commits between diffBase and HEAD
     logger?.info(`PR-scoped analysis: ${diffBase}..HEAD`);
-    logResult = await git.log([`${diffBase}..HEAD`]);
-    logger?.info(`Found ${logResult.all.length} commits in PR`);
+    rangeArgs = [`${diffBase}..HEAD`];
   } else {
     // Standard mode: collect from all branches within date range
     logger?.info(
       `Collecting commits from ${sinceDate?.toISOString() || 'beginning'} to ${untilDate.toISOString()}`
     );
-
-    const logArgs: string[] = ['--all'];
+    rangeArgs = ['--all'];
     if (sinceDate) {
-      logArgs.push(`--after=${sinceDate.toISOString()}`);
+      rangeArgs.push(`--after=${sinceDate.toISOString()}`);
     }
-    logArgs.push(`--before=${untilDate.toISOString()}`);
-
-    logResult = await git.log(logArgs);
-    logger?.info(`Found ${logResult.all.length} commits (all branches)`);
+    rangeArgs.push(`--before=${untilDate.toISOString()}`);
   }
+
+  // Single batched pass: metadata, parents, and diff stats for all commits
+  const rawCommits = await logWithStats(git, rangeArgs);
+  logger?.info(`Found ${rawCommits.length} commits${diffBase ? ' in PR' : ' (all branches)'}`);
 
   // Get the set of commit hashes reachable from the default branch
   let defaultBranchHashes: Set<string>;
@@ -121,26 +120,6 @@ export async function collectCommits(options: CollectOptions): Promise<CommitStr
   }
   logger?.info(`Default branch commits: ${defaultBranchHashes.size}`);
 
-  // Batch-fetch parent hashes for all commits in a single git call
-  const parentMap = new Map<string, string[]>();
-  if (logResult.all.length > 0) {
-    try {
-      const parentArgs = diffBase
-        ? ['rev-list', '--parents', `${diffBase}..HEAD`]
-        : ['log', '--format=%H %P', '--all',
-          ...(sinceDate ? [`--after=${sinceDate.toISOString()}`] : []),
-          `--before=${untilDate.toISOString()}`];
-      const parentOutput = await git.raw(parentArgs);
-      for (const line of parentOutput.trim().split('\n').filter(Boolean)) {
-        const parts = line.split(' ').filter(Boolean);
-        const [hash, ...parents] = parts;
-        parentMap.set(hash, parents);
-      }
-    } catch {
-      // Fallback: parent map will be empty, parents default to []
-    }
-  }
-
   // Create AI tagger
   const aiTagger = createAITagger({
     patterns: aiPatterns,
@@ -152,40 +131,28 @@ export async function collectCommits(options: CollectOptions): Promise<CommitStr
   // Deduplicate commits (same hash can appear from multiple branches)
   const seen = new Set<string>();
   const commits: Commit[] = [];
-  for (const gitCommit of logResult.all) {
-    if (seen.has(gitCommit.hash)) continue;
-    seen.add(gitCommit.hash);
+  for (const rawCommit of rawCommits) {
+    if (seen.has(rawCommit.hash)) continue;
+    seen.add(rawCommit.hash);
 
-    logger?.debug(`Processing commit ${gitCommit.hash}`);
+    logger?.debug(`Processing commit ${rawCommit.hash}`);
 
-    // Get diff stats
-    const stats = await getDiffStats(git, gitCommit.hash);
-
-    // Tag AI (include body for trailer detection like Co-Authored-By)
-    const fullMessage = gitCommit.body
-      ? `${gitCommit.message}\n\n${gitCommit.body}`
-      : gitCommit.message;
-    const aiTag = aiTagger(fullMessage);
-
-    // Get parents from batch-fetched map
-    const parents = parentMap.get(gitCommit.hash) || [];
-
-    const inDefaultBranchAncestry = defaultBranchHashes.has(gitCommit.hash);
+    // Tag AI on the full message (body included, for trailers like Co-Authored-By)
+    const aiTag = aiTagger(rawCommit.message);
 
     const commit: Commit = {
-      hash: gitCommit.hash,
-      authorName: gitCommit.author_name,
-      authorEmail: gitCommit.author_email,
-      authorDate: new Date(gitCommit.date).toISOString(),
-      committerName: gitCommit.author_name, // Simple-git doesn't separate these easily
-      committerEmail: gitCommit.author_email,
-      committerDate: new Date(gitCommit.date).toISOString(),
-      message: gitCommit.message,
-      parents,
-      branch: defaultBranch,
-      inDefaultBranchAncestry,
+      hash: rawCommit.hash,
+      authorName: rawCommit.authorName,
+      authorEmail: rawCommit.authorEmail,
+      authorDate: new Date(rawCommit.authorDate).toISOString(),
+      committerName: rawCommit.committerName,
+      committerEmail: rawCommit.committerEmail,
+      committerDate: new Date(rawCommit.committerDate).toISOString(),
+      message: rawCommit.message.split('\n')[0],
+      parents: rawCommit.parents,
+      inDefaultBranchAncestry: defaultBranchHashes.has(rawCommit.hash),
       tags: aiTag,
-      stats,
+      stats: rawCommit.stats,
     };
 
     commits.push(commit);

--- a/packages/core/src/git/log.ts
+++ b/packages/core/src/git/log.ts
@@ -1,0 +1,123 @@
+import { SimpleGit } from 'simple-git';
+import { FileChange } from '../schema/commit.js';
+import type { z } from 'zod';
+
+type FileChangeType = z.infer<typeof FileChange>;
+
+export interface RawCommit {
+  hash: string;
+  authorName: string;
+  authorEmail: string;
+  authorDate: string; // ISO 8601 (%aI)
+  committerName: string;
+  committerEmail: string;
+  committerDate: string; // ISO 8601 (%cI)
+  parents: string[];
+  message: string; // full message: subject + body (%B)
+  stats: {
+    totalAdditions: number;
+    totalDeletions: number;
+    files: FileChangeType[];
+  };
+}
+
+// Record separator / field separator (ASCII control chars, cannot appear in
+// normal commit metadata) so multi-line messages parse unambiguously.
+const RS = '\x1e';
+const FS = '\x1f';
+const LOG_FORMAT = `${RS}%H${FS}%an${FS}%ae${FS}%aI${FS}%cn${FS}%ce${FS}%cI${FS}%P${FS}%B${FS}`;
+
+const NUMSTAT_LINE = /^(\d+|-)\t(\d+|-)\t(.+)$/;
+const NAME_STATUS_LINE = /^([A-Z])\S*\t(.+)$/;
+
+function parseStatus(code: string): FileChangeType['status'] {
+  switch (code) {
+    case 'A':
+      return 'added';
+    case 'D':
+      return 'deleted';
+    case 'R':
+      return 'renamed';
+    default:
+      return 'modified';
+  }
+}
+
+/**
+ * Fetch commits with metadata and diff stats in two batched `git log` passes
+ * (one with --numstat, one with --name-status — git ignores --numstat when
+ * both are combined), instead of spawning one git process per commit.
+ *
+ * `rangeArgs` selects the commits (e.g. `['--all', '--after=...']` or
+ * `['base..HEAD']`) and must be identical for both passes.
+ */
+export async function logWithStats(git: SimpleGit, rangeArgs: string[]): Promise<RawCommit[]> {
+  const [numstatRaw, nameStatusRaw] = await Promise.all([
+    git.raw(['log', `--format=${LOG_FORMAT}`, '--numstat', ...rangeArgs]),
+    git.raw(['log', `--format=${RS}%H`, '--name-status', ...rangeArgs]),
+  ]);
+
+  // hash -> path -> status
+  const statusByCommit = new Map<string, Map<string, FileChangeType['status']>>();
+  for (const record of nameStatusRaw.split(RS)) {
+    const lines = record.split('\n').filter((l) => l.trim());
+    if (lines.length === 0) continue;
+    const hash = lines[0].trim();
+    const statusMap = new Map<string, FileChangeType['status']>();
+    for (const line of lines.slice(1)) {
+      const match = line.match(NAME_STATUS_LINE);
+      if (match) {
+        const paths = match[2].split('\t');
+        // last element handles renames (old\tnew)
+        statusMap.set(paths[paths.length - 1], parseStatus(match[1]));
+      }
+    }
+    statusByCommit.set(hash, statusMap);
+  }
+
+  const commits: RawCommit[] = [];
+  for (const record of numstatRaw.split(RS)) {
+    if (!record.trim()) continue;
+    const parts = record.split(FS);
+    if (parts.length < 10) continue;
+    const [hash, authorName, authorEmail, authorDate, committerName, committerEmail, committerDate, parentsRaw, message, tail] = parts;
+
+    const statusMap = statusByCommit.get(hash);
+    const files: FileChangeType[] = [];
+    let totalAdditions = 0;
+    let totalDeletions = 0;
+    for (const line of tail.split('\n')) {
+      const match = line.match(NUMSTAT_LINE);
+      if (!match) continue;
+      // Skip binary files (marked with -)
+      if (match[1] === '-' && match[2] === '-') continue;
+      const additions = match[1] === '-' ? 0 : parseInt(match[1], 10) || 0;
+      const deletions = match[2] === '-' ? 0 : parseInt(match[2], 10) || 0;
+      const pathParts = match[3].split('\t');
+      const path = pathParts[pathParts.length - 1];
+      totalAdditions += additions;
+      totalDeletions += deletions;
+      files.push({
+        path,
+        status: statusMap?.get(path) || 'modified',
+        additions,
+        deletions,
+      });
+    }
+
+    commits.push({
+      hash,
+      authorName,
+      authorEmail,
+      authorDate,
+      committerName,
+      committerEmail,
+      committerDate,
+      parents: parentsRaw.trim().split(' ').filter(Boolean),
+      message: message.replace(/\n+$/, ''),
+      stats: { totalAdditions, totalDeletions, files },
+    });
+  }
+
+  return commits;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,7 @@ export * from './schema/commit.js';
 export * from './schema/stream.js';
 export * from './git/collect.js';
 export * from './git/diff.js';
+export * from './git/log.js';
 export * from './tags/ai-tags.js';
 export * from './io/fs.js';
 export * from './utils/dates.js';

--- a/packages/core/src/schema/commit.ts
+++ b/packages/core/src/schema/commit.ts
@@ -17,7 +17,6 @@ export const Commit = z.object({
   committerDate: z.string().datetime(),
   message: z.string(),
   parents: z.array(z.string()),
-  branch: z.string().optional(), // best-effort if known
   inDefaultBranchAncestry: z.boolean(), // set during collect
   tags: z.object({
     ai: z.boolean(),

--- a/packages/metrics/src/index.ts
+++ b/packages/metrics/src/index.ts
@@ -27,6 +27,7 @@ export function calculateMetrics(commitStream: CommitStream): Metrics {
   const caveats = [
     'Persistence is file-level, not line-level.',
     'Merge ratio: commits from all branches checked against default branch ancestry. Squash merges may undercount unmerged commits.',
+    'Time-windowed collection (--since) also windows the ancestry check: commits merged into the default branch before the window may appear unmerged.',
     'AI tagging uses heuristic patterns; false positives/negatives possible.',
     'Baseline covers all non-AI-tagged commits; undetected AI usage may leak into the baseline.',
   ];


### PR DESCRIPTION
Closes #24

## Changes

1. **Real committer identity/dates** — new `logWithStats()` (`packages/core/src/git/log.ts`) uses a custom `git log --format` with control-char separators (`%x1e`/`%x1f`, safe against multi-line messages) and reads `%cn %ce %cI` — previously committer fields were duplicated from author values (simple-git limitation), which is wrong after rebase/squash.
2. **Batched collection** — commit metadata, parents (`%P`), and diff stats now come from **two** `git log` passes total (`--numstat` + `--name-status`; git ignores `--numstat` when both flags are combined, verified), replacing two `git show` processes *per commit* and the separate parents fetch. On this repo: 74 commits collected in 0.33s.
3. **Removed misleading `branch` field** from the `Commit` schema — it was hardcoded to the default branch for every commit, including those collected from other branches via `--all`. No consumer used it (verified by grep).
4. **Documented window/ancestry truncation** — new caveat in `metrics.json`/report: time-windowed collection also windows the ancestry check. The substantive fix belongs with the squash-merge work (#20).

## Verification

- New end-to-end suite `collect.test.ts` on a temp repo: diverging author/committer identities and dates, add/modify/delete statuses, line counts, parents chain, no `branch` field, AI trailer tagging on multi-line messages.
- Full run on this repo: 74 commits, 25 AI-tagged (unchanged), 2 commits now show real diverging committer dates (the squash merges), `analyze` + `report` pipeline works.
- 49 tests passing, build & lint clean. Changeset included (`core` minor, `metrics` patch).

Co-Authored-By: Claude <noreply@anthropic.com>