### PR TITLE
feat: 'automated' as fourth attribution state — bots have known provenance (#39)

### DIFF
--- a/.changeset/automated-attribution.md
+++ b/.changeset/automated-attribution.md
@@ -1,0 +1,16 @@
+---
+'@aida-dev/core': minor
+'@aida-dev/metrics': minor
+'@aida-dev/cli': patch
+---
+
+'automated' as fourth attribution state (#39)
+
+Merge commits and bot-authored commits are automation, not authored code — their provenance is known, yet they landed in `unknown`, dragging coverage down forever (and decaying it with every release) or getting pulled into cohorts by `defaultAttribution` priors.
+
+- New attribution state `automated`: auto-detected at collect time (merge commits via parent count, bots via the #21 blocklist matched against author/committer identity) or declared via manifest `excluded_commits`. In-commit AI evidence and manifest ai/human declarations always win over the structural heuristics.
+- Coverage now counts `automated` as known provenance: `(ai + human + automated) / total`.
+- Automated commits join no cohort and priors never touch them; they carry `mode: none`.
+- Report and logs show the automated count; the `defaultAttribution` prior note is hidden when there are no unknown commits left.
+
+Breaking for `metrics.json`/`commit-stream.json` consumers: attribution enum gains `automated`; the attribution block gains a required `automated` count.

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ Heuristics only see what commit messages admit to. The manifest lets you declare
 |------|--------|
 | `ai_assisted_commits` | Attribution `ai`, level `explicit`, source `manifest` |
 | `human_authored_commits` | Attribution `human`, source `manifest` — the way to build a real human baseline |
-| `excluded_commits` | Forces attribution `unknown` (overrides heuristics) — for automation like release bots and merge commits |
+| `excluded_commits` | Declares attribution `automated` (overrides heuristics) — for automation the auto-detection misses (bots not in the blocklist, templates) |
 | `mode` (top-level or per-entry) | Declares the autonomy level of `ai_assisted_commits`: `autocomplete` \| `assisted` \| `agent` ([#25](https://github.com/ceccode/AIDA-Metrics/issues/25)). Per-entry beats top-level. A manifest mode is `declared` evidence; without one, AIDA infers a coarse mode from the tool named in trailers (`inferred`) |
 
 Precedence: in-commit evidence beats retroactive declarations. A commit with an explicit AI trailer stays `ai` even if the manifest declares it human (with a warning); `excluded_commits` always wins, since it exists to correct heuristic false positives. Full hashes are matched exactly (`message` is documentation only); an invalid manifest logs a warning and is ignored — it never fails `collect`.
@@ -299,9 +299,9 @@ aida analyze --default-attribution human --coverage-threshold 0.8
 
 ### Attribution Coverage
 
-The headline metric ([#34](https://github.com/ceccode/AIDA-Metrics/issues/34)). Every commit gets a three-state attribution: `ai` (explicit/implicit detection), `human` (explicit declaration — coming with the attribution manifest, [#10](https://github.com/ceccode/AIDA-Metrics/issues/10)), or `unknown` (no signal — the absence of an AI tag is *not* evidence of human authorship).
+The headline metric ([#34](https://github.com/ceccode/AIDA-Metrics/issues/34)). Every commit gets a four-state attribution: `ai` (explicit/implicit detection or manifest), `human` (explicit declaration via manifest), `automated` (provenance-known automation, [#39](https://github.com/ceccode/AIDA-Metrics/issues/39) — merge commits and known bots auto-detected at collect time, or manifest `excluded_commits`; counts toward coverage, joins no cohort), or `unknown` (no signal — the absence of an AI tag is *not* evidence of human authorship).
 
-**Coverage** = share of commits with known provenance. It is reported first in every output, because every other number is only as trustworthy as coverage says it is. Below `coverageThreshold` (default 70%), the report carries a low-confidence warning.
+**Coverage** = share of commits with known provenance (`ai` + `human` + `automated`). It is reported first in every output, because every other number is only as trustworthy as coverage says it is. Below `coverageThreshold` (default 70%), the report carries a low-confidence warning.
 
 `defaultAttribution` lets a team consciously assign unattributed commits to a cohort (`human` for traditional repos, `ai` for AI-first ones). The prior affects cohort metrics but never coverage: unknown stays unknown in the attribution block, and an assumed baseline is labeled as such.
 
@@ -426,7 +426,8 @@ aida_analysis:
 - **v0.9** ✅ Attribution manifest — retroactive `ai`/`human`/`excluded` declarations via `aida-attribution.json` ([#10](https://github.com/ceccode/AIDA-Metrics/issues/10)).  
 - **v0.10** ✅ Cohort fairness context — age stats ([#29](https://github.com/ceccode/AIDA-Metrics/issues/29), step 1) and task mix by file category ([#36](https://github.com/ceccode/AIDA-Metrics/issues/36), step 1) per cohort.  
 - **v0.11** ✅ Autonomy mode collection — `mode` × `evidence` per commit, manifest declarations, tool inference ([#25](https://github.com/ceccode/AIDA-Metrics/issues/25), step 1).  
-- **Next** → Per-mode cohort metrics ([#25](https://github.com/ceccode/AIDA-Metrics/issues/25), step 2), `automated` attribution state ([#39](https://github.com/ceccode/AIDA-Metrics/issues/39)), synthetic PR merge commit fix ([#40](https://github.com/ceccode/AIDA-Metrics/issues/40)).  
+- **v0.12** ✅ `automated` attribution state — merge commits and bots auto-detected, coverage counts known automation ([#39](https://github.com/ceccode/AIDA-Metrics/issues/39)).  
+- **Next** → Per-mode cohort metrics ([#25](https://github.com/ceccode/AIDA-Metrics/issues/25), step 2), synthetic PR merge commit fix ([#40](https://github.com/ceccode/AIDA-Metrics/issues/40)).  
 - **Next** → Fix squash-merge merge ratio ([#20](https://github.com/ceccode/AIDA-Metrics/issues/20)), anti-leaderboard hardening: author redaction in outputs ([#35](https://github.com/ceccode/AIDA-Metrics/issues/35)).  
 - **Next** → Rework rate ([#22](https://github.com/ceccode/AIDA-Metrics/issues/22)), line-level persistence via blame ([#23](https://github.com/ceccode/AIDA-Metrics/issues/23)).  
 - **Next** → Autonomy levels — autocomplete vs assisted vs agent ([#25](https://github.com/ceccode/AIDA-Metrics/issues/25)), outcome correlation ([#26](https://github.com/ceccode/AIDA-Metrics/issues/26)), cost metrics ([#27](https://github.com/ceccode/AIDA-Metrics/issues/27)).  

--- a/packages/cli/src/commands/analyze.ts
+++ b/packages/cli/src/commands/analyze.ts
@@ -64,7 +64,7 @@ export function createAnalyzeCommand(): Command {
 
         const a = metrics.attribution;
         logger.info(
-          `Attribution coverage: ${(a.coverage * 100).toFixed(1)}% (ai: ${a.ai}, human: ${a.human}, unknown: ${a.unknown})`
+          `Attribution coverage: ${(a.coverage * 100).toFixed(1)}% (ai: ${a.ai}, human: ${a.human}, automated: ${a.automated}, unknown: ${a.unknown})`
         );
         if (a.belowThreshold) {
           logger.warn(

--- a/packages/cli/src/commands/collect.ts
+++ b/packages/cli/src/commands/collect.ts
@@ -87,10 +87,10 @@ export function createCollectCommand(): Command {
         await writeJSON(outputPath, commitStream);
 
         logger.info(`Collected ${commitStream.commits.length} commits`);
-        const counts = { ai: 0, human: 0, unknown: 0 };
+        const counts = { ai: 0, human: 0, automated: 0, unknown: 0 };
         for (const c of commitStream.commits) counts[c.tags.attribution]++;
         logger.info(
-          `Attribution: ai ${counts.ai} · human ${counts.human} · unknown ${counts.unknown}`
+          `Attribution: ai ${counts.ai} · human ${counts.human} · automated ${counts.automated} · unknown ${counts.unknown}`
         );
         logger.info(`Output written to: ${outputPath}`);
       } catch (error) {

--- a/packages/cli/src/commands/report.ts
+++ b/packages/cli/src/commands/report.ts
@@ -21,7 +21,7 @@ function generateMarkdownReport(metrics: Metrics): string {
     : '';
 
   const priorNote =
-    a.defaultAttribution !== 'unknown'
+    a.defaultAttribution !== 'unknown' && a.unknown > 0
       ? `\nUnattributed commits are **assumed \`${a.defaultAttribution}\`** via \`defaultAttribution\` — this is a prior, not observed data.\n`
       : '';
 
@@ -85,7 +85,7 @@ ${categories.map((cat) => `| Files: ${cat} | ${mixCell(aiCtx.taskMix, cat)} | ${
 
 ## Attribution Coverage
 
-**${coveragePct}% of commits have known provenance** — ai: ${a.ai} · human: ${a.human} · unknown: ${a.unknown} (${unknownPct}%)
+**${coveragePct}% of commits have known provenance** — ai: ${a.ai} · human: ${a.human} · automated: ${a.automated} · unknown: ${a.unknown} (${unknownPct}%)
 
 **Autonomy:** agent ${a.modes.agent} · assisted ${a.modes.assisted} · autocomplete ${a.modes.autocomplete} · none ${a.modes.none} · unknown ${a.modes.unknown} — evidence: declared ${a.modeEvidence.declared} / inferred ${a.modeEvidence.inferred} / none ${a.modeEvidence.none}
 ${coverageWarning}${priorNote}

--- a/packages/core/src/git/collect.test.ts
+++ b/packages/core/src/git/collect.test.ts
@@ -146,13 +146,57 @@ describe('collectCommits with attribution manifest', () => {
     expect(byHash[humanCommit].attribution).toBe('human');
     expect(byHash[humanCommit].sources).toContain('manifest');
 
-    // The bot trailer would tag this explicit ai; excluded forces unknown
-    expect(byHash[releaseCommit].attribution).toBe('unknown');
+    // The bot trailer would tag this explicit ai; excluded declares automation
+    expect(byHash[releaseCommit].attribution).toBe('automated');
     expect(byHash[releaseCommit].ai).toBe(false);
     expect(byHash[releaseCommit].sources).toContain('manifest:excluded');
 
     expect(byHash[plainCommit].attribution).toBe('unknown');
     expect(byHash[plainCommit].sources).not.toContain('manifest');
+  });
+
+  it('auto-detects bot-authored commits as automated, but AI trailers win', async () => {
+    const botHash = (() => {
+      execSync(
+        'git commit -q --allow-empty -m "chore: release packages"',
+        {
+          cwd: manifestRepoPath,
+          env: {
+            ...process.env,
+            GIT_AUTHOR_NAME: 'github-actions[bot]',
+            GIT_AUTHOR_EMAIL: 'github-actions[bot]@users.noreply.github.com',
+            GIT_COMMITTER_NAME: 'github-actions[bot]',
+            GIT_COMMITTER_EMAIL: 'github-actions[bot]@users.noreply.github.com',
+          },
+        }
+      );
+      return execSync('git rev-parse HEAD', { cwd: manifestRepoPath }).toString().trim();
+    })();
+    const aiByBotHash = (() => {
+      execSync(
+        'git commit -q --allow-empty -m "feat: agent PR\n\nCo-Authored-By: Claude <noreply@anthropic.com>"',
+        {
+          cwd: manifestRepoPath,
+          env: {
+            ...process.env,
+            GIT_AUTHOR_NAME: 'github-actions[bot]',
+            GIT_AUTHOR_EMAIL: 'github-actions[bot]@users.noreply.github.com',
+            GIT_COMMITTER_NAME: 'github-actions[bot]',
+            GIT_COMMITTER_EMAIL: 'github-actions[bot]@users.noreply.github.com',
+          },
+        }
+      );
+      return execSync('git rev-parse HEAD', { cwd: manifestRepoPath }).toString().trim();
+    })();
+
+    rmSync(join(manifestRepoPath, 'aida-attribution.json'), { force: true });
+    const stream = await collectCommits({ repoPath: manifestRepoPath });
+    const byHash = Object.fromEntries(stream.commits.map((c) => [c.hash, c.tags]));
+
+    expect(byHash[botHash].attribution).toBe('automated');
+    expect(byHash[botHash].sources).toContain('automated:bot');
+    // In-commit AI evidence beats the bot-identity heuristic
+    expect(byHash[aiByBotHash].attribution).toBe('ai');
   });
 
   it('does not fail collect when the manifest is invalid', async () => {

--- a/packages/core/src/git/collect.ts
+++ b/packages/core/src/git/collect.ts
@@ -1,6 +1,7 @@
 import { simpleGit, SimpleGit } from 'simple-git';
 import { Commit, CommitStream } from '../schema/commit.js';
 import { createAITagger } from '../tags/ai-tags.js';
+import { createAutomatedDetector } from '../tags/automated.js';
 import {
   applyManifest,
   indexManifest,
@@ -134,6 +135,9 @@ export async function collectCommits(options: CollectOptions): Promise<CommitStr
     botBlocklist: aiBotBlocklist,
   });
 
+  // Automated detection (#39): merge commits and bot authors
+  const detectAutomated = createAutomatedDetector(aiBotBlocklist);
+
   // Optional retroactive attribution manifest at the repo root (#10)
   const manifest = await loadAttributionManifest(repoPath, logger);
   const manifestIndex = manifest ? indexManifest(manifest) : null;
@@ -149,6 +153,22 @@ export async function collectCommits(options: CollectOptions): Promise<CommitStr
 
     // Tag AI on the full message (body included, for trailers like Co-Authored-By)
     let aiTag = aiTagger(rawCommit.message);
+    // Automated detection only when heuristics found no AI signal:
+    // in-commit evidence wins over structural heuristics
+    if (aiTag.attribution === 'unknown') {
+      const automatedSource = detectAutomated(rawCommit);
+      if (automatedSource) {
+        aiTag = {
+          ai: false,
+          attribution: 'automated',
+          mode: 'none',
+          modeEvidence: 'inferred',
+          level: 'none',
+          sources: [...aiTag.sources, automatedSource],
+        };
+      }
+    }
+    // Manifest declarations beat structural heuristics
     if (manifestIndex) {
       aiTag = applyManifest(aiTag, rawCommit.hash, manifestIndex, logger);
     }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,7 @@ export * from './git/diff.js';
 export * from './git/log.js';
 export * from './tags/ai-tags.js';
 export * from './tags/attribution-manifest.js';
+export * from './tags/automated.js';
 export * from './io/fs.js';
 export * from './utils/dates.js';
 export * from './utils/log.js';

--- a/packages/core/src/schema/commit.ts
+++ b/packages/core/src/schema/commit.ts
@@ -20,9 +20,10 @@ export const Commit = z.object({
   inDefaultBranchAncestry: z.boolean(), // set during collect
   tags: z.object({
     ai: z.boolean(),
-    // Three-state attribution (#34). Heuristics emit 'ai' or 'unknown';
-    // 'human' requires an explicit declaration (manifest, #10).
-    attribution: z.enum(['ai', 'human', 'unknown']),
+    // Four-state attribution (#34, #39). Heuristics emit 'ai' or 'unknown';
+    // 'human' requires an explicit declaration (manifest, #10); 'automated'
+    // is provenance-known automation (merge commits, bots, manifest-excluded).
+    attribution: z.enum(['ai', 'human', 'automated', 'unknown']),
     // Autonomy axis (#25): what level of AI participated, and how we know
     mode: z.enum(['none', 'autocomplete', 'assisted', 'agent', 'unknown']),
     modeEvidence: z.enum(['declared', 'inferred', 'none']),

--- a/packages/core/src/tags/ai-tags.ts
+++ b/packages/core/src/tags/ai-tags.ts
@@ -1,10 +1,12 @@
 export type AILevel = 'explicit' | 'implicit' | 'mention' | 'none';
 
-// Three-state attribution (#34). Message heuristics can only ever produce
-// 'ai' or 'unknown': the absence of an AI signal is not evidence of human
-// authorship. 'human' requires an explicit declaration (e.g. attribution
-// manifest, #10) or the defaultAttribution prior applied at analysis time.
-export type Attribution = 'ai' | 'human' | 'unknown';
+// Four-state attribution (#34, #39). Message heuristics can only ever
+// produce 'ai' or 'unknown': the absence of an AI signal is not evidence of
+// human authorship. 'human' requires an explicit declaration (manifest,
+// #10). 'automated' is provenance-known automation — merge commits, release
+// bots — detected at collect time or declared via the manifest; it counts
+// toward coverage but joins no cohort.
+export type Attribution = 'ai' | 'human' | 'automated' | 'unknown';
 
 // Autonomy axis (#25): what level of AI participated. The durable dimension
 // in an AI-first world, where "was AI involved" trends toward "yes".

--- a/packages/core/src/tags/attribution-manifest.test.ts
+++ b/packages/core/src/tags/attribution-manifest.test.ts
@@ -72,10 +72,12 @@ describe('applyManifest precedence', () => {
     expect(logger.warn).toHaveBeenCalledOnce();
   });
 
-  it('excluded overrides heuristics and forces unknown', () => {
+  it('excluded overrides heuristics and declares automation', () => {
     const result = applyManifest(aiTag, HASH_EXCLUDED, makeIndex());
-    expect(result.attribution).toBe('unknown');
+    expect(result.attribution).toBe('automated');
     expect(result.ai).toBe(false);
+    expect(result.mode).toBe('none');
+    expect(result.modeEvidence).toBe('declared');
     expect(result.sources).toContain('manifest:excluded');
   });
 

--- a/packages/core/src/tags/attribution-manifest.ts
+++ b/packages/core/src/tags/attribution-manifest.ts
@@ -100,9 +100,10 @@ export function applyManifest(
     index.matched.add(hash);
     return {
       ai: false,
-      attribution: 'unknown',
-      mode: 'unknown',
-      modeEvidence: 'none',
+      // Excluded = declared automation (#39): provenance known, no cohort
+      attribution: 'automated',
+      mode: 'none',
+      modeEvidence: 'declared',
       level: 'none',
       sources: [...heuristic.sources, 'manifest:excluded'],
     };

--- a/packages/core/src/tags/automated.test.ts
+++ b/packages/core/src/tags/automated.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { createAutomatedDetector } from './automated.js';
+
+const base = {
+  parents: ['p1'],
+  authorName: 'Alice',
+  authorEmail: 'alice@example.com',
+  committerName: 'Alice',
+  committerEmail: 'alice@example.com',
+};
+
+describe('createAutomatedDetector', () => {
+  const detect = createAutomatedDetector();
+
+  it('flags merge commits via parent count', () => {
+    expect(detect({ ...base, parents: ['p1', 'p2'] })).toBe('automated:merge-commit');
+  });
+
+  it('flags known bots by author or committer identity', () => {
+    expect(detect({ ...base, authorName: 'github-actions[bot]' })).toBe('automated:bot');
+    expect(detect({ ...base, authorEmail: 'dependabot@github.com' })).toBe('automated:bot');
+    expect(detect({ ...base, committerName: 'renovate[bot]' })).toBe('automated:bot');
+  });
+
+  it('supports custom blocklist entries', () => {
+    const custom = createAutomatedDetector(['acme-release-bot']);
+    expect(custom({ ...base, authorName: 'acme-release-bot' })).toBe('automated:bot');
+  });
+
+  it('returns null for regular single-parent human-identity commits', () => {
+    expect(detect(base)).toBeNull();
+  });
+});

--- a/packages/core/src/tags/automated.ts
+++ b/packages/core/src/tags/automated.ts
@@ -1,0 +1,40 @@
+import { DEFAULT_BOT_BLOCKLIST } from './ai-tags.js';
+
+// Automated detection (#39): merge commits and bot-authored commits are
+// automation, not authored code. Their provenance is KNOWN — counting them
+// as 'unknown' misreads a bookkeeping artifact as a data-quality gap, and
+// letting a defaultAttribution prior pull them into a cohort pollutes it.
+// Applied only when message heuristics found no AI signal: in-commit
+// evidence always wins.
+
+export interface AutomatedCheckInput {
+  parents: string[];
+  authorName: string;
+  authorEmail: string;
+  committerName: string;
+  committerEmail: string;
+}
+
+export function createAutomatedDetector(
+  botBlocklist: string[] = []
+): (commit: AutomatedCheckInput) => string | null {
+  const allBots = [...DEFAULT_BOT_BLOCKLIST, ...botBlocklist];
+  const botRegex = allBots.length ? new RegExp(`\\b(${allBots.join('|')})\\b`, 'i') : null;
+
+  // Returns the matched source label, or null when not automated
+  return (commit: AutomatedCheckInput): string | null => {
+    if (commit.parents.length > 1) {
+      return 'automated:merge-commit';
+    }
+    if (
+      botRegex &&
+      (botRegex.test(commit.authorName) ||
+        botRegex.test(commit.authorEmail) ||
+        botRegex.test(commit.committerName) ||
+        botRegex.test(commit.committerEmail))
+    ) {
+      return 'automated:bot';
+    }
+    return null;
+  };
+}

--- a/packages/metrics/src/index.test.ts
+++ b/packages/metrics/src/index.test.ts
@@ -52,6 +52,30 @@ describe('calculateMetrics attribution coverage', () => {
     expect(metrics.attribution.belowThreshold).toBe(true); // default threshold 0.7
   });
 
+  it('counts automated commits toward coverage — their provenance is known', () => {
+    const automatedTags = {
+      ai: false,
+      attribution: 'automated',
+      mode: 'none',
+      modeEvidence: 'inferred',
+      level: 'none',
+      sources: ['automated:bot'],
+    } as const;
+    const metrics = calculateMetrics(
+      makeStream([
+        makeCommit({ hash: 'a1', tags: aiTags }),
+        makeCommit({ hash: 'b1', tags: automatedTags }),
+        makeCommit({ hash: 'b2', tags: automatedTags }),
+        makeCommit({ hash: 'u1', tags: unknownTags }),
+      ])
+    );
+
+    expect(metrics.attribution.automated).toBe(2);
+    expect(metrics.attribution.coverage).toBe(0.75); // (1 ai + 0 human + 2 automated) / 4
+    // automated joins no cohort
+    expect(metrics.mergeRatio.aiCommitsTotal).toBe(1);
+  });
+
   it('flags belowThreshold using a custom coverageThreshold', () => {
     const metrics = calculateMetrics(
       makeStream([
@@ -123,12 +147,12 @@ describe('calculateMetrics baseline cohort', () => {
     expect(metrics.caveats.some((c) => c.includes('assumed human'))).toBe(true);
   });
 
-  it('never assigns manifest-excluded commits to a cohort, even with a prior', () => {
+  it('never assigns automated commits to a cohort, even with a prior', () => {
     const excludedTags = {
       ai: false,
-      attribution: 'unknown',
-      mode: 'unknown',
-      modeEvidence: 'none',
+      attribution: 'automated',
+      mode: 'none',
+      modeEvidence: 'declared',
       level: 'none',
       sources: ['manifest:excluded'],
     } as const;

--- a/packages/metrics/src/index.ts
+++ b/packages/metrics/src/index.ts
@@ -26,7 +26,7 @@ export function calculateMetrics(
 ): Metrics {
   const { defaultAttribution = 'unknown', coverageThreshold = 0.7 } = options;
 
-  const counts = { ai: 0, human: 0, unknown: 0 };
+  const counts = { ai: 0, human: 0, automated: 0, unknown: 0 };
   const modes = { none: 0, autocomplete: 0, assisted: 0, agent: 0, unknown: 0 };
   const modeEvidence = { declared: 0, inferred: 0, none: 0 };
   for (const commit of commitStream.commits) {
@@ -35,12 +35,14 @@ export function calculateMetrics(
     modeEvidence[commit.tags.modeEvidence]++;
   }
   const total = commitStream.commits.length;
-  const coverage = total > 0 ? (counts.ai + counts.human) / total : 0;
+  // Automated commits have known provenance (#39): they count as covered
+  const coverage = total > 0 ? (counts.ai + counts.human + counts.automated) / total : 0;
 
   const attribution: Attribution = {
     commitsTotal: total,
     ai: counts.ai,
     human: counts.human,
+    automated: counts.automated,
     unknown: counts.unknown,
     coverage: round(coverage, 4),
     defaultAttribution,
@@ -51,17 +53,14 @@ export function calculateMetrics(
   };
 
   // Cohort membership: unknown commits join a cohort only via the prior.
-  // Manifest-excluded commits (release bots, merges) never do — they were
-  // excluded precisely to stay out of both cohorts.
-  const isExcluded = (commit: Commit) => commit.tags.sources.includes('manifest:excluded');
+  // 'automated' is its own state (#39): it joins no cohort and priors never
+  // touch it — automation is not authored code.
   const isAI = (commit: Commit) =>
     commit.tags.attribution === 'ai' ||
-    (defaultAttribution === 'ai' && commit.tags.attribution === 'unknown' && !isExcluded(commit));
+    (defaultAttribution === 'ai' && commit.tags.attribution === 'unknown');
   const isBaseline = (commit: Commit) =>
     commit.tags.attribution === 'human' ||
-    (defaultAttribution === 'human' &&
-      commit.tags.attribution === 'unknown' &&
-      !isExcluded(commit));
+    (defaultAttribution === 'human' && commit.tags.attribution === 'unknown');
 
   const mergeRatio = calculateMergeRatio(commitStream, isAI);
   const persistence = calculatePersistence(commitStream, isAI);

--- a/packages/metrics/src/schema/metrics.ts
+++ b/packages/metrics/src/schema/metrics.ts
@@ -6,8 +6,11 @@ export const Attribution = z.object({
   commitsTotal: z.number().int().nonnegative(),
   ai: z.number().int().nonnegative(),
   human: z.number().int().nonnegative(),
+  // Provenance-known automation (#39): merge commits, bots, manifest-excluded.
+  // Counts toward coverage, joins no cohort, untouched by priors.
+  automated: z.number().int().nonnegative(),
   unknown: z.number().int().nonnegative(),
-  coverage: z.number().min(0).max(1), // (ai + human) / total
+  coverage: z.number().min(0).max(1), // (ai + human + automated) / total
   defaultAttribution: z.enum(['ai', 'human', 'unknown']), // prior applied to unknown commits
   coverageThreshold: z.number().min(0).max(1),
   belowThreshold: z.boolean(),


### PR DESCRIPTION
Closes #39.

## Why now

Dogfooding caught a silent drift: **every changesets release added an unknown commit** (the manifest is static), so coverage decayed from 68.7% → 70.3% → 70.2% release after release, permanently hovering at the warning threshold. The gap wasn't a data-quality problem — it was automation with perfectly known provenance that the three-state model had no bucket for.

## What

- **New attribution state `automated`**, from two sources:
  - **Auto-detection at collect time**: merge commits (parent count > 1) and bot identities (the #21 blocklist — dependabot, renovate, github-actions, … plus custom entries — matched against author/committer name and email). This is what stops the drift: future releases classify themselves.
  - **Manifest `excluded_commits`**: now *declare* automation instead of forcing `unknown` — for what auto-detection can't see (templates, bots not in the blocklist).
- **Coverage counts automated as known provenance**: `(ai + human + automated) / total`.
- **Cohort hygiene**: automated joins no cohort and `defaultAttribution` priors never touch it (replaces the `manifest:excluded` source-check workaround with a real state). Mode is `none` — no AI authored anything.
- **Precedence unchanged in spirit**: in-commit AI evidence beats structural heuristics (a bot-authored commit with a Claude trailer stays `ai` — that's an agent PR); manifest ai/human declarations beat auto-detection.

## Dogfood (this repo, 94 commits)

| | before | after |
|---|---:|---:|
| Coverage | 70.2% | **100.0%** |
| unknown | 28 | **0** |
| automated | — | 28 (13 merges, 14 bot releases, 1 template) |

The attribution line now reads: *ai: 66 · human: 0 · automated: 28 · unknown: 0* — and it stays there without manifest maintenance.

## Testing

95 tests pass (6 new: detector unit tests, bot-author auto-detection end-to-end, AI-trailer-beats-bot-identity, automated-counts-toward-coverage, automated-never-in-cohort). Lint clean. Dogfooded.

Breaking (0.x minor): attribution enum gains `automated`; `metrics.json` attribution block gains a required `automated` count.

Co-Authored-By: Claude <noreply@anthropic.com>