### PR TITLE
feat: version the output schemas + end-to-end CLI tests (#53)

### DIFF
--- a/.changeset/schema-versioning.md
+++ b/.changeset/schema-versioning.md
@@ -1,0 +1,14 @@
+---
+'@aida-dev/core': minor
+'@aida-dev/metrics': minor
+'@aida-dev/cli': minor
+---
+
+Version the output schemas + end-to-end CLI tests (#53)
+
+`commit-stream.json` and `metrics.json` now carry a `schemaVersion` (both v1). The shape of these files changed six times in three days and a consumer had no way to detect it — a stale file parsed against a newer schema yields silent `undefined`s, not an error.
+
+- **Contract**: additive changes don't bump the version; removing a field, renaming it, or changing its meaning does. Documented in the README, replacing the previous (untrue) "stable JSON schemas" claim.
+- **Readers refuse what they don't understand**: `aida analyze` and `aida report` check the version before schema parsing and fail with an actionable message (`Rerun 'aida collect'`) instead of a zod dump or a half-parsed result. Pre-versioning output is named as such.
+- **End-to-end CLI tests**: the `collect → analyze → report → comment --dry-run` pipeline is now covered on a fixture repo (CLI package went from 1 test to 7), including the version gate and `--redact-authors`.
+- **`pnpm typecheck`**: new script (wired into CI) that typechecks tests too. It immediately caught pre-existing type errors in test fixtures that had been invisible, since vitest transpiles without checking.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,7 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
+      - run: pnpm typecheck
       - run: pnpm test
 
       - name: Create Release Pull Request or Publish

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ AIDA provides **tangible, auditable metrics** to distinguish between **AI noise*
 - **Attribution Coverage** — Four-state provenance (`ai`/`human`/`automated`/`unknown`) with coverage as the headline metric
 - **Persistence** — Measure how long AI-generated code survives in your codebase
 - **Comparative Baseline** — AI vs non-AI side-by-side with delta, so metrics are interpretable
-- **Fast & Deterministic** — Built for production use with stable JSON schemas
+- **Fast & Deterministic** — Versioned JSON output schemas, so consumers detect breaking changes instead of reading silent `undefined`s
 - **CLI-First** — Simple commands for collection, analysis, and reporting
 - **CI/CD Ready** — GitHub Actions integration out of the box
 
@@ -357,9 +357,19 @@ These metrics are honest approximations, not ground truth. Read the numbers with
 
 ## Output Files
 
-- `commit-stream.json` - Normalized commit data with AI tagging
-- `metrics.json` - Calculated metrics with merge ratio, persistence, baseline (non-AI), and delta
-- `report.md` - Human-readable Markdown report with AI vs non-AI comparison table
+- `commit-stream.json` - Normalized commit data with four-state attribution and autonomy mode
+- `metrics.json` - Attribution coverage, persistence, per-cohort and per-autonomy-level metrics
+- `report.md` - Human-readable Markdown report
+
+### Schema versioning
+
+Both JSON files carry a `schemaVersion` ([#53](https://github.com/ceccode/AIDA-Metrics/issues/53)). The contract:
+
+- **Additive changes** (a new field) do **not** bump the version — consumers keep working.
+- **Removing a field, renaming it, or changing its meaning** bumps `schemaVersion`.
+- Readers **refuse** a version they don't understand rather than parsing it half-way: `aida analyze` on a stale `commit-stream.json` fails with `Rerun 'aida collect'`, not a silent wrong result.
+
+Current: `commit-stream.json` v1, `metrics.json` v1.
 
 ## CI/CD Integration
 
@@ -450,7 +460,8 @@ aida_analysis:
 - **v0.13** ✅ Per-mode cohort metrics — persistence per autonomy level ([#25](https://github.com/ceccode/AIDA-Metrics/issues/25), step 2).  
 - **v0.14** ✅ Merge ratio removed — git cannot measure it honestly; PR acceptance rate via forge APIs is the successor ([#20](https://github.com/ceccode/AIDA-Metrics/issues/20)).  
 - **v0.15** ✅ Author redaction ([#35](https://github.com/ceccode/AIDA-Metrics/issues/35)) and synthetic PR merge commit fix ([#40](https://github.com/ceccode/AIDA-Metrics/issues/40)).  
-- **Next** → PR acceptance rate via forge APIs ([#51](https://github.com/ceccode/AIDA-Metrics/issues/51)), autonomy as primary axis ([#25](https://github.com/ceccode/AIDA-Metrics/issues/25) step 3), windowed coverage ([#52](https://github.com/ceccode/AIDA-Metrics/issues/52)), schema versioning ([#53](https://github.com/ceccode/AIDA-Metrics/issues/53)).  
+- **v0.16** ✅ Versioned output schemas with reader-side version gate, plus end-to-end CLI tests and `pnpm typecheck` in CI ([#53](https://github.com/ceccode/AIDA-Metrics/issues/53)).  
+- **Next** → PR acceptance rate via forge APIs ([#51](https://github.com/ceccode/AIDA-Metrics/issues/51)), autonomy as primary axis ([#25](https://github.com/ceccode/AIDA-Metrics/issues/25) step 3), windowed coverage ([#52](https://github.com/ceccode/AIDA-Metrics/issues/52)).  
 - **Next** → Rework rate ([#22](https://github.com/ceccode/AIDA-Metrics/issues/22)), line-level persistence via blame ([#23](https://github.com/ceccode/AIDA-Metrics/issues/23)).  
 - **Next** → Outcome correlation ([#26](https://github.com/ceccode/AIDA-Metrics/issues/26)), cost metrics ([#27](https://github.com/ceccode/AIDA-Metrics/issues/27)).  
 - **Next** → GitLab ([#16](https://github.com/ceccode/AIDA-Metrics/issues/16)) and Bitbucket ([#17](https://github.com/ceccode/AIDA-Metrics/issues/17)) PR comment providers.  

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "pnpm -r run build",
     "dev": "pnpm -r --parallel --filter ./packages/* run dev",
     "test": "pnpm -r run test",
+    "typecheck": "pnpm -r run typecheck",
     "lint": "pnpm -r run lint",
     "format": "pnpm -r run format",
     "changeset": "changeset",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -43,6 +43,7 @@
     "build": "tsup src/index.ts --dts",
     "dev": "tsup src/index.ts --dts --watch",
     "test": "vitest run",
+    "typecheck": "tsc --noEmit",
     "lint": "eslint .",
     "format": "prettier -w ."
   },

--- a/packages/cli/src/commands/analyze.ts
+++ b/packages/cli/src/commands/analyze.ts
@@ -1,5 +1,13 @@
 import { Command } from 'commander';
-import { readJSON, writeJSON, createLogger, CommitStream, AidaConfig } from '@aida-dev/core';
+import {
+  readJSON,
+  writeJSON,
+  createLogger,
+  CommitStream,
+  AidaConfig,
+  COMMIT_STREAM_SCHEMA_VERSION,
+  assertSchemaVersion,
+} from '@aida-dev/core';
 import { calculateMetrics } from '@aida-dev/metrics';
 import { join } from 'path';
 import { readFile } from 'fs/promises';
@@ -35,7 +43,16 @@ export function createAnalyzeCommand(): Command {
         logger.info('Starting metrics analysis...');
 
         const inputPath = join(config.outDir, 'commit-stream.json');
-        const commitStream = await readJSON(inputPath, CommitStream);
+        // Version gate before schema parsing, so an incompatible file gives an
+        // actionable message instead of a zod dump (#53)
+        const raw = await readJSON<unknown>(inputPath);
+        assertSchemaVersion(
+          raw,
+          COMMIT_STREAM_SCHEMA_VERSION,
+          'commit-stream.json',
+          "Rerun 'aida collect' with this version of AIDA."
+        );
+        const commitStream = CommitStream.parse(raw);
 
         logger.info(`Analyzing ${commitStream.commits.length} commits`);
 

--- a/packages/cli/src/commands/e2e.test.ts
+++ b/packages/cli/src/commands/e2e.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { execSync } from 'child_process';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import type { Command } from 'commander';
+import { createCollectCommand } from './collect.js';
+import { createAnalyzeCommand } from './analyze.js';
+import { createReportCommand } from './report.js';
+import { createCommentCommand } from './comment.js';
+
+// End-to-end coverage for the collect → analyze → report pipeline (#53).
+// Every schema change so far passed CI while this wiring was untested; the
+// mismatches were caught by hand-dogfooding instead.
+
+let repoPath: string;
+let outDir: string;
+
+function git(cmd: string) {
+  execSync(cmd, { cwd: repoPath });
+}
+
+function run(command: Command, args: string[]): Promise<Command> {
+  return command.parseAsync(args, { from: 'user' });
+}
+
+beforeAll(() => {
+  repoPath = mkdtempSync(join(tmpdir(), 'aida-e2e-repo-'));
+  outDir = mkdtempSync(join(tmpdir(), 'aida-e2e-out-'));
+
+  git('git init -q -b main');
+  git('git config user.name test && git config user.email test@example.com');
+
+  writeFileSync(join(repoPath, 'app.ts'), 'export const a = 1;\n');
+  git('git add -A');
+  git('git commit -q -m "feat: human work"');
+
+  writeFileSync(join(repoPath, 'app.ts'), 'export const a = 2;\n');
+  writeFileSync(join(repoPath, 'app.test.ts'), 'test("a", () => {});\n');
+  git('git add -A');
+  git(
+    'git commit -q -m "feat: agent work" -m "Co-Authored-By: Claude <noreply@anthropic.com>"'
+  );
+
+  // Silence CLI logging so test output stays readable
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterAll(() => {
+  vi.restoreAllMocks();
+  rmSync(repoPath, { recursive: true, force: true });
+  rmSync(outDir, { recursive: true, force: true });
+});
+
+describe('collect → analyze → report end to end', () => {
+  it('collects a versioned commit stream', async () => {
+    await run(createCollectCommand(), ['--repo', repoPath, '--out-dir', outDir]);
+
+    const stream = JSON.parse(readFileSync(join(outDir, 'commit-stream.json'), 'utf-8'));
+    expect(stream.schemaVersion).toBe(1);
+    expect(stream.commits).toHaveLength(2);
+    // The trailer commit is detected as AI, the other stays unknown
+    const attributions = stream.commits.map((c: { tags: { attribution: string } }) => c.tags.attribution).sort();
+    expect(attributions).toEqual(['ai', 'unknown']);
+  });
+
+  it('analyzes into versioned metrics with every block populated', async () => {
+    await run(createAnalyzeCommand(), ['--out-dir', outDir]);
+
+    const metrics = JSON.parse(readFileSync(join(outDir, 'metrics.json'), 'utf-8'));
+    expect(metrics.schemaVersion).toBe(1);
+    expect(metrics.attribution.coverage).toBeCloseTo(0.5);
+    expect(metrics.attribution.modes.agent).toBe(1);
+    expect(metrics.persistence).toHaveProperty('censored');
+    expect(metrics.cohorts.ai.taskMix).not.toBeNull();
+    expect(metrics.byMode.agent).not.toBeNull();
+    // No human-attributed commits → no invented comparison
+    expect(metrics.baseline).toBeNull();
+    expect(metrics.delta).toBeNull();
+    expect(metrics).not.toHaveProperty('mergeRatio');
+  });
+
+  it('renders a report containing every section the metrics support', async () => {
+    await run(createReportCommand(), ['--out-dir', outDir]);
+
+    const report = readFileSync(join(outDir, 'report.md'), 'utf-8');
+    expect(report).toContain('# AIDA Report');
+    expect(report).toContain('## Attribution Coverage');
+    expect(report).toContain('**Autonomy:**');
+    expect(report).toContain('## By Autonomy Level');
+    expect(report).toContain('## Cohort Fairness');
+    expect(report).toContain('## Persistence (file-level survival)');
+    expect(report).toContain('### Caveats');
+    // Removed metric must not resurface anywhere
+    expect(report.toLowerCase()).not.toContain('merge ratio');
+    // No unresolved template placeholders
+    expect(report).not.toContain('undefined');
+    expect(report).not.toContain('NaN');
+  });
+
+  it('prints the report on comment --dry-run without needing a CI provider', async () => {
+    const printed: string[] = [];
+    const logSpy = vi.spyOn(console, 'log').mockImplementation((msg?: unknown) => {
+      printed.push(String(msg));
+    });
+    await run(createCommentCommand(), ['--out-dir', outDir, '--dry-run']);
+    logSpy.mockRestore();
+    expect(printed.join('\n')).toContain('## Attribution Coverage');
+  });
+
+  it('applies --redact-authors through the CLI', async () => {
+    const redactedDir = mkdtempSync(join(tmpdir(), 'aida-e2e-redacted-'));
+    try {
+      await run(createCollectCommand(), [
+        '--repo',
+        repoPath,
+        '--out-dir',
+        redactedDir,
+        '--redact-authors',
+      ]);
+      const stream = JSON.parse(readFileSync(join(redactedDir, 'commit-stream.json'), 'utf-8'));
+      for (const commit of stream.commits) {
+        expect(commit.authorName).toMatch(/^redacted-[0-9a-f]{12}$/);
+      }
+    } finally {
+      rmSync(redactedDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('schema version gate', () => {
+  it('refuses an incompatible commit-stream instead of parsing it half-way', async () => {
+    const staleDir = mkdtempSync(join(tmpdir(), 'aida-e2e-stale-'));
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit');
+    });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      // A pre-versioning stream: valid JSON, no schemaVersion
+      writeFileSync(
+        join(staleDir, 'commit-stream.json'),
+        JSON.stringify({ repoPath, defaultBranch: 'main', commits: [] })
+      );
+
+      await expect(run(createAnalyzeCommand(), ['--out-dir', staleDir])).rejects.toThrow(
+        'process.exit'
+      );
+      expect(errorSpy.mock.calls.flat().join(' ')).toMatch(
+        /no schemaVersion field.*Rerun 'aida collect'/
+      );
+    } finally {
+      exitSpy.mockRestore();
+      errorSpy.mockRestore();
+      rmSync(staleDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/cli/src/commands/report.ts
+++ b/packages/cli/src/commands/report.ts
@@ -1,5 +1,10 @@
 import { Command } from 'commander';
-import { readJSON, createLogger } from '@aida-dev/core';
+import {
+  readJSON,
+  createLogger,
+  METRICS_SCHEMA_VERSION,
+  assertSchemaVersion,
+} from '@aida-dev/core';
 import { Metrics } from '@aida-dev/metrics';
 import { join } from 'path';
 import { promises as fs } from 'fs';
@@ -135,7 +140,14 @@ export function createReportCommand(): Command {
         logger.info('Generating report...');
 
         const inputPath = join(config.outDir, 'metrics.json');
-        const metrics = await readJSON(inputPath, Metrics);
+        const raw = await readJSON<unknown>(inputPath);
+        assertSchemaVersion(
+          raw,
+          METRICS_SCHEMA_VERSION,
+          'metrics.json',
+          "Rerun 'aida analyze' with this version of AIDA."
+        );
+        const metrics = Metrics.parse(raw);
 
         const markdown = generateMarkdownReport(metrics);
         const mdPath = join(config.outDir, 'report.md');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,6 +33,7 @@
     "build": "tsup src/index.ts --dts",
     "dev": "tsup src/index.ts --dts --watch",
     "test": "vitest run",
+    "typecheck": "tsc --noEmit",
     "lint": "eslint .",
     "format": "prettier -w .",
     "prepublishOnly": "pnpm build"

--- a/packages/core/src/git/collect.ts
+++ b/packages/core/src/git/collect.ts
@@ -1,5 +1,6 @@
 import { simpleGit, SimpleGit } from 'simple-git';
 import { Commit, CommitStream } from '../schema/commit.js';
+import { COMMIT_STREAM_SCHEMA_VERSION } from '../schema/version.js';
 import { createAITagger } from '../tags/ai-tags.js';
 import { createAutomatedDetector } from '../tags/automated.js';
 import {
@@ -234,6 +235,7 @@ export async function collectCommits(options: CollectOptions): Promise<CommitStr
   }
 
   return {
+    schemaVersion: COMMIT_STREAM_SCHEMA_VERSION,
     repoPath,
     defaultBranch,
     generatedAt: formatISODate(new Date()),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 export * from './schema/aida-config.js';
 export * from './schema/commit.js';
+export * from './schema/version.js';
 export * from './schema/stream.js';
 export * from './git/collect.js';
 export * from './git/diff.js';

--- a/packages/core/src/schema/commit.ts
+++ b/packages/core/src/schema/commit.ts
@@ -40,6 +40,8 @@ export const Commit = z.object({
 export type Commit = z.infer<typeof Commit>;
 
 export const CommitStream = z.object({
+  // Bumped when a field is removed or changes meaning (#53)
+  schemaVersion: z.number().int().positive(),
   repoPath: z.string(),
   defaultBranch: z.string(),
   generatedAt: z.string().datetime(),

--- a/packages/core/src/schema/version.test.ts
+++ b/packages/core/src/schema/version.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { SchemaVersionError, assertSchemaVersion } from './version.js';
+
+describe('assertSchemaVersion', () => {
+  it('accepts a matching version', () => {
+    expect(() => assertSchemaVersion({ schemaVersion: 1 }, 1, 'f.json', 'Rerun.')).not.toThrow();
+  });
+
+  it('rejects an older version with an actionable message', () => {
+    expect(() => assertSchemaVersion({ schemaVersion: 1 }, 2, 'metrics.json', 'Rerun x.')).toThrow(
+      /metrics\.json has schema v1, but this version of AIDA reads schema v2\. Rerun x\./
+    );
+  });
+
+  it('rejects a newer version too — a consumer must not half-parse it', () => {
+    expect(() => assertSchemaVersion({ schemaVersion: 5 }, 2, 'f.json', 'Rerun.')).toThrow(
+      SchemaVersionError
+    );
+  });
+
+  it('names the pre-versioning case explicitly when the field is absent', () => {
+    expect(() => assertSchemaVersion({ commits: [] }, 1, 'commit-stream.json', 'Rerun y.')).toThrow(
+      /no schemaVersion field \(pre-v1 output\).*Rerun y\./
+    );
+  });
+
+  it('rejects non-object input without crashing', () => {
+    expect(() => assertSchemaVersion(null, 1, 'f.json', 'Rerun.')).toThrow(SchemaVersionError);
+    expect(() => assertSchemaVersion('nope', 1, 'f.json', 'Rerun.')).toThrow(SchemaVersionError);
+  });
+});

--- a/packages/core/src/schema/version.ts
+++ b/packages/core/src/schema/version.ts
@@ -1,0 +1,47 @@
+// Output schema versioning (#53).
+//
+// `commit-stream.json` and `metrics.json` are consumed by CI pipelines and
+// scripts outside this repo. Their shape has changed repeatedly (three-state
+// attribution, manifest sources, cohorts, autonomy mode, automated state,
+// merge-ratio removal) and a consumer had no way to detect it: a stale file
+// parsed against a newer schema yields silent `undefined`s, not an error.
+//
+// The contract:
+//   - Additive changes (new optional field) do NOT bump the version.
+//   - Removing a field, renaming it, or changing the meaning of an existing
+//     one DOES bump it.
+//   - Readers refuse a version they don't understand, with a fix in the
+//     message, instead of parsing it half-way.
+export const COMMIT_STREAM_SCHEMA_VERSION = 1;
+export const METRICS_SCHEMA_VERSION = 1;
+
+export class SchemaVersionError extends Error {
+  constructor(
+    readonly filePath: string,
+    readonly found: unknown,
+    readonly expected: number,
+    remedy: string
+  ) {
+    const foundLabel =
+      typeof found === 'number' ? `schema v${found}` : 'no schemaVersion field (pre-v1 output)';
+    super(
+      `${filePath} has ${foundLabel}, but this version of AIDA reads schema v${expected}. ${remedy}`
+    );
+    this.name = 'SchemaVersionError';
+  }
+}
+
+// Checks the version field before schema parsing, so an incompatible file
+// produces an actionable message rather than a wall of zod issues.
+export function assertSchemaVersion(
+  data: unknown,
+  expected: number,
+  filePath: string,
+  remedy: string
+): void {
+  const found =
+    data && typeof data === 'object' ? (data as { schemaVersion?: unknown }).schemaVersion : undefined;
+  if (found !== expected) {
+    throw new SchemaVersionError(filePath, found, expected, remedy);
+  }
+}

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -13,6 +13,7 @@
     "build": "tsup src/index.ts --dts",
     "dev": "tsup src/index.ts --dts --watch",
     "test": "vitest run",
+    "typecheck": "tsc --noEmit",
     "lint": "eslint .",
     "format": "prettier -w ."
   },

--- a/packages/metrics/src/index.test.ts
+++ b/packages/metrics/src/index.test.ts
@@ -21,6 +21,7 @@ function makeCommit(overrides: Partial<Commit> & { hash: string }): Commit {
 
 function makeStream(commits: Commit[]): CommitStream {
   return {
+    schemaVersion: 1,
     repoPath: '/test/repo',
     defaultBranch: 'main',
     generatedAt: '2025-01-01T00:00:00.000Z',
@@ -29,9 +30,9 @@ function makeStream(commits: Commit[]): CommitStream {
   };
 }
 
-const aiTags = { ai: true, attribution: 'ai', mode: 'agent', modeEvidence: 'inferred', level: 'explicit', sources: ['tag:[ai]'] } as const;
-const humanTags = { ai: false, attribution: 'human', mode: 'none', modeEvidence: 'declared', level: 'none', sources: [] } as const;
-const unknownTags = { ai: false, attribution: 'unknown', mode: 'unknown', modeEvidence: 'none', level: 'none', sources: [] } as const;
+const aiTags: Commit['tags'] = { ai: true, attribution: 'ai', mode: 'agent', modeEvidence: 'inferred', level: 'explicit', sources: ['tag:[ai]'] };
+const humanTags: Commit['tags'] = { ai: false, attribution: 'human', mode: 'none', modeEvidence: 'declared', level: 'none', sources: [] };
+const unknownTags: Commit['tags'] = { ai: false, attribution: 'unknown', mode: 'unknown', modeEvidence: 'none', level: 'none', sources: [] };
 
 describe('calculateMetrics attribution coverage', () => {
   it('reports coverage as (ai + human) / total', () => {
@@ -53,14 +54,14 @@ describe('calculateMetrics attribution coverage', () => {
   });
 
   it('counts automated commits toward coverage — their provenance is known', () => {
-    const automatedTags = {
+    const automatedTags: Commit['tags'] = {
       ai: false,
       attribution: 'automated',
       mode: 'none',
       modeEvidence: 'inferred',
       level: 'none',
       sources: ['automated:bot'],
-    } as const;
+    };
     const metrics = calculateMetrics(
       makeStream([
         makeCommit({ hash: 'a1', tags: aiTags }),
@@ -147,14 +148,14 @@ describe('calculateMetrics baseline cohort', () => {
   });
 
   it('never assigns automated commits to a cohort, even with a prior', () => {
-    const excludedTags = {
+    const excludedTags: Commit['tags'] = {
       ai: false,
       attribution: 'automated',
       mode: 'none',
       modeEvidence: 'declared',
       level: 'none',
       sources: ['manifest:excluded'],
-    } as const;
+    };
     const metrics = calculateMetrics(
       makeStream([
         makeCommit({ hash: 'a1', tags: aiTags }),
@@ -195,22 +196,22 @@ describe('calculateMetrics baseline cohort', () => {
   });
 
   it('computes per-mode stats, excluding automated commits, null for empty modes', () => {
-    const assistedTags = {
+    const assistedTags: Commit['tags'] = {
       ai: true,
       attribution: 'ai',
       mode: 'assisted',
       modeEvidence: 'inferred',
       level: 'implicit',
       sources: ['implicit:x'],
-    } as const;
-    const automatedTags = {
+    };
+    const automatedTags: Commit['tags'] = {
       ai: false,
       attribution: 'automated',
       mode: 'none',
       modeEvidence: 'inferred',
       level: 'none',
       sources: ['automated:bot'],
-    } as const;
+    };
     const metrics = calculateMetrics(
       makeStream([
         makeCommit({ hash: 'a1', tags: aiTags }), // agent

--- a/packages/metrics/src/index.ts
+++ b/packages/metrics/src/index.ts
@@ -1,4 +1,4 @@
-import { Commit, CommitStream, formatISODate } from '@aida-dev/core';
+import { Commit, CommitStream, METRICS_SCHEMA_VERSION, formatISODate } from '@aida-dev/core';
 import { calculateAgeStats, calculateCategoryCounts } from './cohort.js';
 import { calculateBaselinePersistence, calculatePersistence } from './persistence.js';
 import { Attribution, ByMode, Metrics, ModeStats } from './schema/metrics.js';
@@ -138,6 +138,7 @@ export function calculateMetrics(
   }
 
   return {
+    schemaVersion: METRICS_SCHEMA_VERSION,
     generatedAt: formatISODate(new Date()),
     window: {
       since: commitStream.since,

--- a/packages/metrics/src/persistence.test.ts
+++ b/packages/metrics/src/persistence.test.ts
@@ -22,6 +22,7 @@ function makeCommit(overrides: Partial<CommitStream['commits'][0]>): CommitStrea
 
 function makeStream(commits: CommitStream['commits']): CommitStream {
   return {
+    schemaVersion: 1,
     repoPath: '/test',
     defaultBranch: 'main',
     generatedAt: '2024-06-01T00:00:00.000Z',
@@ -149,7 +150,7 @@ describe('calculatePersistence', () => {
   });
 
   it('ends the survival clock at the first subsequent touch, same cohort included', () => {
-    const aiTags = { ai: true, attribution: 'ai' as const, mode: 'agent' as const, modeEvidence: 'inferred' as const, level: 'explicit', sources: ['tag:[ai]'] };
+    const aiTags: CommitStream['commits'][0]['tags'] = { ai: true, attribution: 'ai', mode: 'agent', modeEvidence: 'inferred', level: 'explicit', sources: ['tag:[ai]'] };
     const stream = makeStream([
       makeCommit({
         hash: 'a1',

--- a/packages/metrics/src/schema/metrics.ts
+++ b/packages/metrics/src/schema/metrics.ts
@@ -113,6 +113,8 @@ export const ByMode = z.object({
 });
 
 export const Metrics = z.object({
+  // Bumped when a field is removed or changes meaning (#53)
+  schemaVersion: z.number().int().positive(),
   generatedAt: z.string().datetime(),
   window: z.object({
     since: z.string().optional(),


### PR DESCRIPTION
Closes #53.

## Why

`commit-stream.json` and `metrics.json` changed shape **six times in three days** (#34, #10, #29/#36, #25, #39, #20) and a consumer had no way to detect it: no version field, and the README promised "stable JSON schemas". A script pinned to an older CLI reading newer output gets silent `undefined`s, not an error.

## What

- **`schemaVersion` (v1)** on both files, with the contract written down: additive changes don't bump it; removing a field, renaming it, or changing its meaning does.
- **Readers refuse what they don't understand.** `analyze` and `report` check the version *before* schema parsing, so the failure is actionable rather than a wall of zod issues. Verified against a real pre-versioning file:

  ```
  [ERROR] Analysis failed: commit-stream.json has no schemaVersion field (pre-v1 output),
  but this version of AIDA reads schema v1. Rerun 'aida collect' with this version of AIDA.
  ```

- **README**: the false "stable JSON schemas" claim replaced by the actual guarantee.

## The part that matters more than the version field

**End-to-end CLI tests** — the package went from **1 test to 7**, covering `collect → analyze → report → comment --dry-run` on a fixture repo, plus the version gate and `--redact-authors`. The report assertions include `not.toContain('undefined')`, `not.toContain('NaN')` and `not.toContain('merge ratio')`, so template regressions and resurrected metrics fail the build.

**`pnpm typecheck` (new, wired into CI)** — and it earned its place immediately: it surfaced **pre-existing type errors in the test fixtures** that had been invisible because vitest transpiles without typechecking (object-level `as const` on tag literals makes `sources` readonly, and a widened `level: string`). Those fixtures were type-invalid before this PR; now they can't be.

Together these are what would have caught the schema drift automatically instead of by hand-dogfooding.

## Testing

112 tests pass (core 78, metrics 27, cli 7), `pnpm typecheck` clean across all three packages, lint clean, full pipeline dogfooded on this repo (both files emit `schemaVersion: 1`).

Co-Authored-By: Claude <noreply@anthropic.com>