### PR TITLE
fix: persistence measures survival, not churn — censoring + category exclusion

### DIFF
--- a/.changeset/persistence-survival-semantics.md
+++ b/.changeset/persistence-survival-semantics.md
@@ -1,0 +1,12 @@
+---
+'@aida-dev/metrics': minor
+'@aida-dev/cli': patch
+---
+
+Fix persistence semantics: survival with censoring, convention-driven categories excluded
+
+The file-level persistence metric measured the span from a file's first target-cohort touch to the **last** time anyone touched it — churn duration, not survival. A stable file never modified again scored 0 days (the best outcome counted as the worst), while a changelog touched by every release scored maximum.
+
+Now persistence = **survival**: days until the *first* subsequent modification or deletion. Files never modified again are **censored** at collection time (they survived the window) and reported via a new `censored` count. Migrations (append-only by convention) and generated files (churned on every release) carry no quality signal and are excluded from persistence by default — new `filesConsidered`/`filesExcluded` fields make this visible; they still appear in the task-mix table.
+
+Found via community feedback on the task-mix feature. Breaking for `metrics.json` consumers: `persistence` gains required `filesConsidered`, `filesExcluded`, `censored` fields, and bucket distributions shift meaning.

--- a/README.md
+++ b/README.md
@@ -311,10 +311,12 @@ Percentage of AI-tagged commits that were merged into the default branch.
 
 ### Persistence (MVP)
 
-File-level proxy for how long AI-modified files survive before being changed again.
+File-level survival: days from the first target-cohort touch of a file until the **first subsequent modification** (or deletion) by any commit.
 
-- Buckets: 0-1d, 2-7d, 8-30d, 31-90d, 90d+
-- Provides average and median survival times
+- Files never modified again are **censored** at collection time — they survived the whole observation window, the best possible outcome (not zero). The report shows how many.
+- **Migrations and generated files** (lockfiles, changelogs, snapshots) are excluded by default: their lifecycle is convention-driven — append-only or churned on every release — and carries no quality signal either way. They still appear in the task-mix table.
+- Buckets: 0-1d, 2-7d, 8-30d, 31-90d, 90d+, with average and median survival times.
+- Known roughness: multi-commit sessions touching the same file produce short survivals (the clock starts at the first touch); line-level tracking ([#23](https://github.com/ceccode/AIDA-Metrics/issues/23)) will refine this.
 
 ### Comparative Baseline
 

--- a/packages/cli/src/commands/report.ts
+++ b/packages/cli/src/commands/report.ts
@@ -96,8 +96,9 @@ ${fairnessSection}
 - AI-tagged commits merged: ${metrics.mergeRatio.aiCommitsMerged}
 - **Merge Ratio:** ${mergeRatioPct}%
 
-## Persistence (file-level proxy)
+## Persistence (file-level survival)
 - Commits considered: ${metrics.persistence.commitsConsidered}
+- Files measured: ${metrics.persistence.filesConsidered} (${metrics.persistence.censored} still surviving at collection time; ${metrics.persistence.filesExcluded} excluded: migrations/generated)
 - Average days: ${metrics.persistence.avgDays}
 - Median days: ${metrics.persistence.medianDays}
 

--- a/packages/metrics/src/index.ts
+++ b/packages/metrics/src/index.ts
@@ -109,6 +109,7 @@ export function calculateMetrics(
   const caveats = [
     `Attribution coverage is ${(coverage * 100).toFixed(1)}%: metrics only describe commits whose provenance is known.`,
     'Persistence is file-level, not line-level.',
+    'Persistence is survival: days until the first subsequent modification. Files never modified again are censored at collection time. Migrations and generated files (convention-driven lifecycles) are excluded.',
     'Persistence comparisons are only meaningful between cohorts of similar age and task mix — check the cohorts section before reading the delta.',
     'Merge ratio: commits from all branches checked against default branch ancestry. Squash merges may undercount unmerged commits.',
     'Time-windowed collection (--since) also windows the ancestry check: commits merged into the default branch before the window may appear unmerged.',

--- a/packages/metrics/src/persistence.test.ts
+++ b/packages/metrics/src/persistence.test.ts
@@ -121,9 +121,80 @@ describe('calculatePersistence', () => {
       }),
     ]);
     const result = calculatePersistence(stream);
-    // a.ts: 0 days, b.ts: 5 days
-    expect(result.buckets.d0_1).toBe(1);  // a.ts
-    expect(result.buckets.d2_7).toBe(1);  // b.ts
+    // b.ts: modified after 5 days → event, d2_7
+    // a.ts: never touched again → censored at stream end (2024-06-01, 152d) → d90_plus
+    expect(result.buckets.d2_7).toBe(1); // b.ts
+    expect(result.buckets.d90_plus).toBe(1); // a.ts, censored
+    expect(result.censored).toBe(1);
+    expect(result.filesConsidered).toBe(2);
+  });
+
+  it('censors files never modified again at the observation end, not zero', () => {
+    const stream = makeStream([
+      makeCommit({
+        hash: 'a1',
+        authorDate: '2024-01-01T00:00:00.000Z',
+        tags: { ai: true, attribution: 'ai' as const, mode: 'agent' as const, modeEvidence: 'inferred' as const, level: 'explicit', sources: ['tag:[ai]'] },
+        stats: {
+          totalAdditions: 5,
+          totalDeletions: 0,
+          files: [{ path: 'stable.ts', additions: 5, deletions: 0 }],
+        },
+      }),
+    ]);
+    const result = calculatePersistence(stream);
+    // stream generatedAt is 2024-06-01 → survived 152 days, the best outcome
+    expect(result.avgDays).toBe(152);
+    expect(result.censored).toBe(1);
+  });
+
+  it('ends the survival clock at the first subsequent touch, same cohort included', () => {
+    const aiTags = { ai: true, attribution: 'ai' as const, mode: 'agent' as const, modeEvidence: 'inferred' as const, level: 'explicit', sources: ['tag:[ai]'] };
+    const stream = makeStream([
+      makeCommit({
+        hash: 'a1',
+        authorDate: '2024-01-01T00:00:00.000Z',
+        tags: aiTags,
+        stats: { totalAdditions: 5, totalDeletions: 0, files: [{ path: 'foo.ts', additions: 5, deletions: 0 }] },
+      }),
+      makeCommit({
+        hash: 'a2',
+        authorDate: '2024-01-03T00:00:00.000Z',
+        tags: aiTags,
+        stats: { totalAdditions: 1, totalDeletions: 0, files: [{ path: 'foo.ts', additions: 1, deletions: 0, status: 'modified' }] },
+      }),
+      makeCommit({
+        hash: 'a3',
+        authorDate: '2024-01-30T00:00:00.000Z',
+        tags: aiTags,
+        stats: { totalAdditions: 1, totalDeletions: 0, files: [{ path: 'foo.ts', additions: 1, deletions: 0, status: 'modified' }] },
+      }),
+    ]);
+    const result = calculatePersistence(stream);
+    // survival ends at the FIRST subsequent touch (2 days), not the last (29)
+    expect(result.avgDays).toBe(2);
+  });
+
+  it('excludes migrations and generated files from persistence by default', () => {
+    const stream = makeStream([
+      makeCommit({
+        hash: 'a1',
+        authorDate: '2024-01-01T00:00:00.000Z',
+        tags: { ai: true, attribution: 'ai' as const, mode: 'agent' as const, modeEvidence: 'inferred' as const, level: 'explicit', sources: ['tag:[ai]'] },
+        stats: {
+          totalAdditions: 3,
+          totalDeletions: 0,
+          files: [
+            { path: 'db/migrations/001_init.sql', additions: 1, deletions: 0 },
+            { path: 'pnpm-lock.yaml', additions: 1, deletions: 0 },
+            { path: 'src/app.ts', additions: 1, deletions: 0 },
+          ],
+        },
+      }),
+    ]);
+    const result = calculatePersistence(stream);
+    expect(result.filesConsidered).toBe(1); // src/app.ts only
+    expect(result.filesExcluded).toBe(2);
   });
 
   it('handles deleted files by not extending persistence', () => {
@@ -150,8 +221,9 @@ describe('calculatePersistence', () => {
       }),
     ]);
     const result = calculatePersistence(stream);
-    // File was deleted, so persistence should be 0 days (only the first AI commit date)
-    expect(result.avgDays).toBe(0);
+    // Deletion is the first subsequent event: the file survived 19 days
+    expect(result.avgDays).toBe(19);
+    expect(result.censored).toBe(0);
   });
 });
 

--- a/packages/metrics/src/persistence.ts
+++ b/packages/metrics/src/persistence.ts
@@ -1,117 +1,144 @@
 import { Commit, CommitStream, daysBetween } from '@aida-dev/core';
-import { Persistence } from './schema/metrics.js';
+import { categorizeFile } from './cohort.js';
+import { FileCategory, Persistence } from './schema/metrics.js';
 
-interface FileLifecycle {
-  path: string;
-  firstTargetCommitDate: Date;
-  lastSeenDate: Date;
-  persistenceDays: number;
+// Categories whose lifecycle is governed by convention, not code quality:
+// migrations are append-only (never modified once applied), generated files
+// (lockfiles, changelogs) churn on every release regardless of author.
+// Either way their survival carries no signal, so they are excluded from
+// persistence by default. They still appear in the task-mix table.
+export const DEFAULT_PERSISTENCE_EXCLUDED_CATEGORIES: FileCategory[] = [
+  'migrations',
+  'generated',
+];
+
+export interface PersistenceOptions {
+  excludeCategories?: FileCategory[];
+  // End of the observation window, used to measure censored files (never
+  // modified again). Defaults to the stream's collection time.
+  observationEnd?: Date;
 }
 
+interface FileLifecycle {
+  firstTargetIndex: number;
+  firstTargetDate: Date;
+  // Set when a later commit modifies or deletes the file: survival ends
+  eventDate: Date | null;
+}
+
+// Persistence = survival: days from the first target-cohort touch of a file
+// until the FIRST subsequent modification (or deletion) by any commit.
+// Files never touched again are censored at the observation end — they
+// survived the whole window, which is the best possible outcome, not zero.
 export function calculatePersistence(
   commitStream: CommitStream,
-  isTarget: (commit: Commit) => boolean = (commit) => commit.tags.attribution === 'ai'
+  isTarget: (commit: Commit) => boolean = (commit) => commit.tags.attribution === 'ai',
+  options: PersistenceOptions = {}
 ): Persistence {
+  const {
+    excludeCategories = DEFAULT_PERSISTENCE_EXCLUDED_CATEGORIES,
+    observationEnd = new Date(commitStream.generatedAt),
+  } = options;
+  const excluded = new Set<FileCategory>(excludeCategories);
+
   const targetCommits = commitStream.commits.filter(isTarget);
 
-  if (targetCommits.length === 0) {
-    return {
-      commitsConsidered: 0,
-      avgDays: 0,
-      medianDays: 0,
-      buckets: {
-        d0_1: 0,
-        d2_7: 0,
-        d8_30: 0,
-        d31_90: 0,
-        d90_plus: 0,
-      },
-    };
-  }
+  const empty: Persistence = {
+    commitsConsidered: targetCommits.length,
+    filesConsidered: 0,
+    filesExcluded: 0,
+    censored: 0,
+    avgDays: 0,
+    medianDays: 0,
+    buckets: { d0_1: 0, d2_7: 0, d8_30: 0, d31_90: 0, d90_plus: 0 },
+  };
 
-  // Group files by path and track their lifecycle
-  const fileLifecycles = new Map<string, FileLifecycle>();
+  if (targetCommits.length === 0) {
+    return { ...empty, commitsConsidered: 0 };
+  }
 
   // Sort commits by date (oldest first)
   const sortedCommits = [...commitStream.commits].sort(
     (a, b) => new Date(a.authorDate).getTime() - new Date(b.authorDate).getTime()
   );
 
-  // Track first target commit per file
-  for (const commit of sortedCommits) {
-    if (isTarget(commit)) {
-      const commitDate = new Date(commit.authorDate);
-
-      for (const file of commit.stats.files) {
-        if (!fileLifecycles.has(file.path)) {
-          fileLifecycles.set(file.path, {
-            path: file.path,
-            firstTargetCommitDate: commitDate,
-            lastSeenDate: commitDate,
-            persistenceDays: 0,
-          });
-        }
-      }
-    }
-  }
-
-  // Track last seen date for each file
-  for (const commit of sortedCommits) {
-    const commitDate = new Date(commit.authorDate);
-
+  // First target-cohort touch per file
+  const lifecycles = new Map<string, FileLifecycle>();
+  let filesExcluded = 0;
+  sortedCommits.forEach((commit, index) => {
+    if (!isTarget(commit)) return;
     for (const file of commit.stats.files) {
-      const lifecycle = fileLifecycles.get(file.path);
-      if (lifecycle) {
-        // Update last seen date if file is not deleted
-        if (file.status !== 'deleted') {
-          lifecycle.lastSeenDate = commitDate;
-        }
+      if (lifecycles.has(file.path)) continue;
+      if (excluded.has(categorizeFile(file.path))) {
+        filesExcluded++;
+        lifecycles.set(file.path, { firstTargetIndex: -1, firstTargetDate: new Date(0), eventDate: null });
+        continue;
       }
+      lifecycles.set(file.path, {
+        firstTargetIndex: index,
+        firstTargetDate: new Date(commit.authorDate),
+        eventDate: null,
+      });
+    }
+  });
+
+  // First subsequent modification (or deletion) ends the survival clock
+  sortedCommits.forEach((commit, index) => {
+    for (const file of commit.stats.files) {
+      const lifecycle = lifecycles.get(file.path);
+      if (!lifecycle || lifecycle.firstTargetIndex < 0) continue; // excluded category
+      if (index <= lifecycle.firstTargetIndex) continue; // not later than first touch
+      if (lifecycle.eventDate === null) {
+        lifecycle.eventDate = new Date(commit.authorDate);
+      }
+    }
+  });
+
+  const survivalDays: number[] = [];
+  let censored = 0;
+  for (const lifecycle of lifecycles.values()) {
+    if (lifecycle.firstTargetIndex < 0) continue; // excluded category
+    if (lifecycle.eventDate) {
+      survivalDays.push(daysBetween(lifecycle.firstTargetDate, lifecycle.eventDate));
+    } else {
+      // Never modified again: survived to the end of the observation window
+      censored++;
+      survivalDays.push(Math.max(0, daysBetween(lifecycle.firstTargetDate, observationEnd)));
     }
   }
 
-  // Calculate persistence days for each file
-  const persistenceDays: number[] = [];
-
-  for (const lifecycle of fileLifecycles.values()) {
-    lifecycle.persistenceDays = daysBetween(lifecycle.firstTargetCommitDate, lifecycle.lastSeenDate);
-    persistenceDays.push(lifecycle.persistenceDays);
+  if (survivalDays.length === 0) {
+    return { ...empty, filesExcluded };
   }
 
-  // Calculate statistics
-  const avgDays =
-    persistenceDays.length > 0
-      ? persistenceDays.reduce((sum, days) => sum + days, 0) / persistenceDays.length
-      : 0;
-
-  const sortedDays = [...persistenceDays].sort((a, b) => a - b);
+  const avgDays = survivalDays.reduce((sum, days) => sum + days, 0) / survivalDays.length;
+  const sortedDays = [...survivalDays].sort((a, b) => a - b);
   const medianDays =
-    sortedDays.length > 0
-      ? sortedDays.length % 2 === 0
-        ? (sortedDays[sortedDays.length / 2 - 1] + sortedDays[sortedDays.length / 2]) / 2
-        : sortedDays[Math.floor(sortedDays.length / 2)]
-      : 0;
-
-  // Calculate buckets
-  const buckets = {
-    d0_1: persistenceDays.filter((days) => days <= 1).length,
-    d2_7: persistenceDays.filter((days) => days >= 2 && days <= 7).length,
-    d8_30: persistenceDays.filter((days) => days >= 8 && days <= 30).length,
-    d31_90: persistenceDays.filter((days) => days >= 31 && days <= 90).length,
-    d90_plus: persistenceDays.filter((days) => days > 90).length,
-  };
+    sortedDays.length % 2 === 0
+      ? (sortedDays[sortedDays.length / 2 - 1] + sortedDays[sortedDays.length / 2]) / 2
+      : sortedDays[Math.floor(sortedDays.length / 2)];
 
   return {
     commitsConsidered: targetCommits.length,
-    avgDays: Math.round(avgDays * 100) / 100, // Round to 2 decimal places
+    filesConsidered: survivalDays.length,
+    filesExcluded,
+    censored,
+    avgDays: Math.round(avgDays * 100) / 100,
     medianDays: Math.round(medianDays * 100) / 100,
-    buckets,
+    buckets: {
+      d0_1: survivalDays.filter((days) => days <= 1).length,
+      d2_7: survivalDays.filter((days) => days >= 2 && days <= 7).length,
+      d8_30: survivalDays.filter((days) => days >= 8 && days <= 30).length,
+      d31_90: survivalDays.filter((days) => days >= 31 && days <= 90).length,
+      d90_plus: survivalDays.filter((days) => days > 90).length,
+    },
   };
 }
 
 export function calculateBaselinePersistence(
   commitStream: CommitStream,
-  isTarget: (commit: Commit) => boolean = (commit) => commit.tags.attribution === 'human'
+  isTarget: (commit: Commit) => boolean = (commit) => commit.tags.attribution === 'human',
+  options: PersistenceOptions = {}
 ): Persistence {
-  return calculatePersistence(commitStream, isTarget);
+  return calculatePersistence(commitStream, isTarget, options);
 }

--- a/packages/metrics/src/schema/metrics.ts
+++ b/packages/metrics/src/schema/metrics.ts
@@ -32,8 +32,16 @@ export const MergeRatio = z.object({
   mergeRatio: z.number().min(0).max(1),
 });
 
+// Persistence = survival: days from first target-cohort touch of a file to
+// the first subsequent modification. Files never modified again are censored
+// at the observation end (they survived the window — the best outcome).
+// Migrations and generated files are excluded by default: their lifecycle is
+// convention-driven and carries no quality signal.
 export const Persistence = z.object({
   commitsConsidered: z.number().int().nonnegative(),
+  filesConsidered: z.number().int().nonnegative(),
+  filesExcluded: z.number().int().nonnegative(),
+  censored: z.number().int().nonnegative(), // files that survived the whole window
   avgDays: z.number().nonnegative(),
   medianDays: z.number().nonnegative(),
   buckets: z.object({


### PR DESCRIPTION
From [r/devtools feedback](https://www.reddit.com/r/devtools/comments/1v0poe8/) on the task-mix feature:

> migrations might need excluding rather than labelling. They're append only by convention so they score max persistence regardless of who wrote them

The commenter was right — and verifying it exposed something worse: **our persistence didn't measure survival at all.** It measured the span from a file's first target-cohort touch to the **last** time anyone touched it (churn duration). Consequences:

- A stable module never modified again scored **0 days** — the best possible outcome counted as the worst
- `CHANGELOG.md`, touched by every release, scored **maximum** — automation churn read as "AI code holds up great"

## What changed

1. **Survival semantics**: persistence = days from first target-cohort touch to the *first* subsequent modification or deletion by any commit.
2. **Censoring**: files never modified again survived the whole observation window — measured to collection time and counted in a new `censored` field, not zeroed.
3. **Category exclusion** (the original suggestion): `migrations` (append-only by convention) and `generated` (lockfiles/changelogs, churned every release) are excluded from persistence by default — their lifecycle carries no quality signal in either direction. New `filesConsidered`/`filesExcluded` fields expose this; they still appear in the task-mix table.

## Dogfood (this repo, AI cohort)

| | before (churn) | after (survival) |
|---|---:|---:|
| Avg days | ~126 | 80.5 |
| Files 0–1d | inflated by never-touched-again stable files | 27 — now actual same-day rework |
| Files 90d+ | inflated by CHANGELOG/lockfile churn | 34, incl. 12 censored survivors |
| Excluded | 0 | 4 generated files |

Known remaining roughness (documented in README): multi-commit agent sessions touching the same file produce short survivals since the clock starts at the first touch — #23 (line-level) is the structural fix.

## Testing

89 tests pass (4 new: censoring-not-zero, first-touch-ends-clock, deletion-as-event, category exclusion; 3 updated to the corrected semantics). Lint clean. Dogfooded end-to-end.

Co-Authored-By: Claude <noreply@anthropic.com>