### PR TITLE
feat: attribution manifest — retroactive ai/human/excluded declarations (#10)

### DIFF
--- a/.changeset/attribution-manifest.md
+++ b/.changeset/attribution-manifest.md
@@ -1,0 +1,14 @@
+---
+'@aida-dev/core': minor
+'@aida-dev/cli': patch
+---
+
+Attribution manifest support (#10)
+
+`aida collect` now reads an optional `aida-attribution.json` at the repo root to apply retroactive, explicit attribution declarations on top of message heuristics:
+
+- `ai_assisted_commits` → attribution `ai`, level `explicit`, source `manifest`
+- `human_authored_commits` (new) → attribution `human` — the first way to build a real human baseline for the three-state model
+- `excluded_commits` → forces attribution `unknown`, overriding heuristics (for automation such as release bots and merge commits)
+
+Precedence: in-commit evidence beats retroactive declarations — a commit with an explicit AI signal stays `ai` even if declared human (with a warning); `excluded_commits` always wins. Invalid manifests log a warning and are ignored; they never fail `collect`. Manifest hashes that match no collected commit are reported informationally.

--- a/README.md
+++ b/README.md
@@ -226,6 +226,36 @@ Non-AI automation bots (`dependabot`, `renovate`, `github-actions`, `greenkeeper
 
 `copilot`, `cursor`, `windsurf`, `codeium`, `claude`, `chatgpt`, `gemini`
 
+### Attribution Manifest (`aida-attribution.json`)
+
+Heuristics only see what commit messages admit to. The manifest lets you declare attribution **retroactively and explicitly** — for commits made before your team adopted trailers, or to correct heuristic false positives. Place it at the repo root; `aida collect` picks it up automatically ([#10](https://github.com/ceccode/AIDA-Metrics/issues/10)).
+
+```json
+{
+  "version": "1.0",
+  "tool": "windsurf",
+  "model": "claude-opus",
+  "note": "Commits made before Co-Authored-By trailers were adopted.",
+  "ai_assisted_commits": [
+    { "hash": "2f972ace3ff158fbe272d2850e879008abb0b197", "message": "first commit" }
+  ],
+  "human_authored_commits": [
+    { "hash": "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b", "message": "fix: hand-written hotfix" }
+  ],
+  "excluded_commits": [
+    { "hash": "1be7b68039b5156881c080def855c7d4dd30698d", "message": "chore: release packages", "reason": "Automated by changesets" }
+  ]
+}
+```
+
+| List | Effect |
+|------|--------|
+| `ai_assisted_commits` | Attribution `ai`, level `explicit`, source `manifest` |
+| `human_authored_commits` | Attribution `human`, source `manifest` — the way to build a real human baseline |
+| `excluded_commits` | Forces attribution `unknown` (overrides heuristics) — for automation like release bots and merge commits |
+
+Precedence: in-commit evidence beats retroactive declarations. A commit with an explicit AI trailer stays `ai` even if the manifest declares it human (with a warning); `excluded_commits` always wins, since it exists to correct heuristic false positives. Full hashes are matched exactly (`message` is documentation only); an invalid manifest logs a warning and is ignored — it never fails `collect`.
+
 ### Configuration File (`.aida.json`)
 
 Place a `.aida.json` file in your project root to add custom tools, trailer domains, and patterns:
@@ -294,7 +324,7 @@ If no commits are attributed `human` and no `defaultAttribution` prior assigns t
 
 These metrics are honest approximations, not ground truth. Read the numbers with these caveats in mind:
 
-- **Detection is voluntary** — AIDA only sees what commits admit to. Untagged AI code lands in the `unknown` bucket, and attribution coverage ([#34](https://github.com/ceccode/AIDA-Metrics/issues/34)) reports how big that bucket is instead of hiding it — but the tool still cannot see through a commit that lies.
+- **Detection is voluntary** — AIDA only sees what commits admit to. Untagged AI code lands in the `unknown` bucket, and attribution coverage ([#34](https://github.com/ceccode/AIDA-Metrics/issues/34)) reports how big that bucket is instead of hiding it; the attribution manifest ([#10](https://github.com/ceccode/AIDA-Metrics/issues/10)) lets you shrink it retroactively. But the tool still cannot see through a commit that lies.
 - **Squash merges break merge ratio** — branch commits disappear from history, inflating the ratio ([#20](https://github.com/ceccode/AIDA-Metrics/issues/20)).
 - **Persistence is file-level** — one AI-touched line marks the whole file as AI-touched; line-level tracking via `git blame` is planned ([#23](https://github.com/ceccode/AIDA-Metrics/issues/23)).
 - **Cohort age skews persistence** — older commits have had more time to accumulate survival; comparisons need age normalization ([#29](https://github.com/ceccode/AIDA-Metrics/issues/29)).
@@ -388,8 +418,9 @@ aida_analysis:
 - **v0.6** ✅ Comparative baseline — AI vs non-AI metrics with delta ([#19](https://github.com/ceccode/AIDA-Metrics/issues/19)).  
 - **v0.7** ✅ Exclude non-AI bots (dependabot, renovate, …) from trailer matching, with configurable blocklist ([#21](https://github.com/ceccode/AIDA-Metrics/issues/21)).  
 - **v0.8** ✅ Attribution coverage as headline metric — three-state `ai`/`human`/`unknown`, `defaultAttribution` prior, nullable baseline ([#34](https://github.com/ceccode/AIDA-Metrics/issues/34)).  
-- **Next** → Attribution manifest ([#10](https://github.com/ceccode/AIDA-Metrics/issues/10)), fix squash-merge merge ratio ([#20](https://github.com/ceccode/AIDA-Metrics/issues/20)).  
-- **Next** → Anti-leaderboard hardening: author redaction in outputs ([#35](https://github.com/ceccode/AIDA-Metrics/issues/35)), task-mix stratification by file category ([#36](https://github.com/ceccode/AIDA-Metrics/issues/36)).  
+- **v0.9** ✅ Attribution manifest — retroactive `ai`/`human`/`excluded` declarations via `aida-attribution.json` ([#10](https://github.com/ceccode/AIDA-Metrics/issues/10)).  
+- **Next** → Persistence age-normalization ([#29](https://github.com/ceccode/AIDA-Metrics/issues/29)), task-mix stratification by file category ([#36](https://github.com/ceccode/AIDA-Metrics/issues/36)).  
+- **Next** → Fix squash-merge merge ratio ([#20](https://github.com/ceccode/AIDA-Metrics/issues/20)), anti-leaderboard hardening: author redaction in outputs ([#35](https://github.com/ceccode/AIDA-Metrics/issues/35)).  
 - **Next** → Rework rate ([#22](https://github.com/ceccode/AIDA-Metrics/issues/22)), line-level persistence via blame ([#23](https://github.com/ceccode/AIDA-Metrics/issues/23)).  
 - **Next** → Autonomy levels — autocomplete vs assisted vs agent ([#25](https://github.com/ceccode/AIDA-Metrics/issues/25)), outcome correlation ([#26](https://github.com/ceccode/AIDA-Metrics/issues/26)), cost metrics ([#27](https://github.com/ceccode/AIDA-Metrics/issues/27)).  
 - **Next** → GitLab ([#16](https://github.com/ceccode/AIDA-Metrics/issues/16)) and Bitbucket ([#17](https://github.com/ceccode/AIDA-Metrics/issues/17)) PR comment providers.  
@@ -402,7 +433,7 @@ In an AI-first world, "was this commit written by AI?" is becoming the wrong que
 - **Three-state attribution** — `ai` / `human` / `unknown` instead of forcing unattributed commits into a binary bucket ([#34](https://github.com/ceccode/AIDA-Metrics/issues/34)). Attribution **coverage** becomes the headline metric ("62% attributed · 38% unknown" is a data-quality signal, not something to hide inside a default) — because the unknown bucket grows fastest exactly where the numbers are taken most seriously. A configurable `defaultAttribution` prior will let AI-first teams opt into "AI unless stated otherwise" — consciously, instead of the tool silently assuming either way.
 - **Quality over adoption** — the durable question is not "how much code is AI?" but "does AI code hold up?": rework rate ([#22](https://github.com/ceccode/AIDA-Metrics/issues/22)), line-level survival ([#23](https://github.com/ceccode/AIDA-Metrics/issues/23)), outcome correlation ([#26](https://github.com/ceccode/AIDA-Metrics/issues/26)).
 - **Autonomy over the binary** — autocomplete vs assisted vs agent ([#25](https://github.com/ceccode/AIDA-Metrics/issues/25)) is the axis that will replace AI/non-AI.
-- **Shrink the unknown at the source** — commit-time stamping via git hooks and the attribution manifest ([#10](https://github.com/ceccode/AIDA-Metrics/issues/10)) make attribution deterministic instead of heuristic.
+- **Shrink the unknown at the source** — the attribution manifest ([#10](https://github.com/ceccode/AIDA-Metrics/issues/10), shipped) makes attribution declarative; commit-time stamping via git hooks will make it automatic.
 - **Cohorts, not people** — AIDA compares groups of commits, never developers. No per-author aggregation will ever ship, and author identity can be redacted from output artifacts ([#35](https://github.com/ceccode/AIDA-Metrics/issues/35)) so the data model doesn't hand anyone a leaderboard for free.
 
 ## Contributing

--- a/aida-attribution.json
+++ b/aida-attribution.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "description": "Retroactive AI attribution for commits made before automated Co-Authored-By tracking was enabled.",
-  "note": "This repository was built with ~80% AI assistance using Windsurf (Claude Opus). These commits predate the adoption of Co-Authored-By trailers.",
+  "note": "This repository is AI-written with human review. Early commits were made with Windsurf (Claude Opus) before Co-Authored-By trailers were adopted; later untagged commits (CI tweaks, docs, squash-merged features) were added retroactively. Merge commits and changesets release commits are excluded: they are automation, not authored code.",
   "tool": "windsurf",
   "model": "claude-opus",
   "ai_assisted_commits": [
@@ -68,13 +68,61 @@
     {
       "hash": "76f5bda5255734abf874cc8b7e10ce559872e19d",
       "message": "chore: add changeset for AI detection improvements"
+    },
+    {
+      "hash": "5025f0b9f61d908004aba86f7c391d7730241ca3",
+      "message": "update gitignore"
+    },
+    {
+      "hash": "d108ed6cd869d58965894677f5db11182b7401a8",
+      "message": "feat: add comparative baseline metrics (AI vs non-AI)"
+    },
+    {
+      "hash": "54a508b112eefcef9a8f142de705ca31f5bb078b",
+      "message": "feat: add comparative baseline metrics (AI vs non-AI) (#28)"
+    },
+    {
+      "hash": "1948d709c39d1e3c2e8ca3ce29a9f58545baa4b0",
+      "message": "docs: update README and landing page with comparative baseline feature"
+    },
+    {
+      "hash": "76311033a4b38febeaadb8fcd00fce58b25d79ac",
+      "message": "ci: run AIDA on PRs with comment, dogfood on own repo"
+    },
+    {
+      "hash": "2e22b88ff23c6dcba925b76269c5eee16ae62dce",
+      "message": "fix: exclude non-AI bots from trailer matching (#21)"
+    },
+    {
+      "hash": "a529073e36a13896907d2ed784d44d55a44b54bf",
+      "message": "fix: use diff base ref for default-branch commit set in PR mode"
+    },
+    {
+      "hash": "938a72dd8f9e21f19a0df41b5d7fd5cf2bf04373",
+      "message": "fix: exclude non-AI bots from trailer matching (#21) (#30)"
+    },
+    {
+      "hash": "c22d1a7c1ea7b9d2f0a36d3ccf88b70708e54dd4",
+      "message": "ci: bump actions to Node 24 runtime (checkout@v5, setup-node@v5, pnpm/action-setup@v4)"
+    },
+    {
+      "hash": "7612e2bd879488a471cc713eb579c1998e50ed4e",
+      "message": "ci: drop pnpm version from action-setup, defer to packageManager"
+    },
+    {
+      "hash": "d477c3a4bbb4d5f6a5949736f0c7b04e296e4e18",
+      "message": "ci: drop pnpm version from action-setup, defer to packageManager"
+    },
+    {
+      "hash": "d92f0089b83bd6a51403339dae1d0c088ea2cd95",
+      "message": "docs: add Known Limits section, link community-driven issues #34-#36"
     }
   ],
   "excluded_commits": [
     {
       "hash": "38b8007ef656b27194e90952b6a676068868299b",
       "message": "feat: initial AIDA metrics implementation with AI-powered analysis"
-    },    
+    },
     {
       "hash": "300d0f153b39b29d5624df6880aa07cedc2ab37a",
       "message": "docs: add Contributor Covenant Code of Conduct",
@@ -87,6 +135,116 @@
     },
     {
       "hash": "a424c3327700f82d41164769c3a956a2586c5e0e",
+      "message": "chore: release packages",
+      "reason": "Automated by changesets"
+    },
+    {
+      "hash": "0c62dda15dd807cef874c63f5d60c3c68cebb412",
+      "message": "Merge pull request #1 from ceccode/feat/core",
+      "reason": "Merge commit"
+    },
+    {
+      "hash": "c41e4deb6f1bf8a9449058bf2e54b3a972ea9bf3",
+      "message": "Merge pull request #2 from ceccode/feat/docs",
+      "reason": "Merge commit"
+    },
+    {
+      "hash": "ee85792010dd521ff1b152fbbeda5c079a6e9a28",
+      "message": "Merge pull request #3 from ceccode/changeset-release/main",
+      "reason": "Merge commit"
+    },
+    {
+      "hash": "2532f4ff997f64aba73fdb106a97c1f4a826bb5b",
+      "message": "Merge branch 'main' of github.com:ceccode/AIDA-Metrics",
+      "reason": "Merge commit"
+    },
+    {
+      "hash": "55051d0a383bbfe50e3e1b5cdea3e9153e7fc892",
+      "message": "Merge pull request #5 from ceccode/fix/since-until-flags",
+      "reason": "Merge commit"
+    },
+    {
+      "hash": "87c0afd9caeccf71ed41ea2da990e3b14c5542dc",
+      "message": "Merge pull request #6 from ceccode/changeset-release/main",
+      "reason": "Merge commit"
+    },
+    {
+      "hash": "d59126d50b75ec3904767f1c1da0cc99975ac933",
+      "message": "Merge branch 'main' of github.com:ceccode/AIDA-Metrics",
+      "reason": "Merge commit"
+    },
+    {
+      "hash": "dfc4acabb92847538aac16b8be08fd38dbbceabc",
+      "message": "chore: release packages",
+      "reason": "Automated by changesets"
+    },
+    {
+      "hash": "44e7f19cdec0f20af6c91111028262c2107597f5",
+      "message": "Merge pull request #8 from ceccode/changeset-release/main",
+      "reason": "Merge commit"
+    },
+    {
+      "hash": "55e9e22092243f6f0c99de73c2685f951014a400",
+      "message": "Merge branch 'main' of github.com:ceccode/AIDA-Metrics",
+      "reason": "Merge commit"
+    },
+    {
+      "hash": "c8ebafd56d635725e5678735a3bbe0c49e312151",
+      "message": "chore: release packages",
+      "reason": "Automated by changesets"
+    },
+    {
+      "hash": "dfc3d0ee21094caa5c82e8385a03bac68506bfb8",
+      "message": "Merge pull request #9 from ceccode/changeset-release/main",
+      "reason": "Merge commit"
+    },
+    {
+      "hash": "4b1ec053d67ab27e619f312f5801d0e0ad9110c9",
+      "message": "chore: release packages",
+      "reason": "Automated by changesets"
+    },
+    {
+      "hash": "0adc293b9776f73ca070c57ad5f14e06b3700fdb",
+      "message": "Merge pull request #11 from ceccode/changeset-release/main",
+      "reason": "Merge commit"
+    },
+    {
+      "hash": "b6d07a2a0857cd4e9dc3c37390368d9db571a470",
+      "message": "chore: release packages",
+      "reason": "Automated by changesets"
+    },
+    {
+      "hash": "a19a55c22091c0c59c2e85417823fa32dd337663",
+      "message": "Merge pull request #13 from ceccode/changeset-release/main",
+      "reason": "Merge commit"
+    },
+    {
+      "hash": "63c4ff040c6899dbe8b0f41a94b217cea434ca95",
+      "message": "chore: release packages",
+      "reason": "Automated by changesets"
+    },
+    {
+      "hash": "ae76233c60276e9956a81deee6c114b9c57dd9ef",
+      "message": "Merge pull request #14 from ceccode/changeset-release/main",
+      "reason": "Merge commit"
+    },
+    {
+      "hash": "10ae380d3dca8df548546a21126b1cfc277e22e7",
+      "message": "chore: release @aida-dev/metrics@0.3.0, @aida-dev/cli@0.4.0",
+      "reason": "Automated by changesets"
+    },
+    {
+      "hash": "d76c62aede1c151895ffa75ec176ce8c0da654b9",
+      "message": "chore: release packages (#31)",
+      "reason": "Automated by changesets"
+    },
+    {
+      "hash": "a34fe47b5441e27db0133f7db7bfb393bf8b9689",
+      "message": "chore: release packages",
+      "reason": "Automated by changesets"
+    },
+    {
+      "hash": "55b418b89652bd15122f8b294a21f2f626b35b17",
       "message": "chore: release packages",
       "reason": "Automated by changesets"
     }

--- a/packages/core/src/git/collect.test.ts
+++ b/packages/core/src/git/collect.test.ts
@@ -94,3 +94,71 @@ describe('collectCommits', () => {
     expect(head.tags.level).toBe('explicit');
   });
 });
+
+describe('collectCommits with attribution manifest', () => {
+  let manifestRepoPath: string;
+
+  function runIn(cmd: string) {
+    execSync(cmd, { cwd: manifestRepoPath });
+  }
+
+  function commitIn(message: string): string {
+    const escaped = message.replace(/"/g, '\\"');
+    runIn(`git commit -q --allow-empty -m "${escaped}"`);
+    return execSync('git rev-parse HEAD', { cwd: manifestRepoPath }).toString().trim();
+  }
+
+  beforeAll(() => {
+    manifestRepoPath = mkdtempSync(join(tmpdir(), 'aida-manifest-collect-'));
+    execSync('git init -q -b main', { cwd: manifestRepoPath });
+    runIn('git config user.name test && git config user.email test@example.com');
+  });
+
+  afterAll(() => {
+    rmSync(manifestRepoPath, { recursive: true, force: true });
+  });
+
+  it('applies manifest declarations on top of heuristics end-to-end', async () => {
+    const untaggedAI = commitIn('feat: untagged but AI-assisted');
+    const humanCommit = commitIn('fix: hand-written fix');
+    const releaseCommit = commitIn(
+      'chore: release\n\nCo-authored-by: some-release-bot <bot@example.com>'
+    );
+    const plainCommit = commitIn('docs: not in manifest');
+
+    writeFileSync(
+      join(manifestRepoPath, 'aida-attribution.json'),
+      JSON.stringify({
+        version: '1.0',
+        ai_assisted_commits: [{ hash: untaggedAI }],
+        human_authored_commits: [{ hash: humanCommit }],
+        excluded_commits: [{ hash: releaseCommit, reason: 'Automated' }],
+      })
+    );
+
+    const stream = await collectCommits({ repoPath: manifestRepoPath });
+    const byHash = Object.fromEntries(stream.commits.map((c) => [c.hash, c.tags]));
+
+    expect(byHash[untaggedAI].attribution).toBe('ai');
+    expect(byHash[untaggedAI].level).toBe('explicit');
+    expect(byHash[untaggedAI].sources).toContain('manifest');
+
+    expect(byHash[humanCommit].attribution).toBe('human');
+    expect(byHash[humanCommit].sources).toContain('manifest');
+
+    // The bot trailer would tag this explicit ai; excluded forces unknown
+    expect(byHash[releaseCommit].attribution).toBe('unknown');
+    expect(byHash[releaseCommit].ai).toBe(false);
+    expect(byHash[releaseCommit].sources).toContain('manifest:excluded');
+
+    expect(byHash[plainCommit].attribution).toBe('unknown');
+    expect(byHash[plainCommit].sources).not.toContain('manifest');
+  });
+
+  it('does not fail collect when the manifest is invalid', async () => {
+    writeFileSync(join(manifestRepoPath, 'aida-attribution.json'), '{ broken');
+    const stream = await collectCommits({ repoPath: manifestRepoPath });
+    expect(stream.commits.length).toBeGreaterThan(0);
+    expect(stream.commits.every((c) => !c.tags.sources.includes('manifest'))).toBe(true);
+  });
+});

--- a/packages/core/src/git/collect.ts
+++ b/packages/core/src/git/collect.ts
@@ -1,6 +1,12 @@
 import { simpleGit, SimpleGit } from 'simple-git';
 import { Commit, CommitStream } from '../schema/commit.js';
 import { createAITagger } from '../tags/ai-tags.js';
+import {
+  applyManifest,
+  indexManifest,
+  loadAttributionManifest,
+  unmatchedManifestHashes,
+} from '../tags/attribution-manifest.js';
 import { logWithStats } from './log.js';
 import { parseRelativeDate, formatISODate } from '../utils/dates.js';
 import { Logger } from '../utils/log.js';
@@ -128,6 +134,10 @@ export async function collectCommits(options: CollectOptions): Promise<CommitStr
     botBlocklist: aiBotBlocklist,
   });
 
+  // Optional retroactive attribution manifest at the repo root (#10)
+  const manifest = await loadAttributionManifest(repoPath, logger);
+  const manifestIndex = manifest ? indexManifest(manifest) : null;
+
   // Deduplicate commits (same hash can appear from multiple branches)
   const seen = new Set<string>();
   const commits: Commit[] = [];
@@ -138,7 +148,10 @@ export async function collectCommits(options: CollectOptions): Promise<CommitStr
     logger?.debug(`Processing commit ${rawCommit.hash}`);
 
     // Tag AI on the full message (body included, for trailers like Co-Authored-By)
-    const aiTag = aiTagger(rawCommit.message);
+    let aiTag = aiTagger(rawCommit.message);
+    if (manifestIndex) {
+      aiTag = applyManifest(aiTag, rawCommit.hash, manifestIndex, logger);
+    }
 
     const commit: Commit = {
       hash: rawCommit.hash,
@@ -156,6 +169,15 @@ export async function collectCommits(options: CollectOptions): Promise<CommitStr
     };
 
     commits.push(commit);
+  }
+
+  if (manifestIndex) {
+    const unmatched = unmatchedManifestHashes(manifestIndex);
+    if (unmatched.length > 0) {
+      logger?.info(
+        `Manifest: ${unmatched.length} hash(es) matched no collected commit (rebase, typo, or outside the --since window)`
+      );
+    }
   }
 
   return {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,6 +5,7 @@ export * from './git/collect.js';
 export * from './git/diff.js';
 export * from './git/log.js';
 export * from './tags/ai-tags.js';
+export * from './tags/attribution-manifest.js';
 export * from './io/fs.js';
 export * from './utils/dates.js';
 export * from './utils/log.js';

--- a/packages/core/src/tags/attribution-manifest.test.ts
+++ b/packages/core/src/tags/attribution-manifest.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  AttributionManifest,
+  applyManifest,
+  indexManifest,
+  loadAttributionManifest,
+  unmatchedManifestHashes,
+} from './attribution-manifest.js';
+import { AITagResult } from './ai-tags.js';
+
+const HASH_AI = 'a'.repeat(40);
+const HASH_HUMAN = 'b'.repeat(40);
+const HASH_EXCLUDED = 'c'.repeat(40);
+const HASH_ABSENT = 'd'.repeat(40);
+
+function makeIndex() {
+  return indexManifest(
+    AttributionManifest.parse({
+      version: '1.0',
+      ai_assisted_commits: [{ hash: HASH_AI }],
+      human_authored_commits: [{ hash: HASH_HUMAN }],
+      excluded_commits: [{ hash: HASH_EXCLUDED, reason: 'Automated' }],
+    })
+  );
+}
+
+const unknownTag: AITagResult = { ai: false, attribution: 'unknown', level: 'none', sources: [] };
+const aiTag: AITagResult = {
+  ai: true,
+  attribution: 'ai',
+  level: 'explicit',
+  sources: ['trailer:^AI:\\s*true$'],
+};
+
+describe('applyManifest precedence', () => {
+  it('tags manifest ai_assisted commits as explicit ai with source manifest', () => {
+    const result = applyManifest(unknownTag, HASH_AI, makeIndex());
+    expect(result.attribution).toBe('ai');
+    expect(result.ai).toBe(true);
+    expect(result.level).toBe('explicit');
+    expect(result.sources).toContain('manifest');
+  });
+
+  it('merges heuristic sources when manifest confirms an already-detected ai commit', () => {
+    const result = applyManifest(aiTag, HASH_AI, makeIndex());
+    expect(result.attribution).toBe('ai');
+    expect(result.sources).toEqual(['trailer:^AI:\\s*true$', 'manifest']);
+  });
+
+  it('tags manifest human_authored commits as human when heuristics found nothing', () => {
+    const result = applyManifest(unknownTag, HASH_HUMAN, makeIndex());
+    expect(result.attribution).toBe('human');
+    expect(result.ai).toBe(false);
+    expect(result.sources).toContain('manifest');
+  });
+
+  it('keeps ai when a human declaration conflicts with in-commit AI evidence, and warns', () => {
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+    const index = indexManifest(
+      AttributionManifest.parse({
+        version: '1.0',
+        human_authored_commits: [{ hash: HASH_AI }],
+      })
+    );
+    const result = applyManifest(aiTag, HASH_AI, index, logger);
+    expect(result.attribution).toBe('ai');
+    expect(logger.warn).toHaveBeenCalledOnce();
+  });
+
+  it('excluded overrides heuristics and forces unknown', () => {
+    const result = applyManifest(aiTag, HASH_EXCLUDED, makeIndex());
+    expect(result.attribution).toBe('unknown');
+    expect(result.ai).toBe(false);
+    expect(result.sources).toContain('manifest:excluded');
+  });
+
+  it('leaves commits absent from the manifest untouched', () => {
+    const result = applyManifest(unknownTag, HASH_ABSENT, makeIndex());
+    expect(result).toEqual(unknownTag);
+  });
+
+  it('reports manifest hashes that matched no collected commit', () => {
+    const index = makeIndex();
+    applyManifest(unknownTag, HASH_AI, index);
+    expect(unmatchedManifestHashes(index).sort()).toEqual([HASH_HUMAN, HASH_EXCLUDED].sort());
+  });
+});
+
+describe('loadAttributionManifest', () => {
+  it('returns null when the manifest is missing', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'aida-manifest-test-'));
+    try {
+      expect(await loadAttributionManifest(dir)).toBeNull();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('warns and returns null on an invalid manifest instead of throwing', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'aida-manifest-test-'));
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+    try {
+      writeFileSync(join(dir, 'aida-attribution.json'), '{ not json');
+      expect(await loadAttributionManifest(dir, logger)).toBeNull();
+      expect(logger.warn).toHaveBeenCalledOnce();
+
+      writeFileSync(join(dir, 'aida-attribution.json'), '{"ai_assisted_commits": "nope"}');
+      expect(await loadAttributionManifest(dir, logger)).toBeNull();
+      expect(logger.warn).toHaveBeenCalledTimes(2);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('parses the documented format, defaulting absent lists', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'aida-manifest-test-'));
+    try {
+      writeFileSync(
+        join(dir, 'aida-attribution.json'),
+        JSON.stringify({
+          version: '1.0',
+          tool: 'windsurf',
+          model: 'claude-opus',
+          note: 'documentation field',
+          ai_assisted_commits: [{ hash: HASH_AI, message: 'feat: x' }],
+        })
+      );
+      const manifest = await loadAttributionManifest(dir);
+      expect(manifest?.ai_assisted_commits).toHaveLength(1);
+      expect(manifest?.human_authored_commits).toEqual([]);
+      expect(manifest?.excluded_commits).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/src/tags/attribution-manifest.ts
+++ b/packages/core/src/tags/attribution-manifest.ts
@@ -1,0 +1,135 @@
+import { z } from 'zod';
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+import { AITagResult } from './ai-tags.js';
+import { Logger } from '../utils/log.js';
+
+export const MANIFEST_FILENAME = 'aida-attribution.json';
+
+const ManifestEntry = z.object({
+  hash: z.string().min(7),
+  message: z.string().optional(), // documentation only, not matched
+  reason: z.string().optional(),
+});
+
+export const AttributionManifest = z.object({
+  version: z.string(),
+  description: z.string().optional(),
+  note: z.string().optional(),
+  tool: z.string().optional(),
+  model: z.string().optional(),
+  ai_assisted_commits: z.array(ManifestEntry).default([]),
+  human_authored_commits: z.array(ManifestEntry).default([]),
+  excluded_commits: z.array(ManifestEntry).default([]),
+});
+
+export type AttributionManifest = z.infer<typeof AttributionManifest>;
+
+// Hash-indexed view of a manifest for O(1) lookup during collect.
+export interface ManifestIndex {
+  ai: Set<string>;
+  human: Set<string>;
+  excluded: Set<string>;
+  // Hashes seen during collect, to report manifest entries that matched nothing
+  matched: Set<string>;
+}
+
+export function indexManifest(manifest: AttributionManifest): ManifestIndex {
+  return {
+    ai: new Set(manifest.ai_assisted_commits.map((e) => e.hash)),
+    human: new Set(manifest.human_authored_commits.map((e) => e.hash)),
+    excluded: new Set(manifest.excluded_commits.map((e) => e.hash)),
+    matched: new Set(),
+  };
+}
+
+// Loads <repoPath>/aida-attribution.json. Missing file → null (manifest is
+// optional). Invalid file → warning, null: a broken manifest must never make
+// collect fail.
+export async function loadAttributionManifest(
+  repoPath: string,
+  logger?: Logger
+): Promise<AttributionManifest | null> {
+  const manifestPath = join(repoPath, MANIFEST_FILENAME);
+
+  let raw: string;
+  try {
+    raw = await readFile(manifestPath, 'utf-8');
+  } catch {
+    return null; // no manifest — the common case
+  }
+
+  try {
+    const manifest = AttributionManifest.parse(JSON.parse(raw));
+    logger?.info(
+      `Attribution manifest loaded: ${manifest.ai_assisted_commits.length} ai, ` +
+        `${manifest.human_authored_commits.length} human, ` +
+        `${manifest.excluded_commits.length} excluded`
+    );
+    return manifest;
+  } catch (error) {
+    logger?.warn(
+      `Ignoring invalid ${MANIFEST_FILENAME}: ${error instanceof Error ? error.message.split('\n')[0] : String(error)}`
+    );
+    return null;
+  }
+}
+
+// Applies manifest declarations on top of the heuristic tag result.
+// Precedence: in-commit evidence beats retroactive declarations, except
+// 'excluded', which always wins (it exists precisely to correct heuristic
+// false positives like automated release commits).
+export function applyManifest(
+  heuristic: AITagResult,
+  hash: string,
+  index: ManifestIndex,
+  logger?: Logger
+): AITagResult {
+  if (index.excluded.has(hash)) {
+    index.matched.add(hash);
+    return {
+      ai: false,
+      attribution: 'unknown',
+      level: 'none',
+      sources: [...heuristic.sources, 'manifest:excluded'],
+    };
+  }
+
+  if (index.ai.has(hash)) {
+    index.matched.add(hash);
+    return {
+      ai: true,
+      attribution: 'ai',
+      // A manifest declaration is explicit, whatever the heuristics said
+      level: 'explicit',
+      sources: [...heuristic.sources, 'manifest'],
+    };
+  }
+
+  if (index.human.has(hash)) {
+    index.matched.add(hash);
+    if (heuristic.attribution === 'ai') {
+      // The commit itself carries an AI signal: in-commit evidence wins.
+      logger?.warn(
+        `Manifest declares ${hash.slice(0, 8)} human, but the commit has an explicit AI signal (${heuristic.sources.join(', ')}) — keeping ai`
+      );
+      return heuristic;
+    }
+    return {
+      ai: false,
+      attribution: 'human',
+      level: heuristic.level,
+      sources: [...heuristic.sources, 'manifest'],
+    };
+  }
+
+  return heuristic;
+}
+
+// Manifest hashes that matched no collected commit — typo, rebase, or a
+// --since window that excludes them. Informational, never an error.
+export function unmatchedManifestHashes(index: ManifestIndex): string[] {
+  return [...index.ai, ...index.human, ...index.excluded].filter(
+    (hash) => !index.matched.has(hash)
+  );
+}


### PR DESCRIPTION
Closes #10.

## What

`aida collect` now reads the optional `aida-attribution.json` at the repo root — the manifest this repo has carried (ignored) since March — and applies explicit, retroactive attribution on top of message heuristics.

- **`ai_assisted_commits`** → attribution `ai`, level `explicit`, source `manifest`
- **`human_authored_commits`** (new list) → attribution `human` — the first real source for the `human` state introduced in #34, i.e. the way to build an honest human baseline
- **`excluded_commits`** → forces `unknown`, overriding heuristics — for automation (release bots, merge commits) that would otherwise pollute either cohort

### Precedence (in-commit evidence > retroactive declaration)
1. `excluded` always wins (it exists to correct heuristic false positives)
2. `ai_assisted` merges with heuristic sources
3. `human_authored` applies only when the commit carries no AI signal; an explicit trailer keeps the commit `ai` with a conflict warning
4. Invalid manifest → **warning, never a failed collect** (per issue acceptance criteria)
5. Unmatched hashes (typo, rebase, `--since` window) → informational log

## Manifest extended (review the diff!)

Per our decision, this repo's manifest now covers the whole history: **+12 substantive untagged commits declared `ai`** (CI tweaks, docs, squash-merged features — this repo is AI-written with human review) and **+22 merge/release commits as `excluded`**. Please review the classification in the `aida-attribution.json` diff.

## Dogfood (this repo, full history, 83 commits)

| | before #34 | after #34 | + manifest (existing 16) | + manifest (extended) |
|---|---:|---:|---:|---:|
| Coverage | *(hidden)* | 34.2% | 54.2% | **68.7%** |
| ai / human / unknown | 27 / "52 human" | 27 / 0 / 52 | 45 / 0 / 38 | 57 / 0 / 26 |

The remaining 26 unknown are **all** manifest-excluded automation (13 merge commits, 12 changesets release commits, 1 template). Their provenance is actually *known* — they're bots — but the three-state model has no bucket for that, so coverage caps at 68.7% and the low-confidence warning stays on forever. That's a real finding from dogfooding: proposal for a fourth `automated` attribution state coming as a follow-up issue.

## Testing

- 70 tests pass: new unit suite for the precedence matrix + invalid-manifest handling, new end-to-end collect test with a manifest in a fixture repo (including excluded-overrides-bot-trailer)
- Lint clean
- `--since 30d` verified: 39 unmatched hashes reported informationally, no error

Co-Authored-By: Claude <noreply@anthropic.com>