### PR TITLE
feat: author redaction (#35) and synthetic PR merge commit fix (#40)

### DIFF
--- a/.changeset/redaction-and-pr-merge.md
+++ b/.changeset/redaction-and-pr-merge.md
@@ -1,0 +1,10 @@
+---
+'@aida-dev/core': minor
+'@aida-dev/cli': minor
+---
+
+Author redaction (#35) and synthetic PR merge commit fix (#40)
+
+**Author redaction** — `aida collect --redact-authors` (or `redactAuthors: true` in `.aida.json`) replaces author/committer names and emails in `commit-stream.json` with a per-run salted hash: stable within one output file so identities can still be grouped, but not reversible to a person and not correlatable across runs. Redaction runs after identity-based detection (bots, #39), so it costs no accuracy. Recommended in CI, where the stream is uploaded as an artifact.
+
+**Synthetic PR merge commit** — in PR-scoped mode (`--pr` / `--diff-base`), the merge head that `actions/checkout` creates for `pull_request` events (`Merge <sha> into <sha>`, authored by nobody) is skipped. It was inflating commit counts and coverage percentages on every PR comment — a 1-commit PR read as 2 commits. Standard time-windowed collection is unchanged: real merge commits are still collected and classified `automated`.

--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ aida report --out-dir ./aida-output
 - `--ai-trailer-domain <domain>` - Additional Co-authored-by domain (repeatable)
 - `--ai-bot-blocklist <name>` - Non-AI bot to exclude from trailer matching (repeatable)
 - `--default-branch <name>` - Default branch name (auto-detect if omitted)
+- `--redact-authors` - Replace author/committer identities with a per-run salted hash (recommended in CI)
 - `--out-dir <path>` - Output directory (default: ./aida-output)
 - `--verbose` - Verbose logging
 
@@ -258,6 +259,16 @@ Heuristics only see what commit messages admit to. The manifest lets you declare
 
 Precedence: in-commit evidence beats retroactive declarations. A commit with an explicit AI trailer stays `ai` even if the manifest declares it human (with a warning); `excluded_commits` always wins, since it exists to correct heuristic false positives. Full hashes are matched exactly (`message` is documentation only); an invalid manifest logs a warning and is ignored — it never fails `collect`.
 
+### Privacy: no leaderboards
+
+AIDA compares **cohorts of commits, never people**. This is a design constraint, not a default:
+
+- No per-author metric will ever ship. Requests for per-developer breakdowns are out of scope by policy, not by omission.
+- `commit-stream.json` carries author identities so identity-based detection (bots, #39) can work — but that file travels: committed to CI, uploaded as an artifact. Pass `--redact-authors` (or set `redactAuthors` in `.aida.json`) to replace names and emails with a **per-run salted hash**: stable within one output file, so grouping still works, but not reversible to a person and not correlatable across runs.
+- Redaction runs *after* detection, so enabling it costs no accuracy.
+
+Git history itself is not anonymous, so nobody can stop a determined manager from writing their own script. What AIDA can do is refuse to make it convenient ([#35](https://github.com/ceccode/AIDA-Metrics/issues/35)).
+
 ### Configuration File (`.aida.json`)
 
 Place a `.aida.json` file in your project root to add custom tools, trailer domains, and patterns:
@@ -281,6 +292,7 @@ Place a `.aida.json` file in your project root to add custom tools, trailer doma
 | `patterns` | Raw regex patterns (treated as explicit) |
 | `defaultAttribution` | Prior applied to unattributed commits at analysis time: `ai`, `human`, or `unknown` (default). With `unknown`, unattributed commits join no cohort — AIDA does not invent a comparison. This repo sets `ai`: it is AI-written with human review. |
 | `coverageThreshold` | Attribution coverage below this fraction (default `0.7`) flags all metrics as low-confidence |
+| `redactAuthors` | Replace author/committer identities in `commit-stream.json` with a per-run salted hash (default `false`; recommended in CI) |
 
 ### CLI Flags
 
@@ -435,12 +447,12 @@ aida_analysis:
 - **v0.10** ✅ Cohort fairness context — age stats ([#29](https://github.com/ceccode/AIDA-Metrics/issues/29), step 1) and task mix by file category ([#36](https://github.com/ceccode/AIDA-Metrics/issues/36), step 1) per cohort.  
 - **v0.11** ✅ Autonomy mode collection — `mode` × `evidence` per commit, manifest declarations, tool inference ([#25](https://github.com/ceccode/AIDA-Metrics/issues/25), step 1).  
 - **v0.12** ✅ `automated` attribution state — merge commits and bots auto-detected, coverage counts known automation ([#39](https://github.com/ceccode/AIDA-Metrics/issues/39)).  
-- **v0.13** ✅ Per-mode cohort metrics — merge ratio and persistence per autonomy level ([#25](https://github.com/ceccode/AIDA-Metrics/issues/25), step 2).  
+- **v0.13** ✅ Per-mode cohort metrics — persistence per autonomy level ([#25](https://github.com/ceccode/AIDA-Metrics/issues/25), step 2).  
 - **v0.14** ✅ Merge ratio removed — git cannot measure it honestly; PR acceptance rate via forge APIs is the successor ([#20](https://github.com/ceccode/AIDA-Metrics/issues/20)).  
-- **Next** → Synthetic PR merge commit fix ([#40](https://github.com/ceccode/AIDA-Metrics/issues/40)), anti-leaderboard hardening ([#35](https://github.com/ceccode/AIDA-Metrics/issues/35)).  
-- **Next** → Fix squash-merge merge ratio ([#20](https://github.com/ceccode/AIDA-Metrics/issues/20)), anti-leaderboard hardening: author redaction in outputs ([#35](https://github.com/ceccode/AIDA-Metrics/issues/35)).  
+- **v0.15** ✅ Author redaction ([#35](https://github.com/ceccode/AIDA-Metrics/issues/35)) and synthetic PR merge commit fix ([#40](https://github.com/ceccode/AIDA-Metrics/issues/40)).  
+- **Next** → PR acceptance rate via forge APIs ([#51](https://github.com/ceccode/AIDA-Metrics/issues/51)), autonomy as primary axis ([#25](https://github.com/ceccode/AIDA-Metrics/issues/25) step 3), windowed coverage ([#52](https://github.com/ceccode/AIDA-Metrics/issues/52)), schema versioning ([#53](https://github.com/ceccode/AIDA-Metrics/issues/53)).  
 - **Next** → Rework rate ([#22](https://github.com/ceccode/AIDA-Metrics/issues/22)), line-level persistence via blame ([#23](https://github.com/ceccode/AIDA-Metrics/issues/23)).  
-- **Next** → Autonomy levels — autocomplete vs assisted vs agent ([#25](https://github.com/ceccode/AIDA-Metrics/issues/25)), outcome correlation ([#26](https://github.com/ceccode/AIDA-Metrics/issues/26)), cost metrics ([#27](https://github.com/ceccode/AIDA-Metrics/issues/27)).  
+- **Next** → Outcome correlation ([#26](https://github.com/ceccode/AIDA-Metrics/issues/26)), cost metrics ([#27](https://github.com/ceccode/AIDA-Metrics/issues/27)).  
 - **Next** → GitLab ([#16](https://github.com/ceccode/AIDA-Metrics/issues/16)) and Bitbucket ([#17](https://github.com/ceccode/AIDA-Metrics/issues/17)) PR comment providers.  
 - **v1.0** → Dashboard / GitHub Action for continuous tracking.  
 
@@ -452,7 +464,7 @@ In an AI-first world, "was this commit written by AI?" is becoming the wrong que
 - **Quality over adoption** — the durable question is not "how much code is AI?" but "does AI code hold up?": rework rate ([#22](https://github.com/ceccode/AIDA-Metrics/issues/22)), line-level survival ([#23](https://github.com/ceccode/AIDA-Metrics/issues/23)), outcome correlation ([#26](https://github.com/ceccode/AIDA-Metrics/issues/26)).
 - **Autonomy over the binary** — autocomplete vs assisted vs agent ([#25](https://github.com/ceccode/AIDA-Metrics/issues/25)) is the axis that will replace AI/non-AI.
 - **Shrink the unknown at the source** — the attribution manifest ([#10](https://github.com/ceccode/AIDA-Metrics/issues/10), shipped) makes attribution declarative; commit-time stamping via git hooks will make it automatic.
-- **Cohorts, not people** — AIDA compares groups of commits, never developers. No per-author aggregation will ever ship, and author identity can be redacted from output artifacts ([#35](https://github.com/ceccode/AIDA-Metrics/issues/35)) so the data model doesn't hand anyone a leaderboard for free.
+- **Cohorts, not people** — AIDA compares groups of commits, never developers. No per-author aggregation will ever ship, and author identity can be redacted from output artifacts ([#35](https://github.com/ceccode/AIDA-Metrics/issues/35), shipped) so the data model doesn't hand anyone a leaderboard for free.
 
 ## Contributing
 

--- a/packages/cli/src/commands/collect.ts
+++ b/packages/cli/src/commands/collect.ts
@@ -31,6 +31,10 @@ export function createCollectCommand(): Command {
     .option('--ai-trailer-domain <domain>', 'Additional Co-authored-by domain (repeatable)', collectRepeatable, [])
     .option('--ai-bot-blocklist <name>', 'Non-AI bot to exclude from trailer matching (repeatable)', collectRepeatable, [])
     .option('--default-branch <name>', 'Default branch name')
+    .option(
+      '--redact-authors',
+      'Replace author/committer identities with a per-run salted hash (recommended in CI)'
+    )
     .option('--out-dir <path>', 'Output directory', './aida-output')
     .option('--verbose', 'Verbose logging', false)
     .action(async (options) => {
@@ -80,6 +84,8 @@ export function createCollectCommand(): Command {
           aiTrailerDomains,
           aiBotBlocklist,
           defaultBranch: config.defaultBranch,
+          // CLI flag wins over .aida.json
+          redactAuthors: config.redactAuthors ?? fileConfig.redactAuthors ?? false,
           logger,
         });
 

--- a/packages/cli/src/schema/config.ts
+++ b/packages/cli/src/schema/config.ts
@@ -9,6 +9,7 @@ export const CLIConfig = z.object({
   aiTrailerDomains: z.array(z.string()).default([]),
   aiBotBlocklist: z.array(z.string()).default([]),
   defaultBranch: z.string().optional(),
+  redactAuthors: z.boolean().optional(),
   outDir: z.string().default('./aida-output'),
   verbose: z.boolean().default(false),
 });

--- a/packages/core/src/git/collect.test.ts
+++ b/packages/core/src/git/collect.test.ts
@@ -206,3 +206,77 @@ describe('collectCommits with attribution manifest', () => {
     expect(stream.commits.every((c) => !c.tags.sources.includes('manifest'))).toBe(true);
   });
 });
+
+describe('collectCommits author redaction (#35)', () => {
+  it('redacts identities while keeping identity-based detection working', async () => {
+    const stream = await collectCommits({ repoPath, redactAuthors: true });
+
+    for (const commit of stream.commits) {
+      expect(commit.authorName).toMatch(/^redacted-[0-9a-f]{12}$/);
+      expect(commit.authorEmail).toMatch(/@redacted\.invalid$/);
+      expect(commit.committerName).toMatch(/^redacted-[0-9a-f]{12}$/);
+      expect(commit.authorName).not.toContain('Alice');
+      expect(commit.authorEmail).not.toContain('alice');
+    }
+
+    // The same identity hashes consistently within a run
+    const names = new Set(stream.commits.map((c) => c.authorName));
+    expect(names.size).toBe(1);
+
+    // Detection still worked: it runs before redaction
+    expect(stream.commits[0].tags.attribution).toBe('ai');
+  });
+
+  it('leaves identities untouched by default', async () => {
+    const stream = await collectCommits({ repoPath });
+    expect(stream.commits[0].authorName).toBe(AUTHOR.name);
+    expect(stream.commits[0].authorEmail).toBe(AUTHOR.email);
+  });
+});
+
+describe('collectCommits synthetic PR merge (#40)', () => {
+  let prRepoPath: string;
+  let realCommit: string;
+
+  beforeAll(() => {
+    prRepoPath = mkdtempSync(join(tmpdir(), 'aida-pr-merge-'));
+    const runHere = (cmd: string) => execSync(cmd, { cwd: prRepoPath });
+    runHere('git init -q -b main');
+    runHere('git config user.name test && git config user.email test@example.com');
+    runHere('git commit -q --allow-empty -m "chore: base"');
+
+    // PR branch with one real commit
+    runHere('git checkout -q -b feature');
+    runHere('git commit -q --allow-empty -m "feat: real work"');
+    realCommit = execSync('git rev-parse HEAD', { cwd: prRepoPath }).toString().trim();
+
+    // main moves on, so the branches actually diverge
+    runHere('git checkout -q main');
+    runHere('git commit -q --allow-empty -m "chore: main moves on"');
+    const mainTip = execSync('git rev-parse HEAD', { cwd: prRepoPath }).toString().trim();
+
+    // Emulate actions/checkout: a merge commit whose subject is the
+    // synthetic "Merge <sha> into <sha>" form
+    runHere('git checkout -q feature');
+    runHere(`git merge -q --no-ff main -m "Merge ${realCommit} into ${mainTip}"`);
+  });
+
+  afterAll(() => {
+    rmSync(prRepoPath, { recursive: true, force: true });
+  });
+
+  it('drops the synthetic merge head in PR-scoped mode', async () => {
+    const stream = await collectCommits({ repoPath: prRepoPath, diffBase: 'main' });
+    const subjects = stream.commits.map((c) => c.message);
+
+    expect(subjects).toContain('feat: real work');
+    expect(subjects.some((s) => /^Merge [0-9a-f]{7,40} into [0-9a-f]{7,40}$/.test(s))).toBe(false);
+  });
+
+  it('keeps merge commits in standard (non-PR) mode', async () => {
+    const stream = await collectCommits({ repoPath: prRepoPath });
+    expect(
+      stream.commits.some((c) => /^Merge [0-9a-f]{7,40} into [0-9a-f]{7,40}$/.test(c.message))
+    ).toBe(true);
+  });
+});

--- a/packages/core/src/git/collect.ts
+++ b/packages/core/src/git/collect.ts
@@ -8,6 +8,7 @@ import {
   loadAttributionManifest,
   unmatchedManifestHashes,
 } from '../tags/attribution-manifest.js';
+import { createRedactor } from '../tags/redact.js';
 import { logWithStats } from './log.js';
 import { parseRelativeDate, formatISODate } from '../utils/dates.js';
 import { Logger } from '../utils/log.js';
@@ -22,7 +23,17 @@ export interface CollectOptions {
   aiTrailerDomains?: string[];
   aiBotBlocklist?: string[];
   defaultBranch?: string;
+  redactAuthors?: boolean;
   logger?: Logger;
+}
+
+// The synthetic merge commit `actions/checkout` creates for `pull_request`
+// events (refs/pull/N/merge): it exists only in the CI checkout, is authored
+// by nobody, and would otherwise inflate every PR-scoped report (#40).
+const SYNTHETIC_MERGE_SUBJECT = /^Merge [0-9a-f]{7,40} into [0-9a-f]{7,40}$/;
+
+function isSyntheticPRMerge(commit: { parents: string[]; message: string }): boolean {
+  return commit.parents.length > 1 && SYNTHETIC_MERGE_SUBJECT.test(commit.message.split('\n')[0].trim());
 }
 
 export async function detectDefaultBranch(git: SimpleGit): Promise<string> {
@@ -62,6 +73,7 @@ export async function collectCommits(options: CollectOptions): Promise<CommitStr
     aiTrailerDomains = [],
     aiBotBlocklist = [],
     defaultBranch: providedDefaultBranch,
+    redactAuthors = false,
     logger,
   } = options;
 
@@ -142,12 +154,27 @@ export async function collectCommits(options: CollectOptions): Promise<CommitStr
   const manifest = await loadAttributionManifest(repoPath, logger);
   const manifestIndex = manifest ? indexManifest(manifest) : null;
 
+  // Author redaction (#35). Applied last: identity-based detection above
+  // must see the real values.
+  const redactor = redactAuthors ? createRedactor() : null;
+  if (redactor) {
+    logger?.info('Author identities redacted with a per-run salted hash');
+  }
+
   // Deduplicate commits (same hash can appear from multiple branches)
   const seen = new Set<string>();
   const commits: Commit[] = [];
+  let syntheticMergesDropped = 0;
   for (const rawCommit of rawCommits) {
     if (seen.has(rawCommit.hash)) continue;
     seen.add(rawCommit.hash);
+
+    // Drop the CI-generated PR merge head (#40): PR-scoped mode only, where
+    // `diffBase..HEAD` would otherwise include a commit authored by nobody.
+    if (diffBase && isSyntheticPRMerge(rawCommit)) {
+      syntheticMergesDropped++;
+      continue;
+    }
 
     logger?.debug(`Processing commit ${rawCommit.hash}`);
 
@@ -175,11 +202,11 @@ export async function collectCommits(options: CollectOptions): Promise<CommitStr
 
     const commit: Commit = {
       hash: rawCommit.hash,
-      authorName: rawCommit.authorName,
-      authorEmail: rawCommit.authorEmail,
+      authorName: redactor ? redactor.name(rawCommit.authorName) : rawCommit.authorName,
+      authorEmail: redactor ? redactor.email(rawCommit.authorEmail) : rawCommit.authorEmail,
       authorDate: new Date(rawCommit.authorDate).toISOString(),
-      committerName: rawCommit.committerName,
-      committerEmail: rawCommit.committerEmail,
+      committerName: redactor ? redactor.name(rawCommit.committerName) : rawCommit.committerName,
+      committerEmail: redactor ? redactor.email(rawCommit.committerEmail) : rawCommit.committerEmail,
       committerDate: new Date(rawCommit.committerDate).toISOString(),
       message: rawCommit.message.split('\n')[0],
       parents: rawCommit.parents,
@@ -189,6 +216,12 @@ export async function collectCommits(options: CollectOptions): Promise<CommitStr
     };
 
     commits.push(commit);
+  }
+
+  if (syntheticMergesDropped > 0) {
+    logger?.info(
+      `Skipped ${syntheticMergesDropped} CI-generated PR merge commit(s) (refs/pull/N/merge)`
+    );
   }
 
   if (manifestIndex) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,6 +7,7 @@ export * from './git/log.js';
 export * from './tags/ai-tags.js';
 export * from './tags/attribution-manifest.js';
 export * from './tags/automated.js';
+export * from './tags/redact.js';
 export * from './io/fs.js';
 export * from './utils/dates.js';
 export * from './utils/log.js';

--- a/packages/core/src/schema/aida-config.ts
+++ b/packages/core/src/schema/aida-config.ts
@@ -10,6 +10,9 @@ export const AidaConfig = z.object({
   defaultAttribution: z.enum(['ai', 'human', 'unknown']).default('unknown'),
   // Attribution coverage below this fraction flags all metrics as low-confidence.
   coverageThreshold: z.number().min(0).max(1).default(0.7),
+  // Replace author/committer identities with a per-run salted hash (#35).
+  // Recommended in CI, where commit-stream.json leaves the machine.
+  redactAuthors: z.boolean().default(false),
 });
 
 export type AidaConfig = z.infer<typeof AidaConfig>;

--- a/packages/core/src/tags/redact.test.ts
+++ b/packages/core/src/tags/redact.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { createRedactor } from './redact.js';
+
+describe('createRedactor', () => {
+  it('produces stable hashes within a run, so identities can still be grouped', () => {
+    const redactor = createRedactor('fixed-salt');
+    expect(redactor.name('Alice Author')).toBe(redactor.name('Alice Author'));
+    expect(redactor.email('alice@example.com')).toBe(redactor.email('alice@example.com'));
+  });
+
+  it('normalizes case and surrounding whitespace', () => {
+    const redactor = createRedactor('fixed-salt');
+    expect(redactor.email(' Alice@Example.com ')).toBe(redactor.email('alice@example.com'));
+  });
+
+  it('distinguishes different identities', () => {
+    const redactor = createRedactor('fixed-salt');
+    expect(redactor.name('Alice')).not.toBe(redactor.name('Bob'));
+  });
+
+  it('produces different hashes across runs, so values cannot be correlated', () => {
+    expect(createRedactor().email('alice@example.com')).not.toBe(
+      createRedactor().email('alice@example.com')
+    );
+  });
+
+  it('never leaks the original value and emits a non-resolvable address', () => {
+    const redactor = createRedactor('fixed-salt');
+    const email = redactor.email('alice@example.com');
+    expect(email).not.toContain('alice');
+    expect(email).not.toContain('example.com');
+    expect(email.endsWith('@redacted.invalid')).toBe(true);
+    expect(redactor.name('Alice Author')).not.toContain('Alice');
+  });
+});

--- a/packages/core/src/tags/redact.ts
+++ b/packages/core/src/tags/redact.ts
@@ -1,0 +1,35 @@
+import { createHash, randomBytes } from 'crypto';
+
+// Author redaction (#35). AIDA compares cohorts of commits, never people, and
+// never emits per-author aggregates. But `commit-stream.json` carries author
+// and committer identities, and that file travels: committed to CI, uploaded
+// as a workflow artifact. A per-developer ranking is one `jq` query away.
+//
+// Redaction replaces identities with a salted hash. The salt is random per
+// run, so hashes stay stable *within* one output file (dedup and per-identity
+// grouping still work) but cannot be matched back to a person, nor correlated
+// across runs by anyone holding a list of candidate emails.
+//
+// Detection that depends on identity (bot/automated, #39, #21) must run
+// BEFORE redaction — see collectCommits.
+
+export interface Redactor {
+  name(value: string): string;
+  email(value: string): string;
+}
+
+function digest(salt: string, value: string): string {
+  return createHash('sha256')
+    .update(salt)
+    .update(value.trim().toLowerCase())
+    .digest('hex')
+    .slice(0, 12);
+}
+
+export function createRedactor(salt: string = randomBytes(16).toString('hex')): Redactor {
+  return {
+    name: (value: string) => `redacted-${digest(salt, value)}`,
+    // .invalid is reserved (RFC 2606): a redacted address can never resolve
+    email: (value: string) => `${digest(salt, value)}@redacted.invalid`,
+  };
+}


### PR DESCRIPTION
Closes #35, closes #40. Bundled because both concern **what leaves the machine** — the artifact and the PR comment — and are small and independent.

## #35 — Author redaction (the Reddit promise)

> "That's a per-developer ranking waiting for one afternoon and one middle manager." — u/shyguy_chad

`aida collect --redact-authors` (or `redactAuthors: true` in `.aida.json`) replaces author/committer names and emails with a **per-run salted hash**:

- **Stable within a run** — identities can still be grouped/deduped inside one output file.
- **Not reversible** — salted sha256, truncated; emails become `<hash>@redacted.invalid` (RFC 2606, can never resolve).
- **Not correlatable across runs** — a fresh random salt each run, so nobody can match hashes against a list of candidate emails, or join two reports.
- **No accuracy cost** — redaction runs *after* identity-based detection (bots, #39). Verified in the tests.

Kept **opt-in** rather than default-on in CI: silently changing what a command writes would be a surprise. Instead the README now has a **"Privacy: no leaderboards"** section that states the constraint as policy — no per-author metric will ever ship — and recommends the flag for CI.

## #40 — Synthetic PR merge commit

On `pull_request` events, `actions/checkout` builds `refs/pull/N/merge`: a merge commit authored by nobody that exists only in the CI checkout. It was landing in every PR-scoped report — a 1-commit PR read as **2 commits, 50% coverage** (visible in the AIDA comments on #37 and #38).

PR-scoped mode now skips merge commits whose subject matches `^Merge <sha> into <sha>$`. Deliberately narrow: legitimate merge commits inside a PR branch are untouched, and standard time-windowed collection is unchanged (real merges are still collected and classified `automated`).

## Dogfood

Redaction on this repo: `redacted-8d734fc2d90b | f08cc08bd81f@redacted.invalid`, zero real identities in the output, 2 distinct hashes (me + the release bot), and **30 automated commits still detected** — proof that detection ran before redaction.

The AIDA comment on *this very PR* is the test for #40: it should report 1 commit, not 2.

## Testing

101 tests pass (10 new: redactor properties incl. cross-run non-correlation and no-leak assertions, redaction end-to-end with detection intact, synthetic-merge dropped in PR mode, real merges kept in standard mode). Lint clean.

Co-Authored-By: Claude <noreply@anthropic.com>