### PR TITLE
feat: attribution coverage as headline metric — three-state ai/human/unknown (#34)

### DIFF
--- a/.aida.json
+++ b/.aida.json
@@ -1,0 +1,3 @@
+{
+  "defaultAttribution": "ai"
+}

--- a/.changeset/attribution-coverage.md
+++ b/.changeset/attribution-coverage.md
@@ -1,0 +1,17 @@
+---
+'@aida-dev/core': minor
+'@aida-dev/metrics': minor
+'@aida-dev/cli': minor
+---
+
+Attribution coverage as headline metric (#34)
+
+Three-state attribution replaces the silent AI/human binary:
+
+- Every commit is attributed `ai`, `human`, or `unknown` (`tags.attribution`). Message heuristics emit only `ai` or `unknown`: the absence of an AI signal is not evidence of human authorship. `human` will come from explicit declarations (attribution manifest, #10).
+- `metrics.json` gains a leading `attribution` block with per-state counts and **coverage** — the share of commits with known provenance — plus a configurable `coverageThreshold` (default 0.7) that flags all metrics as low-confidence when coverage falls below it.
+- `baseline` and `delta` are now nullable: when no commits are attributed `human` and no prior assigns the unknowns, AIDA reports "no baseline" instead of silently comparing AI commits against unattributed ones.
+- New `defaultAttribution` option (`.aida.json` or `aida analyze --default-attribution`) consciously assigns unknown commits to a cohort (`human` for traditional repos, `ai` for AI-first ones). The prior affects cohorts, never coverage; an assumed baseline is labeled `assumed` in output and report.
+- The markdown report opens with an "Attribution Coverage" section and a warning banner when coverage is below threshold.
+
+Breaking (0.x minor): `commit-stream.json` requires the new `tags.attribution` field — rerun `aida collect`. `metrics.json` consumers must handle `baseline: null` / `delta: null` and the renamed baseline semantics (human cohort, not "non-AI").

--- a/README.md
+++ b/README.md
@@ -235,7 +235,9 @@ Place a `.aida.json` file in your project root to add custom tools, trailer doma
   "tools": ["devbot", "codyai", "internal-copilot"],
   "trailerDomains": ["mycompany\\.com"],
   "botBlocklist": ["acme-ci-bot"],
-  "patterns": ["my-custom-regex"]
+  "patterns": ["my-custom-regex"],
+  "defaultAttribution": "unknown",
+  "coverageThreshold": 0.7
 }
 ```
 
@@ -245,6 +247,8 @@ Place a `.aida.json` file in your project root to add custom tools, trailer doma
 | `trailerDomains` | Additional domains for `Co-authored-by` trailer matching |
 | `botBlocklist` | Additional non-AI bots to exclude from `Co-authored-by` trailer matching |
 | `patterns` | Raw regex patterns (treated as explicit) |
+| `defaultAttribution` | Prior applied to unattributed commits at analysis time: `ai`, `human`, or `unknown` (default). With `unknown`, unattributed commits join no cohort — AIDA does not invent a comparison. This repo sets `ai`: it is AI-written with human review. |
+| `coverageThreshold` | Attribution coverage below this fraction (default `0.7`) flags all metrics as low-confidence |
 
 ### CLI Flags
 
@@ -255,9 +259,18 @@ aida collect --ai-tool "devbot" --ai-tool "codyai"
 aida collect --ai-trailer-domain "mycompany\\.com"
 aida collect --ai-bot-blocklist "acme-ci-bot"
 aida collect --ai-pattern "my-custom-regex"
+aida analyze --default-attribution human --coverage-threshold 0.8
 ```
 
 ## Metrics
+
+### Attribution Coverage
+
+The headline metric ([#34](https://github.com/ceccode/AIDA-Metrics/issues/34)). Every commit gets a three-state attribution: `ai` (explicit/implicit detection), `human` (explicit declaration — coming with the attribution manifest, [#10](https://github.com/ceccode/AIDA-Metrics/issues/10)), or `unknown` (no signal — the absence of an AI tag is *not* evidence of human authorship).
+
+**Coverage** = share of commits with known provenance. It is reported first in every output, because every other number is only as trustworthy as coverage says it is. Below `coverageThreshold` (default 70%), the report carries a low-confidence warning.
+
+`defaultAttribution` lets a team consciously assign unattributed commits to a cohort (`human` for traditional repos, `ai` for AI-first ones). The prior affects cohort metrics but never coverage: unknown stays unknown in the attribution block, and an assumed baseline is labeled as such.
 
 ### Merge Ratio
 
@@ -272,15 +285,16 @@ File-level proxy for how long AI-modified files survive before being changed aga
 
 ### Comparative Baseline
 
-Both merge ratio and persistence are computed for non-AI commits as well.  
-The `metrics.json` output includes `baseline` (non-AI cohort) and `delta` (AI minus non-AI) sections.  
-The markdown report renders a side-by-side comparison table at the top.
+Both merge ratio and persistence are computed for the human cohort as well.  
+The `metrics.json` output includes `baseline` (human cohort) and `delta` (AI minus human) sections.  
+The markdown report renders a side-by-side comparison table at the top.  
+If no commits are attributed `human` and no `defaultAttribution` prior assigns the unknowns, `baseline` and `delta` are `null`: AIDA does not invent a comparison cohort.
 
 ### Known Limits
 
 These metrics are honest approximations, not ground truth. Read the numbers with these caveats in mind:
 
-- **Detection is voluntary** — AIDA only sees what commits admit to. Untagged AI code counts as human today; three-state attribution with a coverage metric ([#34](https://github.com/ceccode/AIDA-Metrics/issues/34)) will surface this gap instead of hiding it.
+- **Detection is voluntary** — AIDA only sees what commits admit to. Untagged AI code lands in the `unknown` bucket, and attribution coverage ([#34](https://github.com/ceccode/AIDA-Metrics/issues/34)) reports how big that bucket is instead of hiding it — but the tool still cannot see through a commit that lies.
 - **Squash merges break merge ratio** — branch commits disappear from history, inflating the ratio ([#20](https://github.com/ceccode/AIDA-Metrics/issues/20)).
 - **Persistence is file-level** — one AI-touched line marks the whole file as AI-touched; line-level tracking via `git blame` is planned ([#23](https://github.com/ceccode/AIDA-Metrics/issues/23)).
 - **Cohort age skews persistence** — older commits have had more time to accumulate survival; comparisons need age normalization ([#29](https://github.com/ceccode/AIDA-Metrics/issues/29)).
@@ -373,9 +387,10 @@ aida_analysis:
 - **v0.5** ✅ PR-scoped analysis with `--pr` and `--diff-base` flags ([#18](https://github.com/ceccode/AIDA-Metrics/issues/18)).  
 - **v0.6** ✅ Comparative baseline — AI vs non-AI metrics with delta ([#19](https://github.com/ceccode/AIDA-Metrics/issues/19)).  
 - **v0.7** ✅ Exclude non-AI bots (dependabot, renovate, …) from trailer matching, with configurable blocklist ([#21](https://github.com/ceccode/AIDA-Metrics/issues/21)).  
-- **Next** → Fix squash-merge merge ratio ([#20](https://github.com/ceccode/AIDA-Metrics/issues/20)), attribution coverage as headline metric ([#34](https://github.com/ceccode/AIDA-Metrics/issues/34)).  
+- **v0.8** ✅ Attribution coverage as headline metric — three-state `ai`/`human`/`unknown`, `defaultAttribution` prior, nullable baseline ([#34](https://github.com/ceccode/AIDA-Metrics/issues/34)).  
+- **Next** → Attribution manifest ([#10](https://github.com/ceccode/AIDA-Metrics/issues/10)), fix squash-merge merge ratio ([#20](https://github.com/ceccode/AIDA-Metrics/issues/20)).  
 - **Next** → Anti-leaderboard hardening: author redaction in outputs ([#35](https://github.com/ceccode/AIDA-Metrics/issues/35)), task-mix stratification by file category ([#36](https://github.com/ceccode/AIDA-Metrics/issues/36)).  
-- **Next** → Rework rate ([#22](https://github.com/ceccode/AIDA-Metrics/issues/22)), line-level persistence via blame ([#23](https://github.com/ceccode/AIDA-Metrics/issues/23)), attribution manifest ([#10](https://github.com/ceccode/AIDA-Metrics/issues/10)).  
+- **Next** → Rework rate ([#22](https://github.com/ceccode/AIDA-Metrics/issues/22)), line-level persistence via blame ([#23](https://github.com/ceccode/AIDA-Metrics/issues/23)).  
 - **Next** → Autonomy levels — autocomplete vs assisted vs agent ([#25](https://github.com/ceccode/AIDA-Metrics/issues/25)), outcome correlation ([#26](https://github.com/ceccode/AIDA-Metrics/issues/26)), cost metrics ([#27](https://github.com/ceccode/AIDA-Metrics/issues/27)).  
 - **Next** → GitLab ([#16](https://github.com/ceccode/AIDA-Metrics/issues/16)) and Bitbucket ([#17](https://github.com/ceccode/AIDA-Metrics/issues/17)) PR comment providers.  
 - **v1.0** → Dashboard / GitHub Action for continuous tracking.  

--- a/packages/cli/src/commands/analyze.ts
+++ b/packages/cli/src/commands/analyze.ts
@@ -1,13 +1,31 @@
 import { Command } from 'commander';
-import { readJSON, writeJSON, createLogger, CommitStream } from '@aida-dev/core';
+import { readJSON, writeJSON, createLogger, CommitStream, AidaConfig } from '@aida-dev/core';
 import { calculateMetrics } from '@aida-dev/metrics';
 import { join } from 'path';
+import { readFile } from 'fs/promises';
 import { CLIConfig } from '../schema/config.js';
+
+async function loadAidaConfig(repoPath: string): Promise<Partial<AidaConfig>> {
+  try {
+    const raw = await readFile(join(repoPath, '.aida.json'), 'utf-8');
+    return AidaConfig.parse(JSON.parse(raw));
+  } catch {
+    return {};
+  }
+}
 
 export function createAnalyzeCommand(): Command {
   return new Command('analyze')
     .description('Analyze commit stream and generate metrics.json')
     .option('--out-dir <path>', 'Output directory', './aida-output')
+    .option(
+      '--default-attribution <value>',
+      'Prior for unattributed commits: ai | human | unknown (default: unknown, or .aida.json)'
+    )
+    .option(
+      '--coverage-threshold <fraction>',
+      'Coverage below this flags metrics as low-confidence (default: 0.7, or .aida.json)'
+    )
     .option('--verbose', 'Verbose logging', false)
     .action(async (options) => {
       const config = CLIConfig.parse(options);
@@ -21,13 +39,43 @@ export function createAnalyzeCommand(): Command {
 
         logger.info(`Analyzing ${commitStream.commits.length} commits`);
 
-        const metrics = calculateMetrics(commitStream);
+        // CLI flags override .aida.json (read from the collected repo's root)
+        const fileConfig = await loadAidaConfig(commitStream.repoPath);
+        const defaultAttribution =
+          options.defaultAttribution ?? fileConfig.defaultAttribution ?? 'unknown';
+        if (!['ai', 'human', 'unknown'].includes(defaultAttribution)) {
+          throw new Error(
+            `Invalid --default-attribution "${defaultAttribution}": expected ai, human, or unknown`
+          );
+        }
+        const coverageThreshold = options.coverageThreshold
+          ? Number(options.coverageThreshold)
+          : (fileConfig.coverageThreshold ?? 0.7);
+        if (Number.isNaN(coverageThreshold) || coverageThreshold < 0 || coverageThreshold > 1) {
+          throw new Error(
+            `Invalid --coverage-threshold "${options.coverageThreshold}": expected a fraction between 0 and 1`
+          );
+        }
+
+        const metrics = calculateMetrics(commitStream, { defaultAttribution, coverageThreshold });
 
         const outputPath = join(config.outDir, 'metrics.json');
         await writeJSON(outputPath, metrics);
 
+        const a = metrics.attribution;
+        logger.info(
+          `Attribution coverage: ${(a.coverage * 100).toFixed(1)}% (ai: ${a.ai}, human: ${a.human}, unknown: ${a.unknown})`
+        );
+        if (a.belowThreshold) {
+          logger.warn(
+            `Coverage is below ${(a.coverageThreshold * 100).toFixed(0)}%: metrics are low-confidence. Tag AI commits or set defaultAttribution.`
+          );
+        }
         logger.info(`Merge ratio: ${(metrics.mergeRatio.mergeRatio * 100).toFixed(1)}%`);
         logger.info(`Average persistence: ${metrics.persistence.avgDays} days`);
+        if (!metrics.baseline) {
+          logger.warn('No baseline cohort: no commits attributed as human (see caveats).');
+        }
         logger.info(`Output written to: ${outputPath}`);
       } catch (error) {
         logger.error(`Analysis failed: ${error instanceof Error ? error.message : String(error)}`);

--- a/packages/cli/src/commands/collect.ts
+++ b/packages/cli/src/commands/collect.ts
@@ -87,7 +87,11 @@ export function createCollectCommand(): Command {
         await writeJSON(outputPath, commitStream);
 
         logger.info(`Collected ${commitStream.commits.length} commits`);
-        logger.info(`AI-tagged commits: ${commitStream.commits.filter((c) => c.tags.ai).length}`);
+        const counts = { ai: 0, human: 0, unknown: 0 };
+        for (const c of commitStream.commits) counts[c.tags.attribution]++;
+        logger.info(
+          `Attribution: ai ${counts.ai} · human ${counts.human} · unknown ${counts.unknown}`
+        );
         logger.info(`Output written to: ${outputPath}`);
       } catch (error) {
         logger.error(

--- a/packages/cli/src/commands/report.ts
+++ b/packages/cli/src/commands/report.ts
@@ -12,8 +12,47 @@ function formatDelta(value: number, suffix: string): string {
 
 function generateMarkdownReport(metrics: Metrics): string {
   const mergeRatioPct = (metrics.mergeRatio.mergeRatio * 100).toFixed(1);
-  const baselineMergeRatioPct = (metrics.baseline.mergeRatio.mergeRatio * 100).toFixed(1);
-  const deltaMergeRatioPp = Math.round(metrics.delta.mergeRatio * 1000) / 10;
+  const a = metrics.attribution;
+  const coveragePct = (a.coverage * 100).toFixed(1);
+  const unknownPct = a.commitsTotal > 0 ? ((a.unknown / a.commitsTotal) * 100).toFixed(1) : '0.0';
+
+  const coverageWarning = a.belowThreshold
+    ? `\n> ⚠️ **Coverage is below ${(a.coverageThreshold * 100).toFixed(0)}%.** Most of this history has unknown provenance: every metric below is low-confidence. Tag AI commits (trailers, \`[AI]\`) or set \`defaultAttribution\` in \`.aida.json\`.\n`
+    : '';
+
+  const priorNote =
+    a.defaultAttribution !== 'unknown'
+      ? `\nUnattributed commits are **assumed \`${a.defaultAttribution}\`** via \`defaultAttribution\` — this is a prior, not observed data.\n`
+      : '';
+
+  const baselineLabel = metrics.baseline?.assumed
+    ? 'Human baseline (assumed)'
+    : 'Human baseline';
+
+  const comparisonSection = metrics.baseline && metrics.delta
+    ? `## AI vs Baseline
+
+| Metric | AI commits | ${baselineLabel} | Delta |
+|---|---:|---:|---:|
+| Commits | ${metrics.mergeRatio.aiCommitsTotal} | ${metrics.baseline.mergeRatio.commitsTotal} | — |
+| Merge ratio | ${mergeRatioPct}% | ${(metrics.baseline.mergeRatio.mergeRatio * 100).toFixed(1)}% | ${formatDelta(Math.round(metrics.delta.mergeRatio * 1000) / 10, ' pp')} |
+| Avg persistence (days) | ${metrics.persistence.avgDays} | ${metrics.baseline.persistence.avgDays} | ${formatDelta(metrics.delta.avgPersistenceDays, '')} |
+| Median persistence (days) | ${metrics.persistence.medianDays} | ${metrics.baseline.persistence.medianDays} | ${formatDelta(metrics.delta.medianPersistenceDays, '')} |
+`
+    : `## AI vs Baseline
+
+**No baseline available** — no commits are attributed as human, so there is nothing honest to compare against. If unattributed commits in this repo are human-authored, set \`"defaultAttribution": "human"\` in \`.aida.json\`.
+`;
+
+  const baselineDetail = metrics.baseline
+    ? `## ${baselineLabel}
+- Commits (total): ${metrics.baseline.mergeRatio.commitsTotal}
+- Commits merged: ${metrics.baseline.mergeRatio.commitsMerged}
+- **Merge Ratio:** ${(metrics.baseline.mergeRatio.mergeRatio * 100).toFixed(1)}%
+- Persistence — commits considered: ${metrics.baseline.persistence.commitsConsidered}, avg: ${metrics.baseline.persistence.avgDays}d, median: ${metrics.baseline.persistence.medianDays}d
+
+`
+    : '';
 
   return `# AIDA Report
 
@@ -22,15 +61,11 @@ function generateMarkdownReport(metrics: Metrics): string {
 **Window:** ${metrics.window.since || 'beginning'} → ${metrics.window.until || 'now'}  
 **Generated:** ${metrics.generatedAt}
 
-## AI vs Baseline
+## Attribution Coverage
 
-| Metric | AI commits | Non-AI baseline | Delta |
-|---|---:|---:|---:|
-| Commits | ${metrics.mergeRatio.aiCommitsTotal} | ${metrics.baseline.mergeRatio.commitsTotal} | — |
-| Merge ratio | ${mergeRatioPct}% | ${baselineMergeRatioPct}% | ${formatDelta(deltaMergeRatioPp, ' pp')} |
-| Avg persistence (days) | ${metrics.persistence.avgDays} | ${metrics.baseline.persistence.avgDays} | ${formatDelta(metrics.delta.avgPersistenceDays, '')} |
-| Median persistence (days) | ${metrics.persistence.medianDays} | ${metrics.baseline.persistence.medianDays} | ${formatDelta(metrics.delta.medianPersistenceDays, '')} |
-
+**${coveragePct}% of commits have known provenance** — ai: ${a.ai} · human: ${a.human} · unknown: ${a.unknown} (${unknownPct}%)
+${coverageWarning}${priorNote}
+${comparisonSection}
 ## Merge Ratio
 - AI-tagged commits (total): ${metrics.mergeRatio.aiCommitsTotal}
 - AI-tagged commits merged: ${metrics.mergeRatio.aiCommitsMerged}
@@ -45,13 +80,7 @@ function generateMarkdownReport(metrics: Metrics): string {
 |---:|---:|---:|---:|---:|
 | ${metrics.persistence.buckets.d0_1} | ${metrics.persistence.buckets.d2_7} | ${metrics.persistence.buckets.d8_30} | ${metrics.persistence.buckets.d31_90} | ${metrics.persistence.buckets.d90_plus} |
 
-## Baseline (non-AI commits)
-- Commits (total): ${metrics.baseline.mergeRatio.commitsTotal}
-- Commits merged: ${metrics.baseline.mergeRatio.commitsMerged}
-- **Merge Ratio:** ${baselineMergeRatioPct}%
-- Persistence — commits considered: ${metrics.baseline.persistence.commitsConsidered}, avg: ${metrics.baseline.persistence.avgDays}d, median: ${metrics.baseline.persistence.medianDays}d
-
-### Caveats
+${baselineDetail}### Caveats
 ${metrics.caveats.map((caveat) => `- ${caveat}`).join('\n')}
 `;
 }

--- a/packages/core/src/schema/aida-config.ts
+++ b/packages/core/src/schema/aida-config.ts
@@ -5,6 +5,11 @@ export const AidaConfig = z.object({
   trailerDomains: z.array(z.string()).default([]),
   botBlocklist: z.array(z.string()).default([]),
   patterns: z.array(z.string()).default([]),
+  // Prior applied to 'unknown' commits at analysis time (#34).
+  // 'unknown' (default) = no assumption: unknown commits join no cohort.
+  defaultAttribution: z.enum(['ai', 'human', 'unknown']).default('unknown'),
+  // Attribution coverage below this fraction flags all metrics as low-confidence.
+  coverageThreshold: z.number().min(0).max(1).default(0.7),
 });
 
 export type AidaConfig = z.infer<typeof AidaConfig>;

--- a/packages/core/src/schema/commit.ts
+++ b/packages/core/src/schema/commit.ts
@@ -20,6 +20,9 @@ export const Commit = z.object({
   inDefaultBranchAncestry: z.boolean(), // set during collect
   tags: z.object({
     ai: z.boolean(),
+    // Three-state attribution (#34). Heuristics emit 'ai' or 'unknown';
+    // 'human' requires an explicit declaration (manifest, #10).
+    attribution: z.enum(['ai', 'human', 'unknown']),
     level: z.enum(['explicit', 'implicit', 'mention', 'none']),
     sources: z.array(z.string()), // which heuristic matched
   }),

--- a/packages/core/src/tags/ai-tags.test.ts
+++ b/packages/core/src/tags/ai-tags.test.ts
@@ -212,4 +212,16 @@ Co-authored-by: Claude <noreply@anthropic.com>`
       expect(result.level).toBe('explicit');
     });
   });
+
+  describe('three-state attribution', () => {
+    it('maps explicit and implicit levels to attribution: ai', () => {
+      expect(tagger('[AI] automated change').attribution).toBe('ai');
+      expect(tagger('feat: copilot suggestions applied').attribution).toBe('ai');
+    });
+
+    it('maps mention and none levels to attribution: unknown, never human', () => {
+      expect(tagger('fix: update claude detection pattern').attribution).toBe('unknown');
+      expect(tagger('regular commit with no AI signal').attribution).toBe('unknown');
+    });
+  });
 });

--- a/packages/core/src/tags/ai-tags.ts
+++ b/packages/core/src/tags/ai-tags.ts
@@ -1,7 +1,14 @@
 export type AILevel = 'explicit' | 'implicit' | 'mention' | 'none';
 
+// Three-state attribution (#34). Message heuristics can only ever produce
+// 'ai' or 'unknown': the absence of an AI signal is not evidence of human
+// authorship. 'human' requires an explicit declaration (e.g. attribution
+// manifest, #10) or the defaultAttribution prior applied at analysis time.
+export type Attribution = 'ai' | 'human' | 'unknown';
+
 export interface AITagResult {
   ai: boolean;
+  attribution: Attribution;
   level: AILevel;
   sources: string[];
 }
@@ -163,6 +170,6 @@ export function createAITagger(
 
     // ai: true only for explicit and implicit
     const ai = level === 'explicit' || level === 'implicit';
-    return { ai, level, sources };
+    return { ai, attribution: ai ? 'ai' : 'unknown', level, sources };
   };
 }

--- a/packages/metrics/src/index.test.ts
+++ b/packages/metrics/src/index.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+import { calculateMetrics } from './index.js';
+import { Commit, CommitStream } from '@aida-dev/core';
+
+function makeCommit(overrides: Partial<Commit> & { hash: string }): Commit {
+  return {
+    authorName: 'Test User',
+    authorEmail: 'test@example.com',
+    authorDate: '2025-01-01T00:00:00.000Z',
+    committerName: 'Test User',
+    committerEmail: 'test@example.com',
+    committerDate: '2025-01-01T00:00:00.000Z',
+    message: 'commit',
+    parents: [],
+    inDefaultBranchAncestry: true,
+    tags: { ai: false, attribution: 'unknown', level: 'none', sources: [] },
+    stats: { totalAdditions: 1, totalDeletions: 0, files: [] },
+    ...overrides,
+  };
+}
+
+function makeStream(commits: Commit[]): CommitStream {
+  return {
+    repoPath: '/test/repo',
+    defaultBranch: 'main',
+    generatedAt: '2025-01-01T00:00:00.000Z',
+    aiPatterns: [],
+    commits,
+  };
+}
+
+const aiTags = { ai: true, attribution: 'ai', level: 'explicit', sources: ['tag:[ai]'] } as const;
+const humanTags = { ai: false, attribution: 'human', level: 'none', sources: [] } as const;
+const unknownTags = { ai: false, attribution: 'unknown', level: 'none', sources: [] } as const;
+
+describe('calculateMetrics attribution coverage', () => {
+  it('reports coverage as (ai + human) / total', () => {
+    const metrics = calculateMetrics(
+      makeStream([
+        makeCommit({ hash: 'a1', tags: aiTags }),
+        makeCommit({ hash: 'h1', tags: humanTags }),
+        makeCommit({ hash: 'u1', tags: unknownTags }),
+        makeCommit({ hash: 'u2', tags: unknownTags }),
+      ])
+    );
+
+    expect(metrics.attribution.commitsTotal).toBe(4);
+    expect(metrics.attribution.ai).toBe(1);
+    expect(metrics.attribution.human).toBe(1);
+    expect(metrics.attribution.unknown).toBe(2);
+    expect(metrics.attribution.coverage).toBe(0.5);
+    expect(metrics.attribution.belowThreshold).toBe(true); // default threshold 0.7
+  });
+
+  it('flags belowThreshold using a custom coverageThreshold', () => {
+    const metrics = calculateMetrics(
+      makeStream([
+        makeCommit({ hash: 'a1', tags: aiTags }),
+        makeCommit({ hash: 'u1', tags: unknownTags }),
+      ]),
+      { coverageThreshold: 0.4 }
+    );
+
+    expect(metrics.attribution.coverage).toBe(0.5);
+    expect(metrics.attribution.belowThreshold).toBe(false);
+  });
+
+  it('handles an empty stream', () => {
+    const metrics = calculateMetrics(makeStream([]));
+    expect(metrics.attribution.coverage).toBe(0);
+    expect(metrics.baseline).toBeNull();
+    expect(metrics.delta).toBeNull();
+  });
+});
+
+describe('calculateMetrics baseline cohort', () => {
+  it('returns null baseline and delta when no commits are attributed human', () => {
+    const metrics = calculateMetrics(
+      makeStream([
+        makeCommit({ hash: 'a1', tags: aiTags }),
+        makeCommit({ hash: 'u1', tags: unknownTags }),
+      ])
+    );
+
+    expect(metrics.baseline).toBeNull();
+    expect(metrics.delta).toBeNull();
+    expect(metrics.caveats.some((c) => c.includes('No baseline'))).toBe(true);
+  });
+
+  it('builds the baseline from explicitly human-attributed commits', () => {
+    const metrics = calculateMetrics(
+      makeStream([
+        makeCommit({ hash: 'a1', tags: aiTags }),
+        makeCommit({ hash: 'h1', tags: humanTags }),
+        makeCommit({ hash: 'h2', tags: humanTags, inDefaultBranchAncestry: false }),
+        makeCommit({ hash: 'u1', tags: unknownTags }),
+      ])
+    );
+
+    expect(metrics.baseline).not.toBeNull();
+    expect(metrics.baseline!.assumed).toBe(false);
+    expect(metrics.baseline!.mergeRatio.commitsTotal).toBe(2); // unknown excluded
+    expect(metrics.baseline!.mergeRatio.mergeRatio).toBe(0.5);
+    expect(metrics.delta).not.toBeNull();
+  });
+
+  it('assigns unknown commits to the baseline with defaultAttribution: human, marked assumed', () => {
+    const metrics = calculateMetrics(
+      makeStream([
+        makeCommit({ hash: 'a1', tags: aiTags }),
+        makeCommit({ hash: 'u1', tags: unknownTags }),
+        makeCommit({ hash: 'u2', tags: unknownTags }),
+      ]),
+      { defaultAttribution: 'human' }
+    );
+
+    expect(metrics.baseline).not.toBeNull();
+    expect(metrics.baseline!.assumed).toBe(true);
+    expect(metrics.baseline!.mergeRatio.commitsTotal).toBe(2);
+    // Coverage still reports the truth: unknown commits stay unknown
+    expect(metrics.attribution.unknown).toBe(2);
+    expect(metrics.attribution.coverage).toBeCloseTo(1 / 3);
+    expect(metrics.caveats.some((c) => c.includes('assumed human'))).toBe(true);
+  });
+
+  it('assigns unknown commits to the AI cohort with defaultAttribution: ai', () => {
+    const metrics = calculateMetrics(
+      makeStream([
+        makeCommit({ hash: 'a1', tags: aiTags }),
+        makeCommit({ hash: 'h1', tags: humanTags }),
+        makeCommit({ hash: 'u1', tags: unknownTags }),
+      ]),
+      { defaultAttribution: 'ai' }
+    );
+
+    expect(metrics.mergeRatio.aiCommitsTotal).toBe(2); // ai + unknown
+    expect(metrics.baseline!.mergeRatio.commitsTotal).toBe(1); // human only
+    expect(metrics.baseline!.assumed).toBe(false);
+  });
+});

--- a/packages/metrics/src/index.ts
+++ b/packages/metrics/src/index.ts
@@ -1,36 +1,100 @@
-import { CommitStream, formatISODate } from '@aida-dev/core';
+import { Commit, CommitStream, formatISODate } from '@aida-dev/core';
 import { calculateBaselineMergeRatio, calculateMergeRatio } from './merge-ratio.js';
 import { calculateBaselinePersistence, calculatePersistence } from './persistence.js';
-import { Metrics } from './schema/metrics.js';
+import { Attribution, Metrics } from './schema/metrics.js';
 
 export * from './schema/metrics.js';
 export * from './merge-ratio.js';
 export * from './persistence.js';
+
+export interface MetricsOptions {
+  // Prior applied to 'unknown' commits: which cohort (if any) they join.
+  defaultAttribution?: 'ai' | 'human' | 'unknown';
+  coverageThreshold?: number;
+}
 
 function round(value: number, decimals: number): number {
   const factor = 10 ** decimals;
   return Math.round(value * factor) / factor;
 }
 
-export function calculateMetrics(commitStream: CommitStream): Metrics {
-  const mergeRatio = calculateMergeRatio(commitStream);
-  const persistence = calculatePersistence(commitStream);
-  const baselineMergeRatio = calculateBaselineMergeRatio(commitStream);
-  const baselinePersistence = calculateBaselinePersistence(commitStream);
+export function calculateMetrics(
+  commitStream: CommitStream,
+  options: MetricsOptions = {}
+): Metrics {
+  const { defaultAttribution = 'unknown', coverageThreshold = 0.7 } = options;
 
-  const delta = {
-    mergeRatio: round(mergeRatio.mergeRatio - baselineMergeRatio.mergeRatio, 4),
-    avgPersistenceDays: round(persistence.avgDays - baselinePersistence.avgDays, 2),
-    medianPersistenceDays: round(persistence.medianDays - baselinePersistence.medianDays, 2),
+  const counts = { ai: 0, human: 0, unknown: 0 };
+  for (const commit of commitStream.commits) {
+    counts[commit.tags.attribution]++;
+  }
+  const total = commitStream.commits.length;
+  const coverage = total > 0 ? (counts.ai + counts.human) / total : 0;
+
+  const attribution: Attribution = {
+    commitsTotal: total,
+    ai: counts.ai,
+    human: counts.human,
+    unknown: counts.unknown,
+    coverage: round(coverage, 4),
+    defaultAttribution,
+    coverageThreshold,
+    belowThreshold: coverage < coverageThreshold,
   };
 
+  // Cohort membership: unknown commits join a cohort only via the prior.
+  const isAI = (commit: Commit) =>
+    commit.tags.attribution === 'ai' ||
+    (defaultAttribution === 'ai' && commit.tags.attribution === 'unknown');
+  const isBaseline = (commit: Commit) =>
+    commit.tags.attribution === 'human' ||
+    (defaultAttribution === 'human' && commit.tags.attribution === 'unknown');
+
+  const mergeRatio = calculateMergeRatio(commitStream, isAI);
+  const persistence = calculatePersistence(commitStream, isAI);
+
+  // No baseline cohort → no baseline, no delta. AIDA does not invent a
+  // comparison out of unattributed commits.
+  const baselineSize = commitStream.commits.filter(isBaseline).length;
+  const baselineAssumed = defaultAttribution === 'human' && counts.unknown > 0;
+
+  const baseline =
+    baselineSize > 0
+      ? {
+          assumed: baselineAssumed,
+          mergeRatio: calculateBaselineMergeRatio(commitStream, isBaseline),
+          persistence: calculateBaselinePersistence(commitStream, isBaseline),
+        }
+      : null;
+
+  const delta = baseline
+    ? {
+        mergeRatio: round(mergeRatio.mergeRatio - baseline.mergeRatio.mergeRatio, 4),
+        avgPersistenceDays: round(persistence.avgDays - baseline.persistence.avgDays, 2),
+        medianPersistenceDays: round(
+          persistence.medianDays - baseline.persistence.medianDays,
+          2
+        ),
+      }
+    : null;
+
   const caveats = [
+    `Attribution coverage is ${(coverage * 100).toFixed(1)}%: metrics only describe commits whose provenance is known.`,
     'Persistence is file-level, not line-level.',
     'Merge ratio: commits from all branches checked against default branch ancestry. Squash merges may undercount unmerged commits.',
     'Time-windowed collection (--since) also windows the ancestry check: commits merged into the default branch before the window may appear unmerged.',
     'AI tagging uses heuristic patterns; false positives/negatives possible.',
-    'Baseline covers all non-AI-tagged commits; undetected AI usage may leak into the baseline.',
   ];
+  if (baseline?.assumed) {
+    caveats.push(
+      `Baseline includes ${counts.unknown} unattributed commit(s) assumed human via defaultAttribution — undetected AI usage may leak into it.`
+    );
+  }
+  if (!baseline) {
+    caveats.push(
+      'No baseline: no commits are attributed as human. Set defaultAttribution to "human" in .aida.json if unattributed commits in this repo are human-authored.'
+    );
+  }
 
   return {
     generatedAt: formatISODate(new Date()),
@@ -40,12 +104,10 @@ export function calculateMetrics(commitStream: CommitStream): Metrics {
     },
     repoPath: commitStream.repoPath,
     defaultBranch: commitStream.defaultBranch,
+    attribution,
     mergeRatio,
     persistence,
-    baseline: {
-      mergeRatio: baselineMergeRatio,
-      persistence: baselinePersistence,
-    },
+    baseline,
     delta,
     caveats,
   };

--- a/packages/metrics/src/merge-ratio.test.ts
+++ b/packages/metrics/src/merge-ratio.test.ts
@@ -21,7 +21,7 @@ describe('Merge Ratio Calculation', () => {
           message: 'AI: automated commit',
           parents: [],
           inDefaultBranchAncestry: true,
-          tags: { ai: true, level: 'explicit' as const, sources: ['trailer:AI: true'] },
+          tags: { ai: true, attribution: 'ai' as const, level: 'explicit' as const, sources: ['trailer:AI: true'] },
           stats: { totalAdditions: 10, totalDeletions: 5, files: [] },
         },
         {
@@ -35,7 +35,7 @@ describe('Merge Ratio Calculation', () => {
           message: 'regular commit',
           parents: [],
           inDefaultBranchAncestry: true,
-          tags: { ai: false, level: 'none' as const, sources: [] },
+          tags: { ai: false, attribution: 'unknown' as const, level: 'none' as const, sources: [] },
           stats: { totalAdditions: 5, totalDeletions: 2, files: [] },
         },
       ],
@@ -77,7 +77,7 @@ describe('Baseline Merge Ratio Calculation', () => {
     stats: { totalAdditions: 1, totalDeletions: 0, files: [] },
   };
 
-  it('should calculate baseline merge ratio over non-AI commits only', () => {
+  it('should calculate baseline merge ratio over human-attributed commits only', () => {
     const mockCommitStream: CommitStream = {
       repoPath: '/test/repo',
       defaultBranch: 'main',
@@ -89,21 +89,21 @@ describe('Baseline Merge Ratio Calculation', () => {
           hash: 'ai1',
           message: 'AI: automated commit',
           inDefaultBranchAncestry: true,
-          tags: { ai: true, level: 'explicit' as const, sources: ['trailer:AI: true'] },
+          tags: { ai: true, attribution: 'ai' as const, level: 'explicit' as const, sources: ['trailer:AI: true'] },
         },
         {
           ...baseCommit,
           hash: 'human1',
           message: 'regular commit merged',
           inDefaultBranchAncestry: true,
-          tags: { ai: false, level: 'none' as const, sources: [] },
+          tags: { ai: false, attribution: 'human' as const, level: 'none' as const, sources: [] },
         },
         {
           ...baseCommit,
           hash: 'human2',
           message: 'regular commit unmerged',
           inDefaultBranchAncestry: false,
-          tags: { ai: false, level: 'none' as const, sources: [] },
+          tags: { ai: false, attribution: 'human' as const, level: 'none' as const, sources: [] },
         },
       ],
     };
@@ -127,7 +127,7 @@ describe('Baseline Merge Ratio Calculation', () => {
           hash: 'ai1',
           message: 'AI: automated commit',
           inDefaultBranchAncestry: true,
-          tags: { ai: true, level: 'explicit' as const, sources: ['trailer:AI: true'] },
+          tags: { ai: true, attribution: 'ai' as const, level: 'explicit' as const, sources: ['trailer:AI: true'] },
         },
       ],
     };

--- a/packages/metrics/src/merge-ratio.ts
+++ b/packages/metrics/src/merge-ratio.ts
@@ -11,8 +11,11 @@ function computeMergeRatio(commits: Commit[]): CohortMergeRatio {
   };
 }
 
-export function calculateMergeRatio(commitStream: CommitStream): MergeRatio {
-  const aiCommits = commitStream.commits.filter((commit) => commit.tags.ai);
+export function calculateMergeRatio(
+  commitStream: CommitStream,
+  isTarget: (commit: Commit) => boolean = (commit) => commit.tags.attribution === 'ai'
+): MergeRatio {
+  const aiCommits = commitStream.commits.filter(isTarget);
   const result = computeMergeRatio(aiCommits);
 
   return {
@@ -22,7 +25,10 @@ export function calculateMergeRatio(commitStream: CommitStream): MergeRatio {
   };
 }
 
-export function calculateBaselineMergeRatio(commitStream: CommitStream): CohortMergeRatio {
-  const nonAICommits = commitStream.commits.filter((commit) => !commit.tags.ai);
-  return computeMergeRatio(nonAICommits);
+export function calculateBaselineMergeRatio(
+  commitStream: CommitStream,
+  isTarget: (commit: Commit) => boolean = (commit) => commit.tags.attribution === 'human'
+): CohortMergeRatio {
+  const baselineCommits = commitStream.commits.filter(isTarget);
+  return computeMergeRatio(baselineCommits);
 }

--- a/packages/metrics/src/persistence.test.ts
+++ b/packages/metrics/src/persistence.test.ts
@@ -14,7 +14,7 @@ function makeCommit(overrides: Partial<CommitStream['commits'][0]>): CommitStrea
     message: 'test commit',
     parents: [],
     inDefaultBranchAncestry: true,
-    tags: { ai: false, level: 'none', sources: [] },
+    tags: { ai: false, attribution: 'unknown' as const, level: 'none', sources: [] },
     stats: { totalAdditions: 10, totalDeletions: 0, files: [] },
     ...overrides,
   };
@@ -43,12 +43,12 @@ describe('calculatePersistence', () => {
     const stream = makeStream([
       makeCommit({
         hash: 'a1',
-        tags: { ai: true, level: 'explicit', sources: ['tag:[ai]'] },
+        tags: { ai: true, attribution: 'ai' as const, level: 'explicit', sources: ['tag:[ai]'] },
         stats: { totalAdditions: 5, totalDeletions: 0, files: [{ path: 'foo.ts', additions: 5, deletions: 0 }] },
       }),
       makeCommit({
         hash: 'a2',
-        tags: { ai: false, level: 'none', sources: [] },
+        tags: { ai: false, attribution: 'unknown' as const, level: 'none', sources: [] },
       }),
     ]);
     const result = calculatePersistence(stream);
@@ -60,7 +60,7 @@ describe('calculatePersistence', () => {
       makeCommit({
         hash: 'a1',
         authorDate: '2024-01-01T00:00:00.000Z',
-        tags: { ai: true, level: 'explicit', sources: ['tag:[ai]'] },
+        tags: { ai: true, attribution: 'ai' as const, level: 'explicit', sources: ['tag:[ai]'] },
         stats: {
           totalAdditions: 5,
           totalDeletions: 0,
@@ -70,7 +70,7 @@ describe('calculatePersistence', () => {
       makeCommit({
         hash: 'a2',
         authorDate: '2024-01-11T00:00:00.000Z',
-        tags: { ai: false, level: 'none', sources: [] },
+        tags: { ai: false, attribution: 'unknown' as const, level: 'none', sources: [] },
         stats: {
           totalAdditions: 2,
           totalDeletions: 1,
@@ -90,7 +90,7 @@ describe('calculatePersistence', () => {
       makeCommit({
         hash: 'a1',
         authorDate: '2024-01-01T00:00:00.000Z',
-        tags: { ai: true, level: 'explicit', sources: ['tag:[ai]'] },
+        tags: { ai: true, attribution: 'ai' as const, level: 'explicit', sources: ['tag:[ai]'] },
         stats: {
           totalAdditions: 5,
           totalDeletions: 0,
@@ -101,7 +101,7 @@ describe('calculatePersistence', () => {
       makeCommit({
         hash: 'a2',
         authorDate: '2024-01-01T00:00:00.000Z',
-        tags: { ai: true, level: 'explicit', sources: ['tag:[ai]'] },
+        tags: { ai: true, attribution: 'ai' as const, level: 'explicit', sources: ['tag:[ai]'] },
         stats: {
           totalAdditions: 5,
           totalDeletions: 0,
@@ -112,7 +112,7 @@ describe('calculatePersistence', () => {
       makeCommit({
         hash: 'a3',
         authorDate: '2024-01-06T00:00:00.000Z',
-        tags: { ai: false, level: 'none', sources: [] },
+        tags: { ai: false, attribution: 'unknown' as const, level: 'none', sources: [] },
         stats: {
           totalAdditions: 2,
           totalDeletions: 0,
@@ -131,7 +131,7 @@ describe('calculatePersistence', () => {
       makeCommit({
         hash: 'a1',
         authorDate: '2024-01-01T00:00:00.000Z',
-        tags: { ai: true, level: 'explicit', sources: ['tag:[ai]'] },
+        tags: { ai: true, attribution: 'ai' as const, level: 'explicit', sources: ['tag:[ai]'] },
         stats: {
           totalAdditions: 5,
           totalDeletions: 0,
@@ -141,7 +141,7 @@ describe('calculatePersistence', () => {
       makeCommit({
         hash: 'a2',
         authorDate: '2024-01-20T00:00:00.000Z',
-        tags: { ai: false, level: 'none', sources: [] },
+        tags: { ai: false, attribution: 'unknown' as const, level: 'none', sources: [] },
         stats: {
           totalAdditions: 0,
           totalDeletions: 5,
@@ -156,18 +156,18 @@ describe('calculatePersistence', () => {
 });
 
 describe('calculateBaselinePersistence', () => {
-  it('measures persistence over non-AI commits only, ignoring AI commits', () => {
+  it('measures persistence over human-attributed commits only, ignoring AI commits', () => {
     const stream = makeStream([
       makeCommit({
         hash: 'h1',
         authorDate: '2024-01-01T00:00:00.000Z',
-        tags: { ai: false, level: 'none', sources: [] },
+        tags: { ai: false, attribution: 'human' as const, level: 'none', sources: [] },
         stats: { totalAdditions: 5, totalDeletions: 0, files: [{ path: 'foo.ts', additions: 5, deletions: 0 }] },
       }),
       makeCommit({
         hash: 'ai1',
         authorDate: '2024-01-06T00:00:00.000Z',
-        tags: { ai: true, level: 'explicit', sources: ['tag:[ai]'] },
+        tags: { ai: true, attribution: 'ai' as const, level: 'explicit', sources: ['tag:[ai]'] },
         stats: { totalAdditions: 2, totalDeletions: 0, files: [{ path: 'foo.ts', additions: 2, deletions: 0, status: 'modified' }] },
       }),
     ]);
@@ -177,11 +177,11 @@ describe('calculateBaselinePersistence', () => {
     expect(result.avgDays).toBe(5);
   });
 
-  it('returns zeros when there are no non-AI commits', () => {
+  it('returns zeros when there are no human-attributed commits', () => {
     const stream = makeStream([
       makeCommit({
         hash: 'ai1',
-        tags: { ai: true, level: 'explicit', sources: ['tag:[ai]'] },
+        tags: { ai: true, attribution: 'ai' as const, level: 'explicit', sources: ['tag:[ai]'] },
         stats: { totalAdditions: 1, totalDeletions: 0, files: [{ path: 'x.ts', additions: 1, deletions: 0 }] },
       }),
     ]);

--- a/packages/metrics/src/persistence.ts
+++ b/packages/metrics/src/persistence.ts
@@ -10,7 +10,7 @@ interface FileLifecycle {
 
 export function calculatePersistence(
   commitStream: CommitStream,
-  isTarget: (commit: Commit) => boolean = (commit) => commit.tags.ai
+  isTarget: (commit: Commit) => boolean = (commit) => commit.tags.attribution === 'ai'
 ): Persistence {
   const targetCommits = commitStream.commits.filter(isTarget);
 
@@ -109,6 +109,9 @@ export function calculatePersistence(
   };
 }
 
-export function calculateBaselinePersistence(commitStream: CommitStream): Persistence {
-  return calculatePersistence(commitStream, (commit) => !commit.tags.ai);
+export function calculateBaselinePersistence(
+  commitStream: CommitStream,
+  isTarget: (commit: Commit) => boolean = (commit) => commit.tags.attribution === 'human'
+): Persistence {
+  return calculatePersistence(commitStream, isTarget);
 }

--- a/packages/metrics/src/schema/metrics.ts
+++ b/packages/metrics/src/schema/metrics.ts
@@ -1,5 +1,18 @@
 import { z } from 'zod';
 
+// Attribution coverage (#34): the headline metric. Every other number in this
+// file is only as trustworthy as this block says it is.
+export const Attribution = z.object({
+  commitsTotal: z.number().int().nonnegative(),
+  ai: z.number().int().nonnegative(),
+  human: z.number().int().nonnegative(),
+  unknown: z.number().int().nonnegative(),
+  coverage: z.number().min(0).max(1), // (ai + human) / total
+  defaultAttribution: z.enum(['ai', 'human', 'unknown']), // prior applied to unknown commits
+  coverageThreshold: z.number().min(0).max(1),
+  belowThreshold: z.boolean(),
+});
+
 export const MergeRatio = z.object({
   aiCommitsTotal: z.number().int().nonnegative(),
   aiCommitsMerged: z.number().int().nonnegative(),
@@ -26,6 +39,9 @@ export const CohortMergeRatio = z.object({
 });
 
 export const Baseline = z.object({
+  // True when the cohort includes 'unknown' commits via defaultAttribution:
+  // the baseline is an assumption, not observed attribution.
+  assumed: z.boolean(),
   mergeRatio: CohortMergeRatio,
   persistence: Persistence,
 });
@@ -44,13 +60,17 @@ export const Metrics = z.object({
   }),
   repoPath: z.string(),
   defaultBranch: z.string(),
+  attribution: Attribution,
   mergeRatio: MergeRatio,
   persistence: Persistence,
-  baseline: Baseline,
-  delta: Delta,
+  // Null when no commit is attributed 'human' and no defaultAttribution prior
+  // assigns the unknowns: AIDA does not invent a comparison cohort.
+  baseline: Baseline.nullable(),
+  delta: Delta.nullable(),
   caveats: z.array(z.string()),
 });
 
+export type Attribution = z.infer<typeof Attribution>;
 export type MergeRatio = z.infer<typeof MergeRatio>;
 export type Persistence = z.infer<typeof Persistence>;
 export type CohortMergeRatio = z.infer<typeof CohortMergeRatio>;


### PR DESCRIPTION
Closes #34.

## What

Replaces the silent AI/human binary with three-state attribution and makes **coverage** the first number in every output.

- **`tags.attribution`** on every commit: `ai` | `human` | `unknown`. Message heuristics emit only `ai` or `unknown` — the absence of an AI signal is not evidence of human authorship. `human` will come from explicit declarations (attribution manifest, #10).
- **`metrics.json` leads with an `attribution` block**: per-state counts, coverage `(ai+human)/total`, configurable `coverageThreshold` (default 0.7), `belowThreshold` flag.
- **`baseline`/`delta` are nullable**: with no human-attributed commits and no prior, AIDA reports *no baseline* instead of comparing AI commits against a fictional human cohort.
- **`defaultAttribution`** (`.aida.json` or `aida analyze --default-attribution`): consciously assigns unknown commits to a cohort. Affects cohort metrics, never coverage; an assumed baseline is labeled `assumed` in both metrics and report.
- **Report** opens with an *Attribution Coverage* section + low-confidence warning banner below threshold.
- This repo's own `.aida.json` now declares `defaultAttribution: "ai"` — the repo is AI-written with human review.

## Dogfood (this repo, full history)

Before: 27 AI vs 52 "human" commits, delta −81d persistence — but the 52 are untagged AI, the comparison was fiction.

After, out of the box:

> **34.2% of commits have known provenance** — ai: 27 · human: 0 · unknown: 52 (65.8%)
> ⚠️ Coverage is below 70%. Most of this history has unknown provenance: every metric below is low-confidence.
> **No baseline available** — no commits are attributed as human, so there is nothing honest to compare against.

With `--default-attribution human` the old comparison is still one flag away, now labeled *Human baseline (assumed)* with a leak caveat.

## Breaking (0.x minor)

- `commit-stream.json` requires `tags.attribution` — rerun `aida collect`.
- `metrics.json` consumers must handle `baseline: null` / `delta: null`; baseline semantics are now *human cohort*, not *non-AI*.

## Testing

- 58 tests pass (`pnpm test`), including new `calculateMetrics` suite: coverage math, custom threshold, null baseline, both priors, assumed labeling.
- Lint clean.
- Dogfooded end-to-end on this repo with all three `defaultAttribution` values.

Origin: [r/devtools feedback](https://www.reddit.com/r/devtools/comments/1v0poe8/) — "the ai/human/unknown honesty in the next version is the whole product, not a feature."

Co-Authored-By: Claude <noreply@anthropic.com>