### PR TITLE
proposal: squash-merge detection via git patch-id (#20)

### DIFF
--- a/packages/cli/src/commands/collect.ts
+++ b/packages/cli/src/commands/collect.ts
@@ -32,6 +32,10 @@ export function createCollectCommand(): Command {
     .option('--ai-bot-blocklist <name>', 'Non-AI bot to exclude from trailer matching (repeatable)', collectRepeatable, [])
     .option('--default-branch <name>', 'Default branch name')
     .option(
+      '--detect-squash-merges',
+      'Match unmerged commits against squashed ones by patch-id (proposal for #20)'
+    )
+    .option(
       '--redact-authors',
       'Replace author/committer identities with a per-run salted hash (recommended in CI)'
     )
@@ -86,6 +90,7 @@ export function createCollectCommand(): Command {
           defaultBranch: config.defaultBranch,
           // CLI flag wins over .aida.json
           redactAuthors: config.redactAuthors ?? fileConfig.redactAuthors ?? false,
+          detectSquashMerges: Boolean(options.detectSquashMerges),
           logger,
         });
 

--- a/packages/core/src/git/collect.ts
+++ b/packages/core/src/git/collect.ts
@@ -11,6 +11,7 @@ import {
 } from '../tags/attribution-manifest.js';
 import { createRedactor } from '../tags/redact.js';
 import { logWithStats } from './log.js';
+import { computePatchIds, findSquashMatch } from './patch-id.js';
 import { parseRelativeDate, formatISODate } from '../utils/dates.js';
 import { Logger } from '../utils/log.js';
 
@@ -25,6 +26,8 @@ export interface CollectOptions {
   aiBotBlocklist?: string[];
   defaultBranch?: string;
   redactAuthors?: boolean;
+  // Proposal for #20: match unmerged commits against squashed ones by patch-id
+  detectSquashMerges?: boolean;
   logger?: Logger;
 }
 
@@ -75,6 +78,7 @@ export async function collectCommits(options: CollectOptions): Promise<CommitStr
     aiBotBlocklist = [],
     defaultBranch: providedDefaultBranch,
     redactAuthors = false,
+    detectSquashMerges = false,
     logger,
   } = options;
 
@@ -155,6 +159,16 @@ export async function collectCommits(options: CollectOptions): Promise<CommitStr
   const manifest = await loadAttributionManifest(repoPath, logger);
   const manifestIndex = manifest ? indexManifest(manifest) : null;
 
+  // Squash-merge detection (proposal for #20): patch-ids of the default
+  // branch, to match against commits that are not ancestors of it.
+  let defaultBranchPatchIds = null;
+  let allPatchIds = null;
+  if (detectSquashMerges && !diffBase) {
+    logger?.info('Computing patch-ids for squash-merge detection...');
+    defaultBranchPatchIds = await computePatchIds(repoPath, defaultBranch);
+    allPatchIds = await computePatchIds(repoPath, '--all');
+  }
+
   // Author redaction (#35). Applied last: identity-based detection above
   // must see the real values.
   const redactor = redactAuthors ? createRedactor() : null;
@@ -212,6 +226,12 @@ export async function collectCommits(options: CollectOptions): Promise<CommitStr
       message: rawCommit.message.split('\n')[0],
       parents: rawCommit.parents,
       inDefaultBranchAncestry: defaultBranchHashes.has(rawCommit.hash),
+      mergedVia: defaultBranchHashes.has(rawCommit.hash)
+        ? 'ancestry'
+        : allPatchIds && defaultBranchPatchIds &&
+            findSquashMatch(rawCommit.hash, allPatchIds, defaultBranchPatchIds)
+          ? 'patch-id'
+          : null,
       tags: aiTag,
       stats: rawCommit.stats,
     };

--- a/packages/core/src/git/patch-id.test.ts
+++ b/packages/core/src/git/patch-id.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execSync } from 'child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { collectCommits } from './collect.js';
+import { computePatchIds, findSquashMatch } from './patch-id.js';
+
+// Proposal for #20: can patch-id recover squash-merged commits that an
+// ancestry check reports as unmerged?
+
+let repoPath: string;
+let squashedCommit: string;
+let multiCommitA: string;
+
+function git(cmd: string) {
+  execSync(cmd, { cwd: repoPath });
+}
+
+beforeAll(() => {
+  repoPath = mkdtempSync(join(tmpdir(), 'aida-squash-'));
+  git('git init -q -b main');
+  git('git config user.name test && git config user.email test@example.com');
+
+  writeFileSync(join(repoPath, 'base.txt'), 'base\n');
+  git('git add -A && git commit -q -m "chore: base"');
+
+  // Branch A: a single commit, squash-merged into main
+  git('git checkout -q -b feature-single');
+  writeFileSync(join(repoPath, 'single.txt'), 'one change\n');
+  git('git add -A && git commit -q -m "feat: single-commit branch"');
+  squashedCommit = execSync('git rev-parse HEAD', { cwd: repoPath }).toString().trim();
+
+  git('git checkout -q main');
+  git('git merge -q --squash feature-single');
+  git('git commit -q -m "feat: single-commit branch (#1)"');
+
+  // Branch B: two commits, squash-merged into one — the hard case
+  git('git checkout -q -b feature-multi');
+  writeFileSync(join(repoPath, 'multi.txt'), 'first\n');
+  git('git add -A && git commit -q -m "feat: part one"');
+  multiCommitA = execSync('git rev-parse HEAD', { cwd: repoPath }).toString().trim();
+  writeFileSync(join(repoPath, 'multi.txt'), 'first\nsecond\n');
+  git('git add -A && git commit -q -m "feat: part two"');
+
+  git('git checkout -q main');
+  git('git merge -q --squash feature-multi');
+  git('git commit -q -m "feat: multi-commit branch (#2)"');
+});
+
+afterAll(() => {
+  rmSync(repoPath, { recursive: true, force: true });
+});
+
+describe('patch-id squash detection', () => {
+  it('recovers a single-commit squash that ancestry reports as unmerged', async () => {
+    const stream = await collectCommits({ repoPath, detectSquashMerges: true });
+    const commit = stream.commits.find((c) => c.hash === squashedCommit);
+
+    expect(commit).toBeDefined();
+    // The branch commit is genuinely not an ancestor of main...
+    expect(commit!.inDefaultBranchAncestry).toBe(false);
+    // ...but its diff matches the squashed commit
+    expect(commit!.mergedVia).toBe('patch-id');
+  });
+
+  it('does NOT recover commits from a multi-commit squash', async () => {
+    const stream = await collectCommits({ repoPath, detectSquashMerges: true });
+    const commit = stream.commits.find((c) => c.hash === multiCommitA);
+
+    expect(commit).toBeDefined();
+    // The squashed commit contains BOTH commits' changes, so its patch-id
+    // matches neither one individually. This is the limit of the approach.
+    expect(commit!.mergedVia).toBeNull();
+  });
+
+  it('is off by default: no patch-id cost unless asked for', async () => {
+    const stream = await collectCommits({ repoPath });
+    const commit = stream.commits.find((c) => c.hash === squashedCommit);
+    expect(commit!.mergedVia).toBeNull();
+  });
+
+  it('computes stable patch ids keyed by commit sha', async () => {
+    const ids = await computePatchIds(repoPath, 'main');
+    expect(ids.bySha.size).toBeGreaterThan(0);
+    for (const [sha, patchId] of ids.bySha) {
+      expect(sha).toMatch(/^[0-9a-f]{40}$/);
+      expect(patchId).toMatch(/^[0-9a-f]{40}$/);
+    }
+  });
+
+  it('returns null when a sha has no patch (e.g. an empty commit)', async () => {
+    const branchIds = await computePatchIds(repoPath, '--all');
+    const mainIds = await computePatchIds(repoPath, 'main');
+    expect(findSquashMatch('0'.repeat(40), branchIds, mainIds)).toBeNull();
+  });
+});

--- a/packages/core/src/git/patch-id.ts
+++ b/packages/core/src/git/patch-id.ts
@@ -1,0 +1,60 @@
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+// Squash-merge detection via `git patch-id` (proposal for #20).
+//
+// With a squash-merge workflow, the branch commits never become ancestors of
+// the default branch: their content lands as a single new commit with a new
+// hash. An ancestry check therefore reports them as unmerged.
+//
+// `git patch-id --stable` hashes a diff independently of commit metadata, so
+// a branch commit and the squashed commit that contains its changes *can*
+// produce the same id — when the squash contains exactly one commit's worth
+// of changes. That caveat is the crux of this proposal: see the PR discussion.
+
+export interface PatchIdMap {
+  // patch-id → commit shas that produce it
+  byPatchId: Map<string, string[]>;
+  bySha: Map<string, string>;
+}
+
+// `git log -p | git patch-id` streams one "<patchId> <commitSha>" line per
+// commit, which is far cheaper than spawning a process per commit.
+export async function computePatchIds(repoPath: string, revRange: string): Promise<PatchIdMap> {
+  const byPatchId = new Map<string, string[]>();
+  const bySha = new Map<string, string>();
+
+  // maxBuffer raised: `log -p` over a long history is large
+  const { stdout } = await execAsync(
+    `git log -p --no-merges --no-color ${revRange} | git patch-id --stable`,
+    { cwd: repoPath, maxBuffer: 256 * 1024 * 1024 }
+  );
+
+  for (const line of stdout.split('\n')) {
+    const [patchId, sha] = line.trim().split(/\s+/);
+    if (!patchId || !sha) continue;
+    bySha.set(sha, patchId);
+    const existing = byPatchId.get(patchId);
+    if (existing) {
+      existing.push(sha);
+    } else {
+      byPatchId.set(patchId, [sha]);
+    }
+  }
+
+  return { byPatchId, bySha };
+}
+
+// Returns the sha of the default-branch commit whose patch matches, if any.
+export function findSquashMatch(
+  sha: string,
+  branchIds: PatchIdMap,
+  defaultBranchIds: PatchIdMap
+): string | null {
+  const patchId = branchIds.bySha.get(sha);
+  if (!patchId) return null;
+  const matches = defaultBranchIds.byPatchId.get(patchId);
+  return matches?.[0] ?? null;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,6 +5,7 @@ export * from './schema/stream.js';
 export * from './git/collect.js';
 export * from './git/diff.js';
 export * from './git/log.js';
+export * from './git/patch-id.js';
 export * from './tags/ai-tags.js';
 export * from './tags/attribution-manifest.js';
 export * from './tags/automated.js';

--- a/packages/core/src/schema/commit.ts
+++ b/packages/core/src/schema/commit.ts
@@ -18,6 +18,10 @@ export const Commit = z.object({
   message: z.string(),
   parents: z.array(z.string()),
   inDefaultBranchAncestry: z.boolean(), // set during collect
+  // How the commit was found on the default branch (proposal for #20):
+  // 'ancestry' = reachable from it; 'patch-id' = its diff matches a squashed
+  // commit; null = not found. Additive, so schemaVersion stays 1 (#53).
+  mergedVia: z.enum(['ancestry', 'patch-id']).nullable().default(null),
   tags: z.object({
     ai: z.boolean(),
     // Four-state attribution (#34, #39). Heuristics emit 'ai' or 'unknown';

--- a/packages/metrics/src/cohort.test.ts
+++ b/packages/metrics/src/cohort.test.ts
@@ -14,6 +14,7 @@ function makeCommit(authorDate: string, files: string[] = []): Commit {
     message: 'commit',
     parents: [],
     inDefaultBranchAncestry: true,
+    mergedVia: 'ancestry',
     tags: { ai: false, attribution: 'unknown', mode: 'unknown', modeEvidence: 'none', level: 'none', sources: [] },
     stats: {
       totalAdditions: 1,

--- a/packages/metrics/src/index.test.ts
+++ b/packages/metrics/src/index.test.ts
@@ -13,6 +13,7 @@ function makeCommit(overrides: Partial<Commit> & { hash: string }): Commit {
     message: 'commit',
     parents: [],
     inDefaultBranchAncestry: true,
+    mergedVia: 'ancestry',
     tags: { ai: false, attribution: 'unknown', mode: 'unknown', modeEvidence: 'none', level: 'none', sources: [] },
     stats: { totalAdditions: 1, totalDeletions: 0, files: [] },
     ...overrides,

--- a/packages/metrics/src/persistence.test.ts
+++ b/packages/metrics/src/persistence.test.ts
@@ -14,6 +14,7 @@ function makeCommit(overrides: Partial<CommitStream['commits'][0]>): CommitStrea
     message: 'test commit',
     parents: [],
     inDefaultBranchAncestry: true,
+    mergedVia: 'ancestry',
     tags: { ai: false, attribution: 'unknown' as const, mode: 'unknown' as const, modeEvidence: 'none' as const, level: 'none', sources: [] },
     stats: { totalAdditions: 10, totalDeletions: 0, files: [] },
     ...overrides,


### PR DESCRIPTION
**This is a proposal for discussion, not a merge request.** It implements what [#20](https://github.com/ceccode/AIDA-Metrics/issues/20) originally asked for — and what the r/devtools thread flagged as our biggest known bug — so we can decide on evidence instead of argument.

## What it does

`git patch-id --stable` hashes a diff independently of commit metadata, so a branch commit and the squashed commit containing its changes can produce the same id. Opt-in via `--detect-squash-merges`; adds `mergedVia: 'ancestry' | 'patch-id' | null` to each commit (additive — `schemaVersion` stays 1, which is the #53 contract working as intended).

## It works better than I expected

Run on this repo (111 commits, squash-merge workflow):

| | commits |
|---|---:|
| Found via ancestry | 91 |
| **Recovered via patch-id** | **17** |
| Still unmerged | 3 |

**17 of the 20 previously-"unmerged" commits were recovered**, and the 3 remaining are genuinely unmerged (one is PR #58, still open). The multi-commit squash case fails as expected — a squash containing two commits matches neither individually — and there is a test documenting exactly that.

So: the technique is sound and the squash bug is largely fixable.

## Why I'm still proposing we reject it

Look at what the metric would say **after** the fix: 108 of 111 commits merged = **97.3%**.

That is the whole problem, and this PR is the proof. Fixing squash detection removes one source of error but not the structural one: **abandoned branches get deleted**, so work that was discarded leaves `git log --all` entirely and can never appear in the denominator. The ratio converges to ~100% for every healthy repo regardless of code quality — it measures whether you delete stale branches, not whether AI code is good.

We removed merge ratio in #20 for exactly this reason, and replaced it with PR acceptance from the forge API (#51), where a closed-unmerged PR is never deleted. That metric can distinguish outcomes; this one cannot, however well the plumbing works.

## Recommendation

**Close unmerged.** The code and the numbers stay here as the documented answer for the next person who proposes restoring merge ratio: the squash fix is feasible, it just doesn't rescue the metric.

If we ever want `mergedVia` for other purposes (e.g. more accurate persistence cohorts for squash-heavy repos), it can be reproposed on its own merits — untied to merge ratio.

Co-Authored-By: Claude <noreply@anthropic.com>