### PR TITLE
feat: PR acceptance rate via forge APIs (#51)

### DIFF
--- a/.changeset/pr-acceptance.md
+++ b/.changeset/pr-acceptance.md
@@ -1,0 +1,15 @@
+---
+'@aida-dev/core': minor
+'@aida-dev/metrics': minor
+'@aida-dev/cli': minor
+---
+
+PR acceptance rate via forge APIs (#51)
+
+The honest successor to the merge ratio removed in #20. Git history cannot say whether work was accepted — squash merges and deleted branches erase discarded work — but a forge never deletes a closed pull request.
+
+- **New `aida fetch-prs` command**: fetches closed PRs (merged and closed-unmerged) from the GitHub API into `pr-stream.json` (schema v1). It is the *only* command that touches the network, kept separate on purpose so `collect` stays git-only and offline.
+- **`aida analyze` picks it up when present**: `metrics.json` gains `prAcceptance` with acceptance rates overall, per attribution cohort, and per autonomy mode. Absent without the file — with a caveat pointing at `fetch-prs`, never a silent 0%.
+- **Attribution from the PR's own commit messages** as returned by the API, not from a join against local git: this is what makes it work for squash-merged PRs whose branches no longer exist.
+- **No author identity is fetched or stored** — PR numbers, outcomes, dates, and commit attribution only (#35).
+- Bounded API usage via `--since` and `--max-prs`; a capped fetch is flagged `truncated` and carries a caveat. Rate-limit exhaustion produces a distinct, actionable error.

--- a/README.md
+++ b/README.md
@@ -143,6 +143,14 @@ Collect commits and generate normalized commit stream:
 aida collect --since 90d --out-dir ./aida-output
 ```
 
+#### `aida fetch-prs`
+
+Fetch pull request outcomes from the forge API (**opt-in, the only command that uses the network**):
+
+```bash
+GITHUB_TOKEN=... aida fetch-prs --github-repo owner/name --since 90d
+```
+
 #### `aida analyze`
 
 Calculate attribution coverage and persistence metrics:
@@ -186,6 +194,17 @@ aida report --out-dir ./aida-output
 
 - `--out-dir <path>` - Output directory (default: ./aida-output)
 - `--verbose` - Verbose logging
+
+#### `aida fetch-prs`
+
+- `--github-repo <owner/name>` - GitHub repository (default: `$GITHUB_REPOSITORY`)
+- `--since <date>` - Only PRs closed after this date (ISO or relative like 90d)
+- `--max-prs <n>` - Stop after this many PRs (bounds API usage)
+- `--repo <path>` - Repository path, for reading `.aida.json`
+- `--out-dir <path>` - Output directory (default: ./aida-output)
+- `--verbose` - Verbose logging
+
+Requires `GITHUB_TOKEN`. Without it the command refuses to run and PR acceptance stays **absent** from the report — never a silent 0%.
 
 #### `aida comment`
 
@@ -320,6 +339,19 @@ The headline metric ([#34](https://github.com/ceccode/AIDA-Metrics/issues/34)). 
 
 Merge ratio and persistence computed per autonomy mode (`agent` / `assisted` / `autocomplete` / `none`) — the comparison that stays meaningful when everything is AI-assisted ([#25](https://github.com/ceccode/AIDA-Metrics/issues/25)). Automated commits are excluded; modes with no commits are `null`.
 
+### PR Acceptance
+
+Whether AI-written work is **accepted**, measured from the forge API ([#51](https://github.com/ceccode/AIDA-Metrics/issues/51)): merged vs closed-unmerged pull requests, broken down by attribution and autonomy level.
+
+This is the successor to the removed merge ratio. The difference is the data source: a forge never deletes a closed PR, so the negative outcome is observable — while git history erases it.
+
+Two deliberate properties:
+
+- **Opt-in and additive.** `aida fetch-prs` is the only command that touches the network; everything else stays git-only and offline. Without a token the metric is absent, with a caveat saying so.
+- **No author identity is ever fetched or stored.** `pr-stream.json` holds PR numbers, outcomes, dates, and the attribution of the PR's own commits — nothing that names anyone ([#35](https://github.com/ceccode/AIDA-Metrics/issues/35)).
+
+PRs are attributed from **their own commit messages as returned by the API**, not from a join against local git. That is what makes this work for squash-merged PRs whose branches no longer exist — the exact case where git-based measurement failed.
+
 ### Why there is no Merge Ratio
 
 Early versions shipped a merge ratio ("% of AI commits that land on the default branch"). We removed it ([#20](https://github.com/ceccode/AIDA-Metrics/issues/20)) because git history structurally cannot answer that question honestly:
@@ -350,7 +382,8 @@ If no commits are attributed `human` and no `defaultAttribution` prior assigns t
 These metrics are honest approximations, not ground truth. Read the numbers with these caveats in mind:
 
 - **Detection is voluntary** — AIDA only sees what commits admit to. Untagged AI code lands in the `unknown` bucket, and attribution coverage ([#34](https://github.com/ceccode/AIDA-Metrics/issues/34)) reports how big that bucket is instead of hiding it; the attribution manifest ([#10](https://github.com/ceccode/AIDA-Metrics/issues/10)) lets you shrink it retroactively. But the tool still cannot see through a commit that lies.
-- **Git can't see discarded work** — squash merges and deleted branches erase unmerged commits, which is why the merge ratio was removed entirely rather than patched ([#20](https://github.com/ceccode/AIDA-Metrics/issues/20)).
+- **Git can't see discarded work** — squash merges and deleted branches erase unmerged commits, which is why the merge ratio was removed entirely rather than patched ([#20](https://github.com/ceccode/AIDA-Metrics/issues/20)). PR acceptance ([#51](https://github.com/ceccode/AIDA-Metrics/issues/51)) answers the question from the forge API instead.
+- **The attribution manifest does not apply to PR commits** — manifest entries are keyed by hash, and a squash-merged PR's original commits have different hashes from what landed on the default branch. PR-level attribution therefore relies on trailers alone, so a repo that adopted trailers late will see more `unknown` PRs than `unknown` commits.
 - **Persistence is file-level** — one AI-touched line marks the whole file as AI-touched; line-level tracking via `git blame` is planned ([#23](https://github.com/ceccode/AIDA-Metrics/issues/23)).
 - **Cohort age skews persistence** — older commits have had more time to accumulate survival. The report now shows each cohort's age so you can judge fairness; normalization is still open ([#29](https://github.com/ceccode/AIDA-Metrics/issues/29)).
 - **Task mix skews persistence** — AI is often pointed at boilerplate, tests, and migrations, which survive longer because nobody has a reason to touch them. The report now shows each cohort's file-category mix; within-category comparison is still open ([#36](https://github.com/ceccode/AIDA-Metrics/issues/36)).
@@ -359,6 +392,7 @@ These metrics are honest approximations, not ground truth. Read the numbers with
 
 - `commit-stream.json` - Normalized commit data with four-state attribution and autonomy mode
 - `metrics.json` - Attribution coverage, persistence, per-cohort and per-autonomy-level metrics
+- `pr-stream.json` - PR outcomes and per-PR attribution (only when `aida fetch-prs` ran)
 - `report.md` - Human-readable Markdown report
 
 ### Schema versioning
@@ -369,7 +403,7 @@ Both JSON files carry a `schemaVersion` ([#53](https://github.com/ceccode/AIDA-M
 - **Removing a field, renaming it, or changing its meaning** bumps `schemaVersion`.
 - Readers **refuse** a version they don't understand rather than parsing it half-way: `aida analyze` on a stale `commit-stream.json` fails with `Rerun 'aida collect'`, not a silent wrong result.
 
-Current: `commit-stream.json` v1, `metrics.json` v1.
+Current: `commit-stream.json` v1, `metrics.json` v1, `pr-stream.json` v1.
 
 ## CI/CD Integration
 
@@ -461,7 +495,8 @@ aida_analysis:
 - **v0.14** ✅ Merge ratio removed — git cannot measure it honestly; PR acceptance rate via forge APIs is the successor ([#20](https://github.com/ceccode/AIDA-Metrics/issues/20)).  
 - **v0.15** ✅ Author redaction ([#35](https://github.com/ceccode/AIDA-Metrics/issues/35)) and synthetic PR merge commit fix ([#40](https://github.com/ceccode/AIDA-Metrics/issues/40)).  
 - **v0.16** ✅ Versioned output schemas with reader-side version gate, plus end-to-end CLI tests and `pnpm typecheck` in CI ([#53](https://github.com/ceccode/AIDA-Metrics/issues/53)).  
-- **Next** → PR acceptance rate via forge APIs ([#51](https://github.com/ceccode/AIDA-Metrics/issues/51)), autonomy as primary axis ([#25](https://github.com/ceccode/AIDA-Metrics/issues/25) step 3), windowed coverage ([#52](https://github.com/ceccode/AIDA-Metrics/issues/52)).  
+- **v0.17** ✅ PR acceptance rate via forge APIs — opt-in `aida fetch-prs`, the honest successor to merge ratio ([#51](https://github.com/ceccode/AIDA-Metrics/issues/51)).  
+- **Next** → Autonomy as primary axis ([#25](https://github.com/ceccode/AIDA-Metrics/issues/25) step 3), windowed coverage ([#52](https://github.com/ceccode/AIDA-Metrics/issues/52)), GitLab ([#16](https://github.com/ceccode/AIDA-Metrics/issues/16)) / Bitbucket ([#17](https://github.com/ceccode/AIDA-Metrics/issues/17)) PR providers.  
 - **Next** → Rework rate ([#22](https://github.com/ceccode/AIDA-Metrics/issues/22)), line-level persistence via blame ([#23](https://github.com/ceccode/AIDA-Metrics/issues/23)).  
 - **Next** → Outcome correlation ([#26](https://github.com/ceccode/AIDA-Metrics/issues/26)), cost metrics ([#27](https://github.com/ceccode/AIDA-Metrics/issues/27)).  
 - **Next** → GitLab ([#16](https://github.com/ceccode/AIDA-Metrics/issues/16)) and Bitbucket ([#17](https://github.com/ceccode/AIDA-Metrics/issues/17)) PR comment providers.  

--- a/packages/cli/src/commands/analyze.ts
+++ b/packages/cli/src/commands/analyze.ts
@@ -6,7 +6,10 @@ import {
   CommitStream,
   AidaConfig,
   COMMIT_STREAM_SCHEMA_VERSION,
+  PRStream,
+  PR_STREAM_SCHEMA_VERSION,
   assertSchemaVersion,
+  fileExists,
 } from '@aida-dev/core';
 import { calculateMetrics } from '@aida-dev/metrics';
 import { join } from 'path';
@@ -74,7 +77,27 @@ export function createAnalyzeCommand(): Command {
           );
         }
 
-        const metrics = calculateMetrics(commitStream, { defaultAttribution, coverageThreshold });
+        // Optional PR outcomes (#51): absent unless `aida fetch-prs` ran.
+        // Missing file is the normal offline case, not an error.
+        const prStreamPath = join(config.outDir, 'pr-stream.json');
+        let prStream = null;
+        if (await fileExists(prStreamPath)) {
+          const rawPRs = await readJSON<unknown>(prStreamPath);
+          assertSchemaVersion(
+            rawPRs,
+            PR_STREAM_SCHEMA_VERSION,
+            'pr-stream.json',
+            "Rerun 'aida fetch-prs' with this version of AIDA."
+          );
+          prStream = PRStream.parse(rawPRs);
+          logger.info(`PR outcomes loaded: ${prStream.prs.length} closed PR(s)`);
+        }
+
+        const metrics = calculateMetrics(commitStream, {
+          defaultAttribution,
+          coverageThreshold,
+          prStream,
+        });
 
         const outputPath = join(config.outDir, 'metrics.json');
         await writeJSON(outputPath, metrics);
@@ -89,6 +112,13 @@ export function createAnalyzeCommand(): Command {
           );
         }
         logger.info(`Average persistence: ${metrics.persistence.avgDays} days`);
+        if (metrics.prAcceptance) {
+          const ai = metrics.prAcceptance.byAttribution.ai;
+          logger.info(
+            `PR acceptance overall: ${(metrics.prAcceptance.overall.acceptanceRate * 100).toFixed(1)}%` +
+              (ai ? ` · AI PRs: ${(ai.acceptanceRate * 100).toFixed(1)}% (${ai.total})` : '')
+          );
+        }
         if (!metrics.baseline) {
           logger.warn('No baseline cohort: no commits attributed as human (see caveats).');
         }

--- a/packages/cli/src/commands/e2e.test.ts
+++ b/packages/cli/src/commands/e2e.test.ts
@@ -8,6 +8,7 @@ import { createCollectCommand } from './collect.js';
 import { createAnalyzeCommand } from './analyze.js';
 import { createReportCommand } from './report.js';
 import { createCommentCommand } from './comment.js';
+import { createFetchPRsCommand } from './fetch-prs.js';
 
 // End-to-end coverage for the collect → analyze → report pipeline (#53).
 // Every schema change so far passed CI while this wiring was untested; the
@@ -125,6 +126,101 @@ describe('collect → analyze → report end to end', () => {
       }
     } finally {
       rmSync(redactedDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('PR acceptance (#51)', () => {
+  it('is absent — with a caveat, never a silent 0% — when fetch-prs has not run', async () => {
+    const metrics = JSON.parse(readFileSync(join(outDir, 'metrics.json'), 'utf-8'));
+    expect(metrics.prAcceptance).toBeNull();
+    expect(metrics.caveats.join(' ')).toContain("run 'aida fetch-prs'");
+
+    const report = readFileSync(join(outDir, 'report.md'), 'utf-8');
+    expect(report).not.toContain('## PR Acceptance');
+  });
+
+  it('is computed and rendered when a pr-stream.json is present', async () => {
+    const prDir = mkdtempSync(join(tmpdir(), 'aida-e2e-prs-'));
+    try {
+      await run(createCollectCommand(), ['--repo', repoPath, '--out-dir', prDir]);
+
+      const aiCommit = {
+        sha: 'a'.repeat(40),
+        tags: {
+          ai: true,
+          attribution: 'ai',
+          mode: 'agent',
+          modeEvidence: 'inferred',
+          level: 'explicit',
+          sources: ['trailer'],
+        },
+      };
+      writeFileSync(
+        join(prDir, 'pr-stream.json'),
+        JSON.stringify({
+          schemaVersion: 1,
+          provider: 'github',
+          repo: 'owner/name',
+          fetchedAt: '2026-01-03T00:00:00.000Z',
+          truncated: false,
+          prs: [
+            {
+              number: 1,
+              state: 'merged',
+              createdAt: '2026-01-01T00:00:00.000Z',
+              closedAt: '2026-01-02T00:00:00.000Z',
+              mergedAt: '2026-01-02T00:00:00.000Z',
+              commits: [aiCommit],
+            },
+            {
+              number: 2,
+              state: 'closed',
+              createdAt: '2026-01-01T00:00:00.000Z',
+              closedAt: '2026-01-02T00:00:00.000Z',
+              mergedAt: null,
+              commits: [aiCommit],
+            },
+          ],
+        })
+      );
+
+      await run(createAnalyzeCommand(), ['--out-dir', prDir]);
+      const metrics = JSON.parse(readFileSync(join(prDir, 'metrics.json'), 'utf-8'));
+      expect(metrics.prAcceptance.overall).toEqual({
+        total: 2,
+        merged: 1,
+        closed: 1,
+        acceptanceRate: 0.5,
+      });
+      expect(metrics.prAcceptance.byAttribution.ai.acceptanceRate).toBe(0.5);
+
+      await run(createReportCommand(), ['--out-dir', prDir]);
+      const report = readFileSync(join(prDir, 'report.md'), 'utf-8');
+      expect(report).toContain('## PR Acceptance');
+      expect(report).toContain('Closed unmerged');
+      expect(report).not.toContain('undefined');
+    } finally {
+      rmSync(prDir, { recursive: true, force: true });
+    }
+  });
+
+  it('fetch-prs refuses to run without a token instead of failing silently', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit');
+    });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const savedToken = process.env.GITHUB_TOKEN;
+    delete process.env.GITHUB_TOKEN;
+    try {
+      await expect(
+        run(createFetchPRsCommand(), ['--out-dir', outDir, '--github-repo', 'owner/name'])
+      ).rejects.toThrow('process.exit');
+      expect(errorSpy.mock.calls.flat().join(' ')).toContain('GITHUB_TOKEN is required');
+    } finally {
+      if (savedToken !== undefined) process.env.GITHUB_TOKEN = savedToken;
+      exitSpy.mockRestore();
+      errorSpy.mockRestore();
     }
   });
 });

--- a/packages/cli/src/commands/fetch-prs.ts
+++ b/packages/cli/src/commands/fetch-prs.ts
@@ -1,0 +1,92 @@
+import { Command } from 'commander';
+import { AidaConfig, createLogger, parseRelativeDate, writeJSON } from '@aida-dev/core';
+import { join } from 'path';
+import { readFile } from 'fs/promises';
+import { fetchClosedPRs } from '../providers/github-prs.js';
+
+// `aida fetch-prs` (#51) — the only command that touches the network.
+// Kept separate on purpose: `collect` remains git-only and offline, so the
+// "nothing leaves your machine" promise stays verifiable by not running this.
+
+async function loadAidaConfig(repoPath: string): Promise<Partial<AidaConfig>> {
+  try {
+    const raw = await readFile(join(repoPath, '.aida.json'), 'utf-8');
+    return AidaConfig.parse(JSON.parse(raw));
+  } catch {
+    return {};
+  }
+}
+
+function detectRepo(explicit?: string): string | null {
+  return explicit || process.env.GITHUB_REPOSITORY || null;
+}
+
+export function createFetchPRsCommand(): Command {
+  return new Command('fetch-prs')
+    .description('Fetch pull request outcomes from the forge API (opt-in, requires a token)')
+    .option('--repo <path>', 'Repository path (for .aida.json)', process.cwd())
+    .option('--github-repo <owner/name>', 'GitHub repository (default: $GITHUB_REPOSITORY)')
+    .option('--since <date>', 'Only PRs closed after this date (ISO or relative like 90d)')
+    .option('--max-prs <n>', 'Stop after this many PRs (bounds API usage)')
+    .option('--out-dir <path>', 'Output directory', './aida-output')
+    .option('--verbose', 'Verbose logging', false)
+    .action(async (options) => {
+      const logger = createLogger(Boolean(options.verbose));
+
+      try {
+        const token = process.env.GITHUB_TOKEN;
+        if (!token) {
+          logger.error(
+            'GITHUB_TOKEN is required. Export a token with `repo` (or public_repo) scope.\n' +
+              'PR acceptance stays unavailable without it — every other AIDA command works offline.'
+          );
+          process.exit(1);
+        }
+
+        const githubRepo = detectRepo(options.githubRepo);
+        if (!githubRepo) {
+          logger.error(
+            'Could not determine the GitHub repository. Pass --github-repo <owner/name> or set GITHUB_REPOSITORY.'
+          );
+          process.exit(1);
+        }
+
+        const fileConfig = await loadAidaConfig(options.repo);
+        const maxPRs = options.maxPrs ? Number(options.maxPrs) : undefined;
+        if (maxPRs !== undefined && (!Number.isInteger(maxPRs) || maxPRs <= 0)) {
+          throw new Error(`Invalid --max-prs "${options.maxPrs}": expected a positive integer`);
+        }
+
+        logger.info(`Fetching closed PRs from ${githubRepo}...`);
+
+        const prStream = await fetchClosedPRs({
+          repo: githubRepo,
+          token,
+          since: options.since ? parseRelativeDate(options.since) : undefined,
+          maxPRs,
+          aiPatterns: fileConfig.patterns,
+          aiTools: fileConfig.tools,
+          aiTrailerDomains: fileConfig.trailerDomains,
+          aiBotBlocklist: fileConfig.botBlocklist,
+          logger,
+        });
+
+        const outputPath = join(options.outDir, 'pr-stream.json');
+        await writeJSON(outputPath, prStream);
+
+        const merged = prStream.prs.filter((pr) => pr.state === 'merged').length;
+        logger.info(
+          `Collected ${prStream.prs.length} closed PR(s): ${merged} merged, ${prStream.prs.length - merged} closed unmerged`
+        );
+        if (prStream.truncated) {
+          logger.warn(`Stopped at --max-prs: this is a sample, not the full history.`);
+        }
+        logger.info(`Output written to: ${outputPath}`);
+      } catch (error) {
+        logger.error(
+          `PR fetch failed: ${error instanceof Error ? error.message : String(error)}`
+        );
+        process.exit(1);
+      }
+    });
+}

--- a/packages/cli/src/commands/report.ts
+++ b/packages/cli/src/commands/report.ts
@@ -90,6 +90,33 @@ ${modeRows.join('\n')}
 `
       : '';
 
+  const acc = metrics.prAcceptance;
+  function accRow(label: string, stats: { total: number; merged: number; closed: number; acceptanceRate: number } | null) {
+    if (!stats) return null;
+    return `| ${label} | ${stats.total} | ${stats.merged} | ${stats.closed} | ${(stats.acceptanceRate * 100).toFixed(1)}% |`;
+  }
+  const prSection = acc
+    ? `## PR Acceptance
+
+Whether the work was **accepted**, from the ${acc.provider} API — the question git history cannot answer, since squash merges and deleted branches erase what was discarded.${acc.truncated ? '\n\n> ⚠️ Capped sample (`--max-prs`): not the full history.' : ''}
+
+| Cohort | PRs | Merged | Closed unmerged | Acceptance |
+|---|---:|---:|---:|---:|
+${[
+  accRow('**All PRs**', acc.overall),
+  accRow('ai', acc.byAttribution.ai),
+  accRow('human', acc.byAttribution.human),
+  accRow('unknown', acc.byAttribution.unknown),
+  accRow('mode: agent', acc.byMode.agent),
+  accRow('mode: assisted', acc.byMode.assisted),
+  accRow('mode: autocomplete', acc.byMode.autocomplete),
+]
+  .filter(Boolean)
+  .join('\n')}
+
+`
+    : '';
+
   const baselineDetail = metrics.baseline
     ? `## ${baselineLabel}
 - Persistence — commits considered: ${metrics.baseline.persistence.commitsConsidered}, avg: ${metrics.baseline.persistence.avgDays}d, median: ${metrics.baseline.persistence.medianDays}d
@@ -111,7 +138,7 @@ ${modeRows.join('\n')}
 **Autonomy:** agent ${a.modes.agent} · assisted ${a.modes.assisted} · autocomplete ${a.modes.autocomplete} · none ${a.modes.none} · unknown ${a.modes.unknown} — evidence: declared ${a.modeEvidence.declared} / inferred ${a.modeEvidence.inferred} / none ${a.modeEvidence.none}
 ${coverageWarning}${priorNote}
 ${comparisonSection}
-${byModeSection}${fairnessSection}
+${byModeSection}${prSection}${fairnessSection}
 ## Persistence (file-level survival)
 - Commits considered: ${metrics.persistence.commitsConsidered}
 - Files measured: ${metrics.persistence.filesConsidered} (${metrics.persistence.censored} still surviving at collection time; ${metrics.persistence.filesExcluded} excluded: migrations/generated)

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,6 +2,7 @@
 
 import { Command } from 'commander';
 import { createCollectCommand } from './commands/collect.js';
+import { createFetchPRsCommand } from './commands/fetch-prs.js';
 import { createAnalyzeCommand } from './commands/analyze.js';
 import { createReportCommand } from './commands/report.js';
 import { createCommentCommand } from './commands/comment.js';
@@ -15,6 +16,7 @@ program
 
 // Add commands
 program.addCommand(createCollectCommand());
+program.addCommand(createFetchPRsCommand());
 program.addCommand(createAnalyzeCommand());
 program.addCommand(createReportCommand());
 program.addCommand(createCommentCommand());

--- a/packages/cli/src/providers/github-prs.ts
+++ b/packages/cli/src/providers/github-prs.ts
@@ -1,0 +1,184 @@
+import {
+  AITagResult,
+  Logger,
+  PRCommit,
+  PR_STREAM_SCHEMA_VERSION,
+  PRStream,
+  PullRequest,
+  createAITagger,
+} from '@aida-dev/core';
+
+// GitHub PR fetcher for `aida fetch-prs` (#51).
+//
+// Deliberately the only network code in AIDA, in its own opt-in command:
+// `collect` stays git-only and offline. Nothing about the PR author is read
+// or stored — only outcomes and the attribution of the PR's own commits.
+
+const API_PAGE_SIZE = 100;
+
+interface GitHubPR {
+  number: number;
+  state: string;
+  draft?: boolean;
+  created_at: string;
+  closed_at: string | null;
+  merged_at: string | null;
+}
+
+interface GitHubPRCommit {
+  sha: string;
+  commit: { message: string };
+  parents?: Array<{ sha: string }>;
+}
+
+export interface FetchPROptions {
+  repo: string;
+  token: string;
+  apiUrl?: string;
+  since?: Date;
+  maxPRs?: number;
+  aiPatterns?: string[];
+  aiTools?: string[];
+  aiTrailerDomains?: string[];
+  aiBotBlocklist?: string[];
+  logger?: Logger;
+}
+
+function sanitize(text: string, maxLength = 200): string {
+  const sanitized = text
+    .replace(/gh[pous]_[A-Za-z0-9_]+/g, '[REDACTED]')
+    .replace(/github_pat_[A-Za-z0-9_]+/g, '[REDACTED]')
+    .replace(/Bearer\s+[A-Za-z0-9._-]+/gi, 'Bearer [REDACTED]');
+  return sanitized.length > maxLength ? `${sanitized.slice(0, maxLength)}...(truncated)` : sanitized;
+}
+
+export class GitHubPRFetchError extends Error {
+  constructor(
+    message: string,
+    readonly status?: number
+  ) {
+    super(message);
+    this.name = 'GitHubPRFetchError';
+  }
+}
+
+async function apiGet<T>(url: string, token: string): Promise<T> {
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github.v3+json',
+    },
+  });
+
+  if (!response.ok) {
+    const body = sanitize(await response.text());
+    // Rate limiting deserves a distinguishable message: the fix is waiting,
+    // not fixing the token.
+    const remaining = response.headers.get('x-ratelimit-remaining');
+    if (response.status === 403 && remaining === '0') {
+      const reset = response.headers.get('x-ratelimit-reset');
+      const resetAt = reset ? new Date(Number(reset) * 1000).toISOString() : 'unknown';
+      throw new GitHubPRFetchError(
+        `GitHub API rate limit exhausted (resets at ${resetAt}). Retry later or narrow the window with --since.`,
+        response.status
+      );
+    }
+    throw new GitHubPRFetchError(`GitHub API ${response.status}: ${body}`, response.status);
+  }
+
+  return (await response.json()) as T;
+}
+
+export async function fetchClosedPRs(options: FetchPROptions): Promise<PRStream> {
+  const {
+    repo,
+    token,
+    apiUrl = process.env.GITHUB_API_URL || 'https://api.github.com',
+    since,
+    maxPRs,
+    aiPatterns = [],
+    aiTools = [],
+    aiTrailerDomains = [],
+    aiBotBlocklist = [],
+    logger,
+  } = options;
+
+  // Same tagging rules as `collect`, applied to the PR's own commit messages
+  const tagger = createAITagger({
+    patterns: aiPatterns,
+    tools: aiTools,
+    trailerDomains: aiTrailerDomains,
+    botBlocklist: aiBotBlocklist,
+  });
+
+  const prs: PullRequest[] = [];
+  let page = 1;
+  let truncated = false;
+  let reachedWindow = false;
+
+  while (!reachedWindow) {
+    const url = `${apiUrl}/repos/${repo}/pulls?state=closed&sort=updated&direction=desc&per_page=${API_PAGE_SIZE}&page=${page}`;
+    const batch = await apiGet<GitHubPR[]>(url, token);
+    if (batch.length === 0) break;
+
+    for (const pr of batch) {
+      if (!pr.closed_at) continue; // still open despite the filter
+
+      if (since && new Date(pr.closed_at) < since) {
+        // Sorted by updated desc: everything after this is older
+        reachedWindow = true;
+        break;
+      }
+
+      if (maxPRs && prs.length >= maxPRs) {
+        truncated = true;
+        reachedWindow = true;
+        break;
+      }
+
+      const commits = await apiGet<GitHubPRCommit[]>(
+        `${apiUrl}/repos/${repo}/pulls/${pr.number}/commits?per_page=${API_PAGE_SIZE}`,
+        token
+      );
+
+      const taggedCommits: PRCommit[] = commits.map((commit) => {
+        let tags: AITagResult = tagger(commit.commit.message);
+        if (tags.attribution === 'unknown' && (commit.parents?.length ?? 0) > 1) {
+          // Merge commits inside a PR branch are automation, not authored work
+          tags = {
+            ai: false,
+            attribution: 'automated',
+            mode: 'none',
+            modeEvidence: 'inferred',
+            level: 'none',
+            sources: [...tags.sources, 'automated:merge-commit'],
+          };
+        }
+        return { sha: commit.sha, tags };
+      });
+
+      prs.push({
+        number: pr.number,
+        state: pr.merged_at ? 'merged' : 'closed',
+        createdAt: new Date(pr.created_at).toISOString(),
+        closedAt: new Date(pr.closed_at).toISOString(),
+        mergedAt: pr.merged_at ? new Date(pr.merged_at).toISOString() : null,
+        commits: taggedCommits,
+      });
+    }
+
+    logger?.info(`Fetched ${prs.length} closed PR(s)...`);
+    if (batch.length < API_PAGE_SIZE) break;
+    page++;
+  }
+
+  return {
+    schemaVersion: PR_STREAM_SCHEMA_VERSION,
+    provider: 'github',
+    repo,
+    fetchedAt: new Date().toISOString(),
+    since: since?.toISOString(),
+    truncated,
+    prs,
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 export * from './schema/aida-config.js';
 export * from './schema/commit.js';
+export * from './schema/pr.js';
 export * from './schema/version.js';
 export * from './schema/stream.js';
 export * from './git/collect.js';

--- a/packages/core/src/schema/pr.ts
+++ b/packages/core/src/schema/pr.ts
@@ -1,0 +1,56 @@
+import { z } from 'zod';
+
+// Pull request stream (#51) — the successor data source to merge ratio.
+//
+// Git history cannot say whether work was accepted: squash merges erase
+// branch commits and deleted branches erase abandoned work, so discarded
+// outcomes vanish. Forge APIs keep them: a closed-unmerged PR is never
+// deleted.
+//
+// Two deliberate constraints:
+//   - **No author identity is ever stored.** AIDA compares cohorts, never
+//     people (#35). A PR record carries its number, terminal state, dates,
+//     and the attribution of its commits — nothing that names anyone.
+//   - **Attribution comes from the PR's own commit messages** as returned by
+//     the API, not from a join against local git. That is what makes this
+//     work for squash-merged PRs whose branches no longer exist.
+export const PR_STREAM_SCHEMA_VERSION = 1;
+
+export const PRCommit = z.object({
+  sha: z.string(),
+  tags: z.object({
+    ai: z.boolean(),
+    attribution: z.enum(['ai', 'human', 'automated', 'unknown']),
+    mode: z.enum(['none', 'autocomplete', 'assisted', 'agent', 'unknown']),
+    modeEvidence: z.enum(['declared', 'inferred', 'none']),
+    level: z.enum(['explicit', 'implicit', 'mention', 'none']),
+    sources: z.array(z.string()),
+  }),
+});
+
+export const PullRequest = z.object({
+  number: z.number().int().positive(),
+  // Terminal states only: open and draft PRs have no outcome yet and are
+  // excluded from both numerator and denominator.
+  state: z.enum(['merged', 'closed']),
+  createdAt: z.string().datetime(),
+  closedAt: z.string().datetime(),
+  mergedAt: z.string().datetime().nullable(),
+  commits: z.array(PRCommit),
+});
+
+export const PRStream = z.object({
+  schemaVersion: z.number().int().positive(),
+  provider: z.string(),
+  repo: z.string(),
+  fetchedAt: z.string().datetime(),
+  since: z.string().optional(),
+  // True when the fetch stopped at --max-prs: the sample is not the full
+  // history and acceptance rates must be read as partial.
+  truncated: z.boolean(),
+  prs: z.array(PullRequest),
+});
+
+export type PRCommit = z.infer<typeof PRCommit>;
+export type PullRequest = z.infer<typeof PullRequest>;
+export type PRStream = z.infer<typeof PRStream>;

--- a/packages/metrics/src/index.ts
+++ b/packages/metrics/src/index.ts
@@ -1,16 +1,26 @@
-import { Commit, CommitStream, METRICS_SCHEMA_VERSION, formatISODate } from '@aida-dev/core';
+import {
+  Commit,
+  CommitStream,
+  METRICS_SCHEMA_VERSION,
+  PRStream,
+  formatISODate,
+} from '@aida-dev/core';
 import { calculateAgeStats, calculateCategoryCounts } from './cohort.js';
 import { calculateBaselinePersistence, calculatePersistence } from './persistence.js';
+import { calculatePRAcceptance } from './pr-acceptance.js';
 import { Attribution, ByMode, Metrics, ModeStats } from './schema/metrics.js';
 
 export * from './schema/metrics.js';
 export * from './cohort.js';
 export * from './persistence.js';
+export * from './pr-acceptance.js';
 
 export interface MetricsOptions {
   // Prior applied to 'unknown' commits: which cohort (if any) they join.
   defaultAttribution?: 'ai' | 'human' | 'unknown';
   coverageThreshold?: number;
+  // Optional PR outcomes from `aida fetch-prs` (#51)
+  prStream?: PRStream | null;
 }
 
 function round(value: number, decimals: number): number {
@@ -22,7 +32,7 @@ export function calculateMetrics(
   commitStream: CommitStream,
   options: MetricsOptions = {}
 ): Metrics {
-  const { defaultAttribution = 'unknown', coverageThreshold = 0.7 } = options;
+  const { defaultAttribution = 'unknown', coverageThreshold = 0.7, prStream = null } = options;
 
   const counts = { ai: 0, human: 0, automated: 0, unknown: 0 };
   const modes = { none: 0, autocomplete: 0, assisted: 0, agent: 0, unknown: 0 };
@@ -119,6 +129,9 @@ export function calculateMetrics(
       }
     : null;
 
+  // PR acceptance (#51): present only when fetch-prs ran
+  const prAcceptance = prStream ? calculatePRAcceptance(prStream) : null;
+
   const caveats = [
     `Attribution coverage is ${(coverage * 100).toFixed(1)}%: metrics only describe commits whose provenance is known.`,
     'Persistence is file-level, not line-level.',
@@ -126,6 +139,16 @@ export function calculateMetrics(
     'Persistence comparisons are only meaningful between cohorts of similar age and task mix — check the cohorts section before reading the delta.',
     'AI tagging uses heuristic patterns; false positives/negatives possible.',
   ];
+  if (prAcceptance?.truncated) {
+    caveats.push(
+      'PR acceptance covers a capped sample of pull requests (--max-prs), not the full history.'
+    );
+  }
+  if (!prAcceptance) {
+    caveats.push(
+      "PR acceptance is unavailable: run 'aida fetch-prs' to measure whether AI work is accepted. Git history alone cannot answer that."
+    );
+  }
   if (baseline?.assumed) {
     caveats.push(
       `Baseline includes ${counts.unknown} unattributed commit(s) assumed human via defaultAttribution — undetected AI usage may leak into it.`
@@ -150,6 +173,7 @@ export function calculateMetrics(
     persistence,
     cohorts,
     byMode,
+    prAcceptance,
     baseline,
     delta,
     caveats,

--- a/packages/metrics/src/pr-acceptance.test.ts
+++ b/packages/metrics/src/pr-acceptance.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+import { PRCommit, PRStream, PullRequest } from '@aida-dev/core';
+import { calculatePRAcceptance, prAttribution, prMode } from './pr-acceptance.js';
+
+function commit(
+  attribution: PRCommit['tags']['attribution'],
+  mode: PRCommit['tags']['mode'] = 'unknown'
+): PRCommit {
+  return {
+    sha: 'a'.repeat(40),
+    tags: {
+      ai: attribution === 'ai',
+      attribution,
+      mode,
+      modeEvidence: mode === 'unknown' ? 'none' : 'inferred',
+      level: attribution === 'ai' ? 'explicit' : 'none',
+      sources: [],
+    },
+  };
+}
+
+function pr(number: number, state: 'merged' | 'closed', commits: PRCommit[]): PullRequest {
+  return {
+    number,
+    state,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    closedAt: '2026-01-02T00:00:00.000Z',
+    mergedAt: state === 'merged' ? '2026-01-02T00:00:00.000Z' : null,
+    commits,
+  };
+}
+
+function stream(prs: PullRequest[], truncated = false): PRStream {
+  return {
+    schemaVersion: 1,
+    provider: 'github',
+    repo: 'owner/name',
+    fetchedAt: '2026-01-03T00:00:00.000Z',
+    truncated,
+    prs,
+  };
+}
+
+describe('prAttribution', () => {
+  it('is ai when any authored commit is ai', () => {
+    expect(prAttribution(pr(1, 'merged', [commit('human'), commit('ai')]))).toBe('ai');
+  });
+
+  it('is human only when every authored commit is human', () => {
+    expect(prAttribution(pr(1, 'merged', [commit('human'), commit('human')]))).toBe('human');
+    expect(prAttribution(pr(1, 'merged', [commit('human'), commit('unknown')]))).toBe('unknown');
+  });
+
+  it('ignores automated commits when deciding', () => {
+    expect(prAttribution(pr(1, 'merged', [commit('automated'), commit('human')]))).toBe('human');
+  });
+
+  it('is unknown for a PR of only automated commits', () => {
+    expect(prAttribution(pr(1, 'merged', [commit('automated')]))).toBe('unknown');
+  });
+});
+
+describe('prMode', () => {
+  it('takes the highest autonomy present — the riskiest participation', () => {
+    expect(prMode(pr(1, 'merged', [commit('ai', 'autocomplete'), commit('ai', 'agent')]))).toBe(
+      'agent'
+    );
+    expect(prMode(pr(1, 'merged', [commit('ai', 'assisted'), commit('human', 'none')]))).toBe(
+      'assisted'
+    );
+  });
+
+  it('is unknown for an empty or automated-only PR', () => {
+    expect(prMode(pr(1, 'merged', [commit('automated', 'none')]))).toBe('unknown');
+  });
+});
+
+describe('calculatePRAcceptance', () => {
+  it('computes acceptance overall and per cohort, null for empty cohorts', () => {
+    const result = calculatePRAcceptance(
+      stream([
+        pr(1, 'merged', [commit('ai', 'agent')]),
+        pr(2, 'merged', [commit('ai', 'agent')]),
+        pr(3, 'closed', [commit('ai', 'agent')]),
+        pr(4, 'merged', [commit('human', 'none')]),
+      ])
+    );
+
+    expect(result.overall).toEqual({ total: 4, merged: 3, closed: 1, acceptanceRate: 0.75 });
+    expect(result.byAttribution.ai).toEqual({
+      total: 3,
+      merged: 2,
+      closed: 1,
+      acceptanceRate: 0.6667,
+    });
+    expect(result.byAttribution.human?.acceptanceRate).toBe(1);
+    expect(result.byAttribution.unknown).toBeNull();
+    expect(result.byMode.agent?.total).toBe(3);
+    expect(result.byMode.assisted).toBeNull();
+  });
+
+  it('counts closed-unmerged PRs — the outcome git history destroys', () => {
+    const result = calculatePRAcceptance(
+      stream([pr(1, 'closed', [commit('ai')]), pr(2, 'closed', [commit('ai')])])
+    );
+    expect(result.byAttribution.ai).toEqual({
+      total: 2,
+      merged: 0,
+      closed: 2,
+      acceptanceRate: 0,
+    });
+  });
+
+  it('carries provenance and the truncation flag through', () => {
+    const result = calculatePRAcceptance(stream([pr(1, 'merged', [commit('ai')])], true));
+    expect(result.provider).toBe('github');
+    expect(result.repo).toBe('owner/name');
+    expect(result.truncated).toBe(true);
+  });
+
+  it('handles an empty PR stream without inventing a rate', () => {
+    const result = calculatePRAcceptance(stream([]));
+    expect(result.overall.total).toBe(0);
+    expect(result.byAttribution.ai).toBeNull();
+  });
+});

--- a/packages/metrics/src/pr-acceptance.ts
+++ b/packages/metrics/src/pr-acceptance.ts
@@ -1,0 +1,68 @@
+import { PRStream, PullRequest } from '@aida-dev/core';
+import { AcceptanceStats, PRAcceptance } from './schema/metrics.js';
+
+// PR acceptance (#51): the successor to merge ratio. Unlike git history, a
+// forge keeps closed-unmerged PRs, so the negative outcome is observable.
+
+// A PR's attribution is the strongest AI signal among its commits: if any
+// commit is AI-attributed, AI participated in that PR. Automated commits
+// (merge commits inside the branch) are ignored — they are not authored work.
+export function prAttribution(pr: PullRequest): 'ai' | 'human' | 'unknown' {
+  const authored = pr.commits.filter((c) => c.tags.attribution !== 'automated');
+  if (authored.length === 0) return 'unknown';
+  if (authored.some((c) => c.tags.attribution === 'ai')) return 'ai';
+  if (authored.every((c) => c.tags.attribution === 'human')) return 'human';
+  return 'unknown';
+}
+
+const MODE_RANK = { agent: 4, assisted: 3, autocomplete: 2, none: 1, unknown: 0 } as const;
+type Mode = keyof typeof MODE_RANK;
+
+// A PR's mode is the highest autonomy level present in it: the riskiest kind
+// of participation is what characterizes the change.
+export function prMode(pr: PullRequest): Mode {
+  const authored = pr.commits.filter((c) => c.tags.attribution !== 'automated');
+  return authored.reduce<Mode>(
+    (highest, c) => (MODE_RANK[c.tags.mode] > MODE_RANK[highest] ? c.tags.mode : highest),
+    'unknown'
+  );
+}
+
+function stats(prs: PullRequest[]): AcceptanceStats | null {
+  if (prs.length === 0) return null;
+  const merged = prs.filter((pr) => pr.state === 'merged').length;
+  return {
+    total: prs.length,
+    merged,
+    closed: prs.length - merged,
+    acceptanceRate: Math.round((merged / prs.length) * 10000) / 10000,
+  };
+}
+
+export function calculatePRAcceptance(prStream: PRStream): PRAcceptance {
+  const { prs } = prStream;
+
+  const byAttribution = {
+    ai: stats(prs.filter((pr) => prAttribution(pr) === 'ai')),
+    human: stats(prs.filter((pr) => prAttribution(pr) === 'human')),
+    unknown: stats(prs.filter((pr) => prAttribution(pr) === 'unknown')),
+  };
+
+  const byMode = {
+    agent: stats(prs.filter((pr) => prMode(pr) === 'agent')),
+    assisted: stats(prs.filter((pr) => prMode(pr) === 'assisted')),
+    autocomplete: stats(prs.filter((pr) => prMode(pr) === 'autocomplete')),
+    none: stats(prs.filter((pr) => prMode(pr) === 'none')),
+    unknown: stats(prs.filter((pr) => prMode(pr) === 'unknown')),
+  };
+
+  return {
+    provider: prStream.provider,
+    repo: prStream.repo,
+    fetchedAt: prStream.fetchedAt,
+    truncated: prStream.truncated,
+    overall: stats(prs) ?? { total: 0, merged: 0, closed: 0, acceptanceRate: 0 },
+    byAttribution,
+    byMode,
+  };
+}

--- a/packages/metrics/src/schema/metrics.ts
+++ b/packages/metrics/src/schema/metrics.ts
@@ -112,6 +112,36 @@ export const ByMode = z.object({
   unknown: ModeStats.nullable(),
 });
 
+// PR acceptance (#51): merged vs closed-unmerged, per cohort. Null when no
+// pr-stream.json is present — an absent metric, never a silent 0%.
+export const AcceptanceStats = z.object({
+  total: z.number().int().nonnegative(),
+  merged: z.number().int().nonnegative(),
+  closed: z.number().int().nonnegative(),
+  acceptanceRate: z.number().min(0).max(1),
+});
+
+export const PRAcceptance = z.object({
+  provider: z.string(),
+  repo: z.string(),
+  fetchedAt: z.string().datetime(),
+  // True when the fetch was capped: rates describe a sample, not all history
+  truncated: z.boolean(),
+  overall: AcceptanceStats,
+  byAttribution: z.object({
+    ai: AcceptanceStats.nullable(),
+    human: AcceptanceStats.nullable(),
+    unknown: AcceptanceStats.nullable(),
+  }),
+  byMode: z.object({
+    agent: AcceptanceStats.nullable(),
+    assisted: AcceptanceStats.nullable(),
+    autocomplete: AcceptanceStats.nullable(),
+    none: AcceptanceStats.nullable(),
+    unknown: AcceptanceStats.nullable(),
+  }),
+});
+
 export const Metrics = z.object({
   // Bumped when a field is removed or changes meaning (#53)
   schemaVersion: z.number().int().positive(),
@@ -131,6 +161,8 @@ export const Metrics = z.object({
     baseline: CohortContext,
   }),
   byMode: ByMode,
+  // Null unless `aida fetch-prs` produced a pr-stream.json (#51)
+  prAcceptance: PRAcceptance.nullable(),
   // Null when no commit is attributed 'human' and no defaultAttribution prior
   // assigns the unknowns: AIDA does not invent a comparison cohort.
   baseline: Baseline.nullable(),
@@ -145,6 +177,8 @@ export type CategoryCounts = z.infer<typeof CategoryCounts>;
 export type CohortContext = z.infer<typeof CohortContext>;
 export type ModeStats = z.infer<typeof ModeStats>;
 export type ByMode = z.infer<typeof ByMode>;
+export type AcceptanceStats = z.infer<typeof AcceptanceStats>;
+export type PRAcceptance = z.infer<typeof PRAcceptance>;
 export type Persistence = z.infer<typeof Persistence>;
 export type Baseline = z.infer<typeof Baseline>;
 export type Delta = z.infer<typeof Delta>;


### PR DESCRIPTION
Closes #51. The honest successor to the merge ratio removed in #20.

## Design (as agreed: separate command)

`aida fetch-prs` is **the only command in AIDA that touches the network**, deliberately isolated so `collect` stays git-only and offline — the "nothing leaves your machine" promise remains verifiable by simply not running it. Without `GITHUB_TOKEN` it refuses to run, and PR acceptance is **absent** from the report rather than a silent 0%.

## The key decision: attribution without git

PRs are attributed from **their own commit messages as returned by the API**, not from a join against local `commit-stream.json`. This matters: a squash-merged PR's original commits no longer exist in git, so a local join would fail exactly in the case that broke merge ratio. Going through the API sidesteps it entirely.

## Privacy

`pr-stream.json` stores PR numbers, terminal states, dates, and the attribution of the PR's commits. **No author identity is ever fetched or stored** — consistent with the #35 principle. Rate-limit exhaustion produces a distinct actionable error; token patterns are scrubbed from any API error surfaced.

## Dogfood — an honest null result

Ran against this repo (31 closed PRs):

| Cohort | PRs | Merged | Closed unmerged | Acceptance |
|---|---:|---:|---:|---:|
| **All PRs** | 31 | 31 | 0 | 100.0% |
| ai | 11 | 11 | 0 | 100.0% |
| unknown | 20 | 20 | 0 | 100.0% |
| mode: agent | 11 | 11 | 0 | 100.0% |

**100% acceptance, because this repo has never closed a PR unmerged** (single maintainer, no rejected contributions). So the metric discriminates nothing *here* — but unlike merge ratio, that is a property of the repo, not of the measurement: the denominator is honest, and a closed PR would be counted. The unit tests cover the rejected-PR path explicitly.

Also visible: 20 PRs read `unknown` because their commits predate trailers. The attribution manifest can't help at PR level — entries are keyed by hash and a squash-merged PR's commits have different hashes from what landed on main. Documented as a known limit.

## Testing

125 tests pass (core 78, metrics 37, cli 10). New: PR attribution/mode rules, acceptance math including the all-rejected case, empty stream, truncation flag; e2e for absent-vs-present PR data, report rendering, and the no-token refusal. Typecheck and lint clean.

Co-Authored-By: Claude <noreply@anthropic.com>