### PR TITLE
feat: commit-time mode stamping via git hooks (#61)

### DIFF
--- a/.changeset/commit-time-hooks.md
+++ b/.changeset/commit-time-hooks.md
@@ -1,0 +1,12 @@
+---
+'@aida-dev/core': minor
+'@aida-dev/cli': minor
+---
+
+Commit-time mode stamping via git hook (#61)
+
+The attribution manifest (#10) declares provenance retroactively; this declares it at the source, turning `declared` evidence from the exception into the norm — the prerequisite for making autonomy the primary axis (#25 step 3).
+
+- **`AI-Mode:` trailer** (`none` | `autocomplete` | `assisted` | `agent`) parsed as `mode` with `modeEvidence: declared`, beating tool inference. `AI-Mode: none` is the first mechanism that declares *human* authorship at commit time, without a manifest.
+- **`aida install-hooks`** writes a `prepare-commit-msg` hook: self-contained POSIX shell (no dependency on `aida` at commit time), idempotent, refuses to overwrite a hook it didn't write unless `--force`, `--uninstall` removes only its own marked block, and it can never block a commit.
+- **Mode resolution**: `AIDA_MODE` env var → known agent environment detection → `defaultMode` in `.aida.json` → nothing. An unknown mode writes no trailer: absence honestly means unknown, a guess would be a fabricated declaration.

--- a/README.md
+++ b/README.md
@@ -143,6 +143,14 @@ Collect commits and generate normalized commit stream:
 aida collect --since 90d --out-dir ./aida-output
 ```
 
+#### `aida install-hooks`
+
+Install the commit-time mode stamping hook:
+
+```bash
+aida install-hooks
+```
+
 #### `aida fetch-prs`
 
 Fetch pull request outcomes from the forge API (**opt-in, the only command that uses the network**):
@@ -195,6 +203,13 @@ aida report --out-dir ./aida-output
 - `--out-dir <path>` - Output directory (default: ./aida-output)
 - `--verbose` - Verbose logging
 
+#### `aida install-hooks`
+
+- `--repo <path>` - Repository path (default: current directory)
+- `--force` - Overwrite an existing unrelated hook
+- `--uninstall` - Remove the AIDA hook block
+- `--verbose` - Verbose logging
+
 #### `aida fetch-prs`
 
 - `--github-repo <owner/name>` - GitHub repository (default: `$GITHUB_REPOSITORY`)
@@ -244,6 +259,40 @@ Non-AI automation bots (`dependabot`, `renovate`, `github-actions`, `greenkeeper
 ### Supported Tools (built-in)
 
 `copilot`, `cursor`, `windsurf`, `codeium`, `claude`, `chatgpt`, `gemini`
+
+### Commit-Time Mode Stamping (git hook)
+
+The manifest is retroactive; a hook is **prospective** — it declares provenance at the moment the commit is made, turning `declared` from the exception into the norm ([#61](https://github.com/ceccode/AIDA-Metrics/issues/61)).
+
+```bash
+aida install-hooks          # writes .git/hooks/prepare-commit-msg
+aida install-hooks --uninstall
+```
+
+The hook appends an `AI-Mode:` trailer when the mode is known:
+
+```
+feat: add rate limiting
+
+AI-Mode: agent
+```
+
+| Mode | Meaning |
+|------|---------|
+| `none` | Hand-written — the only mechanism that declares **human** authorship at commit time |
+| `autocomplete` | Line-level suggestions |
+| `assisted` | Supervised pair-programming |
+| `agent` | Autonomous, multi-file work |
+
+Resolution order: **`AIDA_MODE`** env var (explicit and reliable — set it in your agent, wrapper, or shell alias) → auto-detection of known agent environments (best-effort convenience) → `defaultMode` in `.aida.json` → **nothing**. When the mode is unknown the hook writes no trailer at all: an absent declaration honestly means unknown, while a guessed one would be a fabrication.
+
+```bash
+AIDA_MODE=agent git commit -m "feat: ..."
+```
+
+The hook is self-contained POSIX shell with no dependency on `aida` being installed, never blocks a commit whatever happens inside it, refuses to overwrite a hook it didn't write (unless `--force`), and removes only its own block on uninstall.
+
+**Honest limit**: a hook is voluntary and local to each clone. It shrinks the unknown bucket, it does not eliminate it — someone who doesn't install it, or unsets the variable, is invisible to it.
 
 ### Attribution Manifest (`aida-attribution.json`)
 
@@ -311,6 +360,7 @@ Place a `.aida.json` file in your project root to add custom tools, trailer doma
 | `patterns` | Raw regex patterns (treated as explicit) |
 | `defaultAttribution` | Prior applied to unattributed commits at analysis time: `ai`, `human`, or `unknown` (default). With `unknown`, unattributed commits join no cohort — AIDA does not invent a comparison. This repo sets `ai`: it is AI-written with human review. |
 | `coverageThreshold` | Attribution coverage below this fraction (default `0.7`) flags all metrics as low-confidence |
+| `defaultMode` | Autonomy mode the commit hook stamps when nothing else determines it: `none` \| `autocomplete` \| `assisted` \| `agent` ([#61](https://github.com/ceccode/AIDA-Metrics/issues/61)). Absent means leave unknown rather than guess |
 | `redactAuthors` | Replace author/committer identities in `commit-stream.json` with a per-run salted hash (default `false`; recommended in CI) |
 
 ### CLI Flags
@@ -496,7 +546,8 @@ aida_analysis:
 - **v0.15** ✅ Author redaction ([#35](https://github.com/ceccode/AIDA-Metrics/issues/35)) and synthetic PR merge commit fix ([#40](https://github.com/ceccode/AIDA-Metrics/issues/40)).  
 - **v0.16** ✅ Versioned output schemas with reader-side version gate, plus end-to-end CLI tests and `pnpm typecheck` in CI ([#53](https://github.com/ceccode/AIDA-Metrics/issues/53)).  
 - **v0.17** ✅ PR acceptance rate via forge APIs — opt-in `aida fetch-prs`, the honest successor to merge ratio ([#51](https://github.com/ceccode/AIDA-Metrics/issues/51)).  
-- **Next** → Autonomy as primary axis ([#25](https://github.com/ceccode/AIDA-Metrics/issues/25) step 3), windowed coverage ([#52](https://github.com/ceccode/AIDA-Metrics/issues/52)), GitLab ([#16](https://github.com/ceccode/AIDA-Metrics/issues/16)) / Bitbucket ([#17](https://github.com/ceccode/AIDA-Metrics/issues/17)) PR providers.  
+- **v0.18** ✅ Commit-time mode stamping via git hook — `AI-Mode` trailer, `declared` evidence at the source ([#61](https://github.com/ceccode/AIDA-Metrics/issues/61)).  
+- **Next** → Autonomy as primary axis ([#25](https://github.com/ceccode/AIDA-Metrics/issues/25) step 3, once declared data accumulates), windowed coverage ([#52](https://github.com/ceccode/AIDA-Metrics/issues/52)), GitLab ([#16](https://github.com/ceccode/AIDA-Metrics/issues/16)) / Bitbucket ([#17](https://github.com/ceccode/AIDA-Metrics/issues/17)) PR providers.  
 - **Next** → Rework rate ([#22](https://github.com/ceccode/AIDA-Metrics/issues/22)), line-level persistence via blame ([#23](https://github.com/ceccode/AIDA-Metrics/issues/23)).  
 - **Next** → Outcome correlation ([#26](https://github.com/ceccode/AIDA-Metrics/issues/26)), cost metrics ([#27](https://github.com/ceccode/AIDA-Metrics/issues/27)).  
 - **Next** → GitLab ([#16](https://github.com/ceccode/AIDA-Metrics/issues/16)) and Bitbucket ([#17](https://github.com/ceccode/AIDA-Metrics/issues/17)) PR comment providers.  
@@ -509,7 +560,7 @@ In an AI-first world, "was this commit written by AI?" is becoming the wrong que
 - **Three-state attribution** — `ai` / `human` / `unknown` instead of forcing unattributed commits into a binary bucket ([#34](https://github.com/ceccode/AIDA-Metrics/issues/34)). Attribution **coverage** becomes the headline metric ("62% attributed · 38% unknown" is a data-quality signal, not something to hide inside a default) — because the unknown bucket grows fastest exactly where the numbers are taken most seriously. A configurable `defaultAttribution` prior will let AI-first teams opt into "AI unless stated otherwise" — consciously, instead of the tool silently assuming either way.
 - **Quality over adoption** — the durable question is not "how much code is AI?" but "does AI code hold up?": rework rate ([#22](https://github.com/ceccode/AIDA-Metrics/issues/22)), line-level survival ([#23](https://github.com/ceccode/AIDA-Metrics/issues/23)), outcome correlation ([#26](https://github.com/ceccode/AIDA-Metrics/issues/26)).
 - **Autonomy over the binary** — autocomplete vs assisted vs agent ([#25](https://github.com/ceccode/AIDA-Metrics/issues/25)) is the axis that will replace AI/non-AI.
-- **Shrink the unknown at the source** — the attribution manifest ([#10](https://github.com/ceccode/AIDA-Metrics/issues/10), shipped) makes attribution declarative; commit-time stamping via git hooks will make it automatic.
+- **Shrink the unknown at the source** — the attribution manifest ([#10](https://github.com/ceccode/AIDA-Metrics/issues/10)) makes attribution declarative retroactively; commit-time stamping via git hooks ([#61](https://github.com/ceccode/AIDA-Metrics/issues/61)) makes it automatic going forward. Both shipped.
 - **Cohorts, not people** — AIDA compares groups of commits, never developers. No per-author aggregation will ever ship, and author identity can be redacted from output artifacts ([#35](https://github.com/ceccode/AIDA-Metrics/issues/35), shipped) so the data model doesn't hand anyone a leaderboard for free.
 
 ## Contributing

--- a/packages/cli/src/commands/install-hooks.test.ts
+++ b/packages/cli/src/commands/install-hooks.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { execSync } from 'child_process';
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync, statSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import type { Command } from 'commander';
+import { createInstallHooksCommand } from './install-hooks.js';
+import { createCollectCommand } from './collect.js';
+
+let repoPath: string;
+
+// The suite may itself run inside an agent environment (it did during
+// development: the hook correctly detected Claude Code and stamped every
+// commit). Tests must therefore control detection inputs explicitly.
+const DETECTION_VARS = ['AIDA_MODE', 'CLAUDECODE', 'CLAUDE_CODE_ENTRYPOINT', 'CURSOR_TRACE_ID'];
+
+function git(cmd: string, env: Record<string, string> = {}) {
+  const clean = { ...process.env };
+  for (const key of DETECTION_VARS) delete clean[key];
+  execSync(cmd, { cwd: repoPath, env: { ...clean, ...env } });
+}
+
+function run(command: Command, args: string[]): Promise<Command> {
+  return command.parseAsync(args, { from: 'user' });
+}
+
+function hookPath(): string {
+  return join(repoPath, '.git', 'hooks', 'prepare-commit-msg');
+}
+
+beforeEach(() => {
+  repoPath = mkdtempSync(join(tmpdir(), 'aida-hooks-'));
+  git('git init -q -b main');
+  git('git config user.name test && git config user.email test@example.com');
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  rmSync(repoPath, { recursive: true, force: true });
+});
+
+describe('aida install-hooks', () => {
+  it('installs an executable hook', async () => {
+    await run(createInstallHooksCommand(), ['--repo', repoPath]);
+
+    expect(existsSync(hookPath())).toBe(true);
+    expect(statSync(hookPath()).mode & 0o111).toBeTruthy();
+    expect(readFileSync(hookPath(), 'utf-8')).toContain('AI-Mode');
+  });
+
+  it('is idempotent', async () => {
+    await run(createInstallHooksCommand(), ['--repo', repoPath]);
+    const first = readFileSync(hookPath(), 'utf-8');
+    await run(createInstallHooksCommand(), ['--repo', repoPath]);
+    expect(readFileSync(hookPath(), 'utf-8')).toBe(first);
+  });
+
+  it('refuses to clobber a hook it did not write', async () => {
+    writeFileSync(hookPath(), '#!/bin/sh\necho mine\n', { mode: 0o755 });
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit');
+    });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(run(createInstallHooksCommand(), ['--repo', repoPath])).rejects.toThrow(
+      'process.exit'
+    );
+    expect(errorSpy.mock.calls.flat().join(' ')).toContain('not written by AIDA');
+    // The foreign hook is untouched
+    expect(readFileSync(hookPath(), 'utf-8')).toContain('echo mine');
+
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('overwrites a foreign hook only with --force', async () => {
+    writeFileSync(hookPath(), '#!/bin/sh\necho mine\n', { mode: 0o755 });
+    await run(createInstallHooksCommand(), ['--repo', repoPath, '--force']);
+    expect(readFileSync(hookPath(), 'utf-8')).toContain('AI-Mode');
+  });
+
+  it('uninstalls what it installed', async () => {
+    await run(createInstallHooksCommand(), ['--repo', repoPath]);
+    await run(createInstallHooksCommand(), ['--repo', repoPath, '--uninstall']);
+    expect(existsSync(hookPath())).toBe(false);
+  });
+
+  it('uninstall is a no-op when no AIDA hook is present', async () => {
+    writeFileSync(hookPath(), '#!/bin/sh\necho mine\n', { mode: 0o755 });
+    await run(createInstallHooksCommand(), ['--repo', repoPath, '--uninstall']);
+    expect(readFileSync(hookPath(), 'utf-8')).toContain('echo mine');
+  });
+});
+
+describe('the installed hook, running for real', () => {
+  beforeEach(async () => {
+    await run(createInstallHooksCommand(), ['--repo', repoPath]);
+  });
+
+  it('stamps AI-Mode from AIDA_MODE and collect reads it as declared', async () => {
+    git('git commit -q --allow-empty -m "feat: agent work"', { AIDA_MODE: 'agent' });
+
+    const message = execSync('git log -1 --format=%B', { cwd: repoPath }).toString();
+    expect(message).toContain('AI-Mode: agent');
+
+    const outDir = mkdtempSync(join(tmpdir(), 'aida-hooks-out-'));
+    try {
+      await run(createCollectCommand(), ['--repo', repoPath, '--out-dir', outDir]);
+      const stream = JSON.parse(readFileSync(join(outDir, 'commit-stream.json'), 'utf-8'));
+      const commit = stream.commits[0];
+      expect(commit.tags.mode).toBe('agent');
+      expect(commit.tags.modeEvidence).toBe('declared');
+      expect(commit.tags.attribution).toBe('ai');
+    } finally {
+      rmSync(outDir, { recursive: true, force: true });
+    }
+  });
+
+  it('declares human authorship with AIDA_MODE=none', async () => {
+    git('git commit -q --allow-empty -m "fix: hand written"', { AIDA_MODE: 'none' });
+
+    const outDir = mkdtempSync(join(tmpdir(), 'aida-hooks-out-'));
+    try {
+      await run(createCollectCommand(), ['--repo', repoPath, '--out-dir', outDir]);
+      const stream = JSON.parse(readFileSync(join(outDir, 'commit-stream.json'), 'utf-8'));
+      // The first real source of `human` attribution that isn't the manifest
+      expect(stream.commits[0].tags.attribution).toBe('human');
+      expect(stream.commits[0].tags.mode).toBe('none');
+      expect(stream.commits[0].tags.modeEvidence).toBe('declared');
+    } finally {
+      rmSync(outDir, { recursive: true, force: true });
+    }
+  });
+
+  it('writes nothing when the mode is unknown — absence stays honest', () => {
+    git('git commit -q --allow-empty -m "chore: no mode known"');
+    const message = execSync('git log -1 --format=%B', { cwd: repoPath }).toString();
+    expect(message).not.toContain('AI-Mode');
+  });
+
+  it('rejects an invalid AIDA_MODE instead of stamping garbage', () => {
+    git('git commit -q --allow-empty -m "chore: bogus mode"', { AIDA_MODE: 'wizard' });
+    const message = execSync('git log -1 --format=%B', { cwd: repoPath }).toString();
+    expect(message).not.toContain('AI-Mode');
+  });
+
+  it('does not double-stamp a message that already declares a mode', () => {
+    git('git commit -q --allow-empty -m "feat: x" -m "AI-Mode: assisted"', {
+      AIDA_MODE: 'agent',
+    });
+    const message = execSync('git log -1 --format=%B', { cwd: repoPath }).toString();
+    expect(message.match(/AI-Mode:/g)).toHaveLength(1);
+    expect(message).toContain('AI-Mode: assisted');
+  });
+
+  it('reads defaultMode from .aida.json when nothing else determines it', () => {
+    writeFileSync(join(repoPath, '.aida.json'), JSON.stringify({ defaultMode: 'assisted' }));
+    git('git add -A && git commit -q -m "chore: config"');
+    const message = execSync('git log -1 --format=%B', { cwd: repoPath }).toString();
+    expect(message).toContain('AI-Mode: assisted');
+  });
+
+  it('never blocks a commit, even if the hook body fails', () => {
+    // A hook whose logic throws must still let the commit through
+    writeFileSync(
+      hookPath(),
+      '#!/bin/sh\n# >>> aida-metrics mode stamp >>>\nthis-command-does-not-exist 2>/dev/null || true\nexit 0\n# <<< aida-metrics mode stamp <<<\n',
+      { mode: 0o755 }
+    );
+    expect(() => git('git commit -q --allow-empty -m "chore: survives"')).not.toThrow();
+  });
+});

--- a/packages/cli/src/commands/install-hooks.ts
+++ b/packages/cli/src/commands/install-hooks.ts
@@ -1,0 +1,105 @@
+import { Command } from 'commander';
+import { createLogger } from '@aida-dev/core';
+import { promises as fs } from 'fs';
+import { execFile } from 'child_process';
+import { join } from 'path';
+import { promisify } from 'util';
+import { HOOK_END_MARKER, HOOK_MARKER, HOOK_SCRIPT } from '../hooks/prepare-commit-msg.js';
+
+const execFileAsync = promisify(execFile);
+
+const HOOK_NAME = 'prepare-commit-msg';
+
+// Resolves the real hooks directory: worktrees and `core.hooksPath` both
+// move it away from `.git/hooks`.
+async function resolveHooksDir(repoPath: string): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync('git', ['rev-parse', '--git-path', 'hooks'], {
+      cwd: repoPath,
+    });
+    const relative = stdout.trim();
+    return relative.startsWith('/') ? relative : join(repoPath, relative);
+  } catch {
+    return join(repoPath, '.git', 'hooks');
+  }
+}
+
+function isAidaHook(content: string): boolean {
+  return content.includes(HOOK_MARKER);
+}
+
+// Removes only AIDA's marked block, leaving any surrounding hook intact.
+function stripAidaBlock(content: string): string {
+  const start = content.indexOf(HOOK_MARKER);
+  const end = content.indexOf(HOOK_END_MARKER);
+  if (start === -1 || end === -1) return content;
+  const before = content.slice(0, start);
+  const after = content.slice(end + HOOK_END_MARKER.length);
+  return `${before.trimEnd()}\n${after.trimStart()}`.trim() + '\n';
+}
+
+export function createInstallHooksCommand(): Command {
+  return new Command('install-hooks')
+    .description(
+      'Install a prepare-commit-msg hook that stamps the autonomy mode (AI-Mode trailer)'
+    )
+    .option('--repo <path>', 'Repository path', process.cwd())
+    .option('--force', 'Overwrite an existing unrelated hook', false)
+    .option('--uninstall', 'Remove the AIDA hook block', false)
+    .option('--verbose', 'Verbose logging', false)
+    .action(async (options) => {
+      const logger = createLogger(Boolean(options.verbose));
+
+      try {
+        const hooksDir = await resolveHooksDir(options.repo);
+        const hookPath = join(hooksDir, HOOK_NAME);
+
+        let existing: string | null = null;
+        try {
+          existing = await fs.readFile(hookPath, 'utf-8');
+        } catch {
+          existing = null;
+        }
+
+        if (options.uninstall) {
+          if (!existing || !isAidaHook(existing)) {
+            logger.info('No AIDA hook found: nothing to uninstall.');
+            return;
+          }
+          const remainder = stripAidaBlock(existing);
+          // Only our block was there → remove the file entirely
+          if (remainder.replace(/^#!.*\n?/, '').trim() === '') {
+            await fs.rm(hookPath);
+            logger.info(`Removed ${hookPath}`);
+          } else {
+            await fs.writeFile(hookPath, remainder, { mode: 0o755 });
+            logger.info(`Removed the AIDA block from ${hookPath}, leaving the rest intact`);
+          }
+          return;
+        }
+
+        if (existing && !isAidaHook(existing) && !options.force) {
+          logger.error(
+            `${hookPath} already exists and was not written by AIDA.\n` +
+              'Refusing to overwrite someone else\'s hook. Re-run with --force to replace it, ' +
+              'or add the AI-Mode trailer from your own hook.'
+          );
+          process.exit(1);
+        }
+
+        await fs.mkdir(hooksDir, { recursive: true });
+        await fs.writeFile(hookPath, HOOK_SCRIPT, { mode: 0o755 });
+
+        logger.info(`Installed ${hookPath}`);
+        logger.info(
+          'Commits will now carry an `AI-Mode:` trailer when the mode is known ' +
+            '(AIDA_MODE env var, a detected agent environment, or defaultMode in .aida.json).'
+        );
+      } catch (error) {
+        logger.error(
+          `Hook installation failed: ${error instanceof Error ? error.message : String(error)}`
+        );
+        process.exit(1);
+      }
+    });
+}

--- a/packages/cli/src/hooks/prepare-commit-msg.ts
+++ b/packages/cli/src/hooks/prepare-commit-msg.ts
@@ -1,0 +1,59 @@
+// The prepare-commit-msg hook installed by `aida install-hooks` (#61).
+//
+// Deliberately self-contained POSIX shell: it runs on every commit, so it
+// must not depend on `aida` being installed, on node startup time, or on
+// network. Every failure path exits 0 — a provenance hook must never block
+// a commit.
+
+export const HOOK_MARKER = '# >>> aida-metrics mode stamp >>>';
+export const HOOK_END_MARKER = '# <<< aida-metrics mode stamp <<<';
+
+// Auto-detection is a convenience for known agent environments, not a
+// guarantee. AIDA_MODE always wins; when nothing is known we write nothing,
+// because an absent trailer honestly means "unknown" while a guessed one
+// would be a fabricated declaration.
+export const HOOK_SCRIPT = `#!/bin/sh
+${HOOK_MARKER}
+# Stamps 'AI-Mode: <mode>' so commit provenance is declared, not inferred.
+# Docs: https://github.com/ceccode/AIDA-Metrics/issues/61
+# Remove with: aida install-hooks --uninstall
+
+aida_stamp_mode() {
+  msg_file="$1"
+  [ -f "$msg_file" ] || return 0
+
+  # Already declared (amend, rebase, template, or an agent that stamps its
+  # own): never write a second trailer.
+  if grep -qiE '^AI-Mode:[[:space:]]*(none|autocomplete|assisted|agent)[[:space:]]*$' "$msg_file"; then
+    return 0
+  fi
+
+  mode="$AIDA_MODE"
+
+  # Best-effort detection of known agent environments
+  if [ -z "$mode" ]; then
+    if [ -n "$CLAUDECODE" ] || [ -n "$CLAUDE_CODE_ENTRYPOINT" ]; then
+      mode="agent"
+    elif [ -n "$CURSOR_TRACE_ID" ]; then
+      mode="assisted"
+    fi
+  fi
+
+  # Repo-wide default, opt-in via .aida.json { "defaultMode": "..." }
+  if [ -z "$mode" ] && [ -f .aida.json ]; then
+    mode=$(sed -n 's/.*"defaultMode"[[:space:]]*:[[:space:]]*"\\([a-z]*\\)".*/\\1/p' .aida.json | head -n 1)
+  fi
+
+  case "$mode" in
+    none|autocomplete|assisted|agent) ;;
+    *) return 0 ;;  # unknown stays unknown: write nothing
+  esac
+
+  # Comment lines are stripped by git; append before them so the trailer
+  # survives into the final message.
+  printf '\\nAI-Mode: %s\\n' "$mode" >> "$msg_file"
+}
+
+aida_stamp_mode "$1" 2>/dev/null || true
+${HOOK_END_MARKER}
+`;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,6 +2,7 @@
 
 import { Command } from 'commander';
 import { createCollectCommand } from './commands/collect.js';
+import { createInstallHooksCommand } from './commands/install-hooks.js';
 import { createFetchPRsCommand } from './commands/fetch-prs.js';
 import { createAnalyzeCommand } from './commands/analyze.js';
 import { createReportCommand } from './commands/report.js';
@@ -16,6 +17,7 @@ program
 
 // Add commands
 program.addCommand(createCollectCommand());
+program.addCommand(createInstallHooksCommand());
 program.addCommand(createFetchPRsCommand());
 program.addCommand(createAnalyzeCommand());
 program.addCommand(createReportCommand());

--- a/packages/core/src/schema/aida-config.ts
+++ b/packages/core/src/schema/aida-config.ts
@@ -10,6 +10,9 @@ export const AidaConfig = z.object({
   defaultAttribution: z.enum(['ai', 'human', 'unknown']).default('unknown'),
   // Attribution coverage below this fraction flags all metrics as low-confidence.
   coverageThreshold: z.number().min(0).max(1).default(0.7),
+  // Repo-wide autonomy mode stamped by the commit hook when nothing else
+  // determines it (#61). Absent means: leave unknown rather than guess.
+  defaultMode: z.enum(['none', 'autocomplete', 'assisted', 'agent']).optional(),
   // Replace author/committer identities with a per-run salted hash (#35).
   // Recommended in CI, where commit-stream.json leaves the machine.
   redactAuthors: z.boolean().default(false),

--- a/packages/core/src/tags/ai-tags.test.ts
+++ b/packages/core/src/tags/ai-tags.test.ts
@@ -243,6 +243,40 @@ Co-authored-by: Claude <noreply@anthropic.com>`
     });
   });
 
+  describe('declared mode trailer (#61)', () => {
+    it('reads AI-Mode as a declaration, beating tool inference', () => {
+      const result = tagger(
+        'feat: x\n\nCo-Authored-By: Copilot <noreply@github.com>\nAI-Mode: agent'
+      );
+      // The Copilot trailer would infer autocomplete; the declaration wins
+      expect(result.mode).toBe('agent');
+      expect(result.modeEvidence).toBe('declared');
+      expect(result.attribution).toBe('ai');
+      expect(result.sources).toContain('trailer:AI-Mode');
+    });
+
+    it('treats AI-Mode: none as a declaration of human authorship', () => {
+      const result = tagger('fix: hand written\n\nAI-Mode: none');
+      expect(result.attribution).toBe('human');
+      expect(result.ai).toBe(false);
+      expect(result.mode).toBe('none');
+      expect(result.modeEvidence).toBe('declared');
+    });
+
+    it('accepts every documented mode, case-insensitively', () => {
+      for (const mode of ['autocomplete', 'assisted', 'agent'] as const) {
+        expect(tagger(`feat: x\n\nAI-Mode: ${mode}`).mode).toBe(mode);
+      }
+      expect(tagger('feat: x\n\nai-mode: AGENT').mode).toBe('agent');
+    });
+
+    it('ignores an unrecognized mode value rather than trusting it', () => {
+      const result = tagger('feat: x\n\nAI-Mode: wizard');
+      expect(result.mode).toBe('unknown');
+      expect(result.modeEvidence).toBe('none');
+    });
+  });
+
   describe('three-state attribution', () => {
     it('maps explicit and implicit levels to attribution: ai', () => {
       expect(tagger('[AI] automated change').attribution).toBe('ai');

--- a/packages/core/src/tags/ai-tags.ts
+++ b/packages/core/src/tags/ai-tags.ts
@@ -29,6 +29,16 @@ export const MODE_BY_TOOL: Array<[pattern: RegExp, mode: AIMode]> = [
   [/\b(cursor|windsurf|codeium|chatgpt|gemini)\b/i, 'assisted'],
 ];
 
+// Commit-time declared mode (#61): `AI-Mode: agent` written by the
+// prepare-commit-msg hook. A declaration beats inference — this is the
+// mechanism that turns `declared` from exception into norm.
+const DECLARED_MODE_TRAILER = /^AI-Mode:\s*(none|autocomplete|assisted|agent)\s*$/im;
+
+export function declaredMode(message: string): AIMode | null {
+  const match = message.match(DECLARED_MODE_TRAILER);
+  return match ? (match[1].toLowerCase() as AIMode) : null;
+}
+
 export function inferMode(message: string): AIMode {
   for (const [pattern, mode] of MODE_BY_TOOL) {
     if (pattern.test(message)) {
@@ -200,6 +210,22 @@ export function createAITagger(
         level = 'mention';
         sources.push('tool_name_only');
       }
+    }
+
+    // A declared mode is itself an AI signal: `AI-Mode: agent` states that an
+    // agent wrote this, and `AI-Mode: none` states a human did (#61).
+    const declared = declaredMode(message);
+    if (declared) {
+      sources.push('trailer:AI-Mode');
+      const declaredAI = declared !== 'none';
+      return {
+        ai: declaredAI,
+        attribution: declaredAI ? 'ai' : 'human',
+        mode: declared,
+        modeEvidence: 'declared',
+        level: declaredAI ? 'explicit' : level,
+        sources,
+      };
     }
 
     // ai: true only for explicit and implicit


### PR DESCRIPTION
Closes #61. The prerequisite for #25 step 3, as discussed: don't make autonomy the primary axis while half its data is guessed — fix the data first.

## What

The attribution manifest (#10) declares provenance **retroactively**. This declares it **at the source**.

- **`AI-Mode:` trailer** — `none` | `autocomplete` | `assisted` | `agent` — parsed as `mode` with `modeEvidence: declared`, beating tool inference. Notably `AI-Mode: none` is the **first mechanism that declares human authorship at commit time**, without hand-maintaining a manifest.
- **`aida install-hooks`** writes a `prepare-commit-msg` hook. Design constraints, all tested:
  - **Self-contained POSIX shell** — no dependency on `aida` being installed, no node startup on every commit
  - **Can never block a commit** — every failure path exits 0
  - **Never clobbers silently** — refuses a foreign hook without `--force`; `--uninstall` strips only its own marked block and leaves the rest
  - **Idempotent**, and never double-stamps a message that already declares a mode
- **Resolution order**: `AIDA_MODE` env var → known agent-environment detection → `defaultMode` in `.aida.json` → **nothing**. An unknown mode writes no trailer, because an absent declaration honestly means unknown while a guessed one would be a fabrication — the same principle as the three-state model.

## Dogfood

The hook is installed on this repo and **stamped the very commit in this PR**:

```
feat: commit-time mode stamping via git hooks (#61)
...
Co-Authored-By: Claude <noreply@anthropic.com>
AI-Mode: agent
```

`collect` reads it back as `attribution: ai, mode: agent, modeEvidence: declared`, with both the trailer and `trailer:AI-Mode` in `sources`. Repo-wide evidence is now **54 declared / 60 inferred** — and every future commit made through an agent shifts that ratio, which is exactly the point.

## A finding worth recording

Two tests initially failed because the suite **runs inside Claude Code**, so the hook's agent detection fired and stamped commits the tests expected to be unstamped. The detection was working correctly — on the test process itself. Fixed by making the tests hermetic (they now clear the detection variables explicitly), with a comment explaining why, since this will bite anyone running the suite from an agent.

## Testing

142 tests pass (core 82, metrics 37, cli 23). New: trailer parsing incl. declaration-beats-inference and rejection of invalid values; install/uninstall/force/idempotency; and the hook exercised **for real** inside fixture repos — stamping, human declaration, no-stamp-when-unknown, no double-stamp, `defaultMode` fallback, and never blocking a commit. Typecheck and lint clean.

Co-Authored-By: Claude <noreply@anthropic.com>