### PR TITLE
feat: per-mode cohort metrics — merge ratio and persistence per autonomy level (#25 step 2)

### DIFF
--- a/.changeset/per-mode-metrics.md
+++ b/.changeset/per-mode-metrics.md
@@ -1,0 +1,10 @@
+---
+'@aida-dev/metrics': minor
+'@aida-dev/cli': patch
+---
+
+Per-mode cohort metrics (#25, step 2)
+
+`metrics.json` gains a `byMode` block: merge ratio and persistence computed per autonomy level (`agent` / `assisted` / `autocomplete` / `none` / `unknown`), `null` for modes with no commits. Automated commits are excluded — automation is not authored code. The report renders a "By Autonomy Level" table.
+
+This is the comparison that stays meaningful in an AI-first world: agent vs assisted vs autocomplete, instead of AI vs human.

--- a/README.md
+++ b/README.md
@@ -305,6 +305,10 @@ The headline metric ([#34](https://github.com/ceccode/AIDA-Metrics/issues/34)). 
 
 `defaultAttribution` lets a team consciously assign unattributed commits to a cohort (`human` for traditional repos, `ai` for AI-first ones). The prior affects cohort metrics but never coverage: unknown stays unknown in the attribution block, and an assumed baseline is labeled as such.
 
+### By Autonomy Level
+
+Merge ratio and persistence computed per autonomy mode (`agent` / `assisted` / `autocomplete` / `none`) — the comparison that stays meaningful when everything is AI-assisted ([#25](https://github.com/ceccode/AIDA-Metrics/issues/25)). Automated commits are excluded; modes with no commits are `null`.
+
 ### Merge Ratio
 
 Percentage of AI-tagged commits that were merged into the default branch.
@@ -427,7 +431,8 @@ aida_analysis:
 - **v0.10** ✅ Cohort fairness context — age stats ([#29](https://github.com/ceccode/AIDA-Metrics/issues/29), step 1) and task mix by file category ([#36](https://github.com/ceccode/AIDA-Metrics/issues/36), step 1) per cohort.  
 - **v0.11** ✅ Autonomy mode collection — `mode` × `evidence` per commit, manifest declarations, tool inference ([#25](https://github.com/ceccode/AIDA-Metrics/issues/25), step 1).  
 - **v0.12** ✅ `automated` attribution state — merge commits and bots auto-detected, coverage counts known automation ([#39](https://github.com/ceccode/AIDA-Metrics/issues/39)).  
-- **Next** → Per-mode cohort metrics ([#25](https://github.com/ceccode/AIDA-Metrics/issues/25), step 2), synthetic PR merge commit fix ([#40](https://github.com/ceccode/AIDA-Metrics/issues/40)).  
+- **v0.13** ✅ Per-mode cohort metrics — merge ratio and persistence per autonomy level ([#25](https://github.com/ceccode/AIDA-Metrics/issues/25), step 2).  
+- **Next** → Fix squash-merge merge ratio ([#20](https://github.com/ceccode/AIDA-Metrics/issues/20)), synthetic PR merge commit fix ([#40](https://github.com/ceccode/AIDA-Metrics/issues/40)).  
 - **Next** → Fix squash-merge merge ratio ([#20](https://github.com/ceccode/AIDA-Metrics/issues/20)), anti-leaderboard hardening: author redaction in outputs ([#35](https://github.com/ceccode/AIDA-Metrics/issues/35)).  
 - **Next** → Rework rate ([#22](https://github.com/ceccode/AIDA-Metrics/issues/22)), line-level persistence via blame ([#23](https://github.com/ceccode/AIDA-Metrics/issues/23)).  
 - **Next** → Autonomy levels — autocomplete vs assisted vs agent ([#25](https://github.com/ceccode/AIDA-Metrics/issues/25)), outcome correlation ([#26](https://github.com/ceccode/AIDA-Metrics/issues/26)), cost metrics ([#27](https://github.com/ceccode/AIDA-Metrics/issues/27)).  

--- a/packages/cli/src/commands/report.ts
+++ b/packages/cli/src/commands/report.ts
@@ -66,6 +66,27 @@ Persistence comparisons are only meaningful between cohorts of similar **age** a
 ${categories.map((cat) => `| Files: ${cat} | ${mixCell(aiCtx.taskMix, cat)} | ${mixCell(baseCtx.taskMix, cat)} |`).join('\n')}
 `;
 
+  const modeOrder = ['agent', 'assisted', 'autocomplete', 'none', 'unknown'] as const;
+  const modeRows = modeOrder
+    .map((mode) => ({ mode, stats: metrics.byMode[mode] }))
+    .filter((row) => row.stats !== null)
+    .map(
+      ({ mode, stats }) =>
+        `| ${mode} | ${stats!.commits} | ${(stats!.mergeRatio.mergeRatio * 100).toFixed(1)}% | ${stats!.persistence.avgDays} | ${stats!.persistence.medianDays} |`
+    );
+  const byModeSection =
+    modeRows.length > 0
+      ? `## By Autonomy Level
+
+The comparison that stays meaningful when everything is AI-assisted: how code holds up per autonomy level (automated commits excluded).
+
+| Mode | Commits | Merge ratio | Avg persistence (d) | Median (d) |
+|---|---:|---:|---:|---:|
+${modeRows.join('\n')}
+
+`
+      : '';
+
   const baselineDetail = metrics.baseline
     ? `## ${baselineLabel}
 - Commits (total): ${metrics.baseline.mergeRatio.commitsTotal}
@@ -90,7 +111,7 @@ ${categories.map((cat) => `| Files: ${cat} | ${mixCell(aiCtx.taskMix, cat)} | ${
 **Autonomy:** agent ${a.modes.agent} · assisted ${a.modes.assisted} · autocomplete ${a.modes.autocomplete} · none ${a.modes.none} · unknown ${a.modes.unknown} — evidence: declared ${a.modeEvidence.declared} / inferred ${a.modeEvidence.inferred} / none ${a.modeEvidence.none}
 ${coverageWarning}${priorNote}
 ${comparisonSection}
-${fairnessSection}
+${byModeSection}${fairnessSection}
 ## Merge Ratio
 - AI-tagged commits (total): ${metrics.mergeRatio.aiCommitsTotal}
 - AI-tagged commits merged: ${metrics.mergeRatio.aiCommitsMerged}

--- a/packages/metrics/src/index.test.ts
+++ b/packages/metrics/src/index.test.ts
@@ -195,6 +195,39 @@ describe('calculateMetrics baseline cohort', () => {
     expect(metrics.cohorts.baseline.taskMix).toBeNull();
   });
 
+  it('computes per-mode stats, excluding automated commits, null for empty modes', () => {
+    const assistedTags = {
+      ai: true,
+      attribution: 'ai',
+      mode: 'assisted',
+      modeEvidence: 'inferred',
+      level: 'implicit',
+      sources: ['implicit:x'],
+    } as const;
+    const automatedTags = {
+      ai: false,
+      attribution: 'automated',
+      mode: 'none',
+      modeEvidence: 'inferred',
+      level: 'none',
+      sources: ['automated:bot'],
+    } as const;
+    const metrics = calculateMetrics(
+      makeStream([
+        makeCommit({ hash: 'a1', tags: aiTags }), // agent
+        makeCommit({ hash: 'a2', tags: aiTags, inDefaultBranchAncestry: false }), // agent, unmerged
+        makeCommit({ hash: 's1', tags: assistedTags }),
+        makeCommit({ hash: 'b1', tags: automatedTags }), // mode none, but automated → excluded
+      ])
+    );
+
+    expect(metrics.byMode.agent?.commits).toBe(2);
+    expect(metrics.byMode.agent?.mergeRatio.mergeRatio).toBe(0.5);
+    expect(metrics.byMode.assisted?.commits).toBe(1);
+    expect(metrics.byMode.none).toBeNull(); // the automated commit doesn't count
+    expect(metrics.byMode.autocomplete).toBeNull();
+  });
+
   it('assigns unknown commits to the AI cohort with defaultAttribution: ai', () => {
     const metrics = calculateMetrics(
       makeStream([

--- a/packages/metrics/src/index.ts
+++ b/packages/metrics/src/index.ts
@@ -2,7 +2,7 @@ import { Commit, CommitStream, formatISODate } from '@aida-dev/core';
 import { calculateAgeStats, calculateCategoryCounts } from './cohort.js';
 import { calculateBaselineMergeRatio, calculateMergeRatio } from './merge-ratio.js';
 import { calculateBaselinePersistence, calculatePersistence } from './persistence.js';
-import { Attribution, Metrics } from './schema/metrics.js';
+import { Attribution, ByMode, Metrics, ModeStats } from './schema/metrics.js';
 
 export * from './schema/metrics.js';
 export * from './cohort.js';
@@ -80,6 +80,26 @@ export function calculateMetrics(
     },
   };
 
+  // Per-autonomy-level metrics (#25, step 2). Automated commits are
+  // excluded: automation is not authored code, whatever its mode field says.
+  const MODES = ['agent', 'assisted', 'autocomplete', 'none', 'unknown'] as const;
+  const byMode = Object.fromEntries(
+    MODES.map((mode) => {
+      const isMode = (commit: Commit) =>
+        commit.tags.mode === mode && commit.tags.attribution !== 'automated';
+      const modeCommits = commitStream.commits.filter(isMode);
+      if (modeCommits.length === 0) {
+        return [mode, null];
+      }
+      const stats: ModeStats = {
+        commits: modeCommits.length,
+        mergeRatio: calculateBaselineMergeRatio(commitStream, isMode),
+        persistence: calculatePersistence(commitStream, isMode),
+      };
+      return [mode, stats];
+    })
+  ) as ByMode;
+
   // No baseline cohort → no baseline, no delta. AIDA does not invent a
   // comparison out of unattributed commits.
   const baselineSize = baselineCommits.length;
@@ -137,6 +157,7 @@ export function calculateMetrics(
     mergeRatio,
     persistence,
     cohorts,
+    byMode,
     baseline,
     delta,
     caveats,

--- a/packages/metrics/src/schema/metrics.ts
+++ b/packages/metrics/src/schema/metrics.ts
@@ -109,6 +109,24 @@ export const Delta = z.object({
   medianPersistenceDays: z.number(),
 });
 
+// Per-autonomy-level metrics (#25, step 2): the durable comparison in an
+// AI-first world is between autonomy levels, not AI vs human. Automated
+// commits are excluded — automation is not authored code. Null when the
+// mode has no commits.
+export const ModeStats = z.object({
+  commits: z.number().int().nonnegative(),
+  mergeRatio: CohortMergeRatio,
+  persistence: Persistence,
+});
+
+export const ByMode = z.object({
+  agent: ModeStats.nullable(),
+  assisted: ModeStats.nullable(),
+  autocomplete: ModeStats.nullable(),
+  none: ModeStats.nullable(),
+  unknown: ModeStats.nullable(),
+});
+
 export const Metrics = z.object({
   generatedAt: z.string().datetime(),
   window: z.object({
@@ -126,6 +144,7 @@ export const Metrics = z.object({
     ai: CohortContext,
     baseline: CohortContext,
   }),
+  byMode: ByMode,
   // Null when no commit is attributed 'human' and no defaultAttribution prior
   // assigns the unknowns: AIDA does not invent a comparison cohort.
   baseline: Baseline.nullable(),
@@ -138,6 +157,8 @@ export type AgeStats = z.infer<typeof AgeStats>;
 export type FileCategory = z.infer<typeof FileCategory>;
 export type CategoryCounts = z.infer<typeof CategoryCounts>;
 export type CohortContext = z.infer<typeof CohortContext>;
+export type ModeStats = z.infer<typeof ModeStats>;
+export type ByMode = z.infer<typeof ByMode>;
 export type MergeRatio = z.infer<typeof MergeRatio>;
 export type Persistence = z.infer<typeof Persistence>;
 export type CohortMergeRatio = z.infer<typeof CohortMergeRatio>;


### PR DESCRIPTION
Step 2 of #25. **Stacked on #46** — merge that first; this retargets to `main` automatically.

## What

`metrics.json` gains `byMode`: merge ratio + persistence per autonomy level (`agent` / `assisted` / `autocomplete` / `none` / `unknown`), `null` for empty modes. Automated commits are excluded from every mode cohort — automation is not authored code (which is why this stacks on #39).

The report renders a **By Autonomy Level** table. This is the comparison that stays meaningful when everything is AI-assisted: for AI-first repos (like this one, human baseline empty by design) it's the only within-repo comparison that will ever say anything.

## Dogfood (this repo)

| Mode | Commits | Merge ratio | Avg persistence (d) | Median (d) |
|---|---:|---:|---:|---:|
| agent | 67 | 82.1% | 76.39 | 64 |

One row, because this repo is agent-written throughout — the table becomes interesting on mixed-mode repos (Copilot + Claude Code teams). Note the merge ratio at 82.1% vs the old ~96%: with #39 the denominator no longer hides behind automation.

## Testing

96 tests pass (1 new: per-mode stats with automated exclusion and null empty modes). Lint clean. Dogfooded.

Co-Authored-By: Claude <noreply@anthropic.com>