### PR TITLE
feat: windowed coverage (#52) and rework rate (#22), fix --version

### DIFF
--- a/.changeset/windowed-coverage-rework.md
+++ b/.changeset/windowed-coverage-rework.md
@@ -1,0 +1,12 @@
+---
+'@aida-dev/metrics': minor
+'@aida-dev/cli': minor
+---
+
+Windowed coverage (#52), rework rate (#22), and correct `--version`
+
+**Windowed coverage** — `attribution.recent` reports coverage over a recent window (default 90 days, `--coverage-window`). All-time coverage is a permanent verdict on history that predates adoption; the recent figure answers "are we tagging now?", so it is what drives the low-confidence warning. All-time stays reported as context, and `belowThreshold` keeps its existing all-time meaning, so this is additive — no schema version bump.
+
+**Rework rate** — `persistence.rework` reports the share of AI-touched files modified again within a short window (default 7 days). Right-censoring is handled explicitly: a file too recent to have a determined outcome counts in neither the numerator nor the denominator, and the count of such files is reported. It is file-level, so within-session iteration inflates it — stated in the caveats and README.
+
+**Fix**: `aida --version` reported a hardcoded `0.0.0` regardless of the installed build; it now reports the real package version.

--- a/README.md
+++ b/README.md
@@ -195,6 +195,9 @@ aida report --out-dir ./aida-output
 
 #### `aida analyze`
 
+- `--default-attribution <value>` - Prior for unattributed commits: `ai` | `human` | `unknown`
+- `--coverage-threshold <fraction>` - Coverage below this flags metrics as low-confidence (default: 0.7)
+- `--coverage-window <days>` - Window for the actionable coverage figure (default: 90)
 - `--out-dir <path>` - Output directory (default: ./aida-output)
 - `--verbose` - Verbose logging
 
@@ -381,7 +384,9 @@ aida analyze --default-attribution human --coverage-threshold 0.8
 
 The headline metric ([#34](https://github.com/ceccode/AIDA-Metrics/issues/34)). Every commit gets a four-state attribution: `ai` (explicit/implicit detection or manifest), `human` (explicit declaration via manifest), `automated` (provenance-known automation, [#39](https://github.com/ceccode/AIDA-Metrics/issues/39) — merge commits and known bots auto-detected at collect time, or manifest `excluded_commits`; counts toward coverage, joins no cohort), or `unknown` (no signal — the absence of an AI tag is *not* evidence of human authorship).
 
-**Coverage** = share of commits with known provenance (`ai` + `human` + `automated`). It is reported first in every output, because every other number is only as trustworthy as coverage says it is. Below `coverageThreshold` (default 70%), the report carries a low-confidence warning.
+**Coverage** = share of commits with known provenance (`ai` + `human` + `automated`). It is reported first in every output, because every other number is only as trustworthy as coverage says it is.
+
+Coverage is reported over **two windows** ([#52](https://github.com/ceccode/AIDA-Metrics/issues/52)): all-time, and a recent window (default 90 days, `--coverage-window`). The recent figure is the actionable one — it answers *"are we tagging now?"* rather than passing a permanent verdict on history that predates adoption — so it is what drives the low-confidence warning below `coverageThreshold` (default 70%). All-time stays visible as context, never replaced.
 
 `defaultAttribution` lets a team consciously assign unattributed commits to a cohort (`human` for traditional repos, `ai` for AI-first ones). The prior affects cohort metrics but never coverage: unknown stays unknown in the attribution block, and an assumed baseline is labeled as such.
 
@@ -410,6 +415,14 @@ Early versions shipped a merge ratio ("% of AI commits that land on the default 
 - **Survivorship bias destroys the denominator** — abandoned branches get deleted, so discarded work leaves `git log --all` entirely. The ratio trends toward 100% for everyone and discriminates nothing.
 
 A rough metric with visible error bars is worth shipping; a metric whose data source systematically deletes the negative outcomes is not. The honest successor is a **PR acceptance rate** built on forge APIs (GitHub/GitLab), where declined PRs are never deleted — planned as a separate metric.
+
+### Rework Rate
+
+Share of AI-touched files modified again within a short window (default 7 days, `--rework-window`) — the bucket that actually carries signal, since tests and source get rewritten when the code moves ([#22](https://github.com/ceccode/AIDA-Metrics/issues/22)).
+
+**Right-censoring is handled explicitly**: a file first touched two days ago and not yet reworked has no determined answer to a seven-day question, so it counts in neither the numerator nor the denominator. The report shows how many files were set aside for this reason.
+
+**Honest limit**: it is file-level, so consecutive commits from a single working session touching the same file count as rework. For iterative workflows this inflates the number substantially — on this repo it reads 55%, most of which is within-session iteration rather than code that had to be redone. Line-level tracking ([#23](https://github.com/ceccode/AIDA-Metrics/issues/23)) is what turns this into a quality signal.
 
 ### Persistence (MVP)
 
@@ -547,6 +560,7 @@ aida_analysis:
 - **v0.16** ✅ Versioned output schemas with reader-side version gate, plus end-to-end CLI tests and `pnpm typecheck` in CI ([#53](https://github.com/ceccode/AIDA-Metrics/issues/53)).  
 - **v0.17** ✅ PR acceptance rate via forge APIs — opt-in `aida fetch-prs`, the honest successor to merge ratio ([#51](https://github.com/ceccode/AIDA-Metrics/issues/51)).  
 - **v0.18** ✅ Commit-time mode stamping via git hook — `AI-Mode` trailer, `declared` evidence at the source ([#61](https://github.com/ceccode/AIDA-Metrics/issues/61)).  
+- **v0.19** ✅ Windowed coverage ([#52](https://github.com/ceccode/AIDA-Metrics/issues/52)) and rework rate with censoring ([#22](https://github.com/ceccode/AIDA-Metrics/issues/22)).  
 - **Next** → Autonomy as primary axis ([#25](https://github.com/ceccode/AIDA-Metrics/issues/25) step 3, once declared data accumulates), windowed coverage ([#52](https://github.com/ceccode/AIDA-Metrics/issues/52)), GitLab ([#16](https://github.com/ceccode/AIDA-Metrics/issues/16)) / Bitbucket ([#17](https://github.com/ceccode/AIDA-Metrics/issues/17)) PR providers.  
 - **Next** → Rework rate ([#22](https://github.com/ceccode/AIDA-Metrics/issues/22)), line-level persistence via blame ([#23](https://github.com/ceccode/AIDA-Metrics/issues/23)).  
 - **Next** → Outcome correlation ([#26](https://github.com/ceccode/AIDA-Metrics/issues/26)), cost metrics ([#27](https://github.com/ceccode/AIDA-Metrics/issues/27)).  

--- a/packages/cli/src/commands/analyze.ts
+++ b/packages/cli/src/commands/analyze.ts
@@ -37,6 +37,10 @@ export function createAnalyzeCommand(): Command {
       '--coverage-threshold <fraction>',
       'Coverage below this flags metrics as low-confidence (default: 0.7, or .aida.json)'
     )
+    .option(
+      '--coverage-window <days>',
+      'Window in days for the actionable coverage figure (default: 90)'
+    )
     .option('--verbose', 'Verbose logging', false)
     .action(async (options) => {
       const config = CLIConfig.parse(options);
@@ -93,9 +97,22 @@ export function createAnalyzeCommand(): Command {
           logger.info(`PR outcomes loaded: ${prStream.prs.length} closed PR(s)`);
         }
 
+        const coverageWindowDays = options.coverageWindow
+          ? Number(options.coverageWindow)
+          : undefined;
+        if (
+          coverageWindowDays !== undefined &&
+          (!Number.isInteger(coverageWindowDays) || coverageWindowDays <= 0)
+        ) {
+          throw new Error(
+            `Invalid --coverage-window "${options.coverageWindow}": expected a positive integer`
+          );
+        }
+
         const metrics = calculateMetrics(commitStream, {
           defaultAttribution,
           coverageThreshold,
+          coverageWindowDays,
           prStream,
         });
 
@@ -106,7 +123,12 @@ export function createAnalyzeCommand(): Command {
         logger.info(
           `Attribution coverage: ${(a.coverage * 100).toFixed(1)}% (ai: ${a.ai}, human: ${a.human}, automated: ${a.automated}, unknown: ${a.unknown})`
         );
-        if (a.belowThreshold) {
+        if (a.recent) {
+          logger.info(
+            `Recent coverage (${a.recent.windowDays}d): ${(a.recent.coverage * 100).toFixed(1)}% over ${a.recent.commitsTotal} commits`
+          );
+        }
+        if (a.recent ? a.recent.belowThreshold : a.belowThreshold) {
           logger.warn(
             `Coverage is below ${(a.coverageThreshold * 100).toFixed(0)}%: metrics are low-confidence. Tag AI commits or set defaultAttribution.`
           );

--- a/packages/cli/src/commands/report.ts
+++ b/packages/cli/src/commands/report.ts
@@ -20,8 +20,15 @@ function generateMarkdownReport(metrics: Metrics): string {
   const coveragePct = (a.coverage * 100).toFixed(1);
   const unknownPct = a.commitsTotal > 0 ? ((a.unknown / a.commitsTotal) * 100).toFixed(1) : '0.0';
 
-  const coverageWarning = a.belowThreshold
-    ? `\n> ⚠️ **Coverage is below ${(a.coverageThreshold * 100).toFixed(0)}%.** Most of this history has unknown provenance: every metric below is low-confidence. Tag AI commits (trailers, \`[AI]\`) or set \`defaultAttribution\` in \`.aida.json\`.\n`
+  // The recent window is the actionable number, so it leads and it drives
+  // the warning; all-time stays visible as context (#52).
+  const recentLine = a.recent
+    ? `\n**Last ${a.recent.windowDays} days: ${(a.recent.coverage * 100).toFixed(1)}%** (${a.recent.commitsTotal} commits) — the number you can move. All-time: ${coveragePct}%.\n`
+    : '';
+  const warnOnRecent = a.recent ? a.recent.belowThreshold : a.belowThreshold;
+
+  const coverageWarning = warnOnRecent
+    ? `\n> ⚠️ **Coverage is below ${(a.coverageThreshold * 100).toFixed(0)}%${a.recent ? ` in the last ${a.recent.windowDays} days` : ''}.** Provenance is largely unknown, so every metric below is low-confidence. Install the commit hook (\`aida install-hooks\`), tag AI commits, or set \`defaultAttribution\` in \`.aida.json\`.\n`
     : '';
 
   const priorNote =
@@ -135,6 +142,7 @@ ${[
 
 **${coveragePct}% of commits have known provenance** — ai: ${a.ai} · human: ${a.human} · automated: ${a.automated} · unknown: ${a.unknown} (${unknownPct}%)
 
+${recentLine}
 **Autonomy:** agent ${a.modes.agent} · assisted ${a.modes.assisted} · autocomplete ${a.modes.autocomplete} · none ${a.modes.none} · unknown ${a.modes.unknown} — evidence: declared ${a.modeEvidence.declared} / inferred ${a.modeEvidence.inferred} / none ${a.modeEvidence.none}
 ${coverageWarning}${priorNote}
 ${comparisonSection}
@@ -143,7 +151,12 @@ ${byModeSection}${prSection}${fairnessSection}
 - Commits considered: ${metrics.persistence.commitsConsidered}
 - Files measured: ${metrics.persistence.filesConsidered} (${metrics.persistence.censored} still surviving at collection time; ${metrics.persistence.filesExcluded} excluded: migrations/generated)
 - Average days: ${metrics.persistence.avgDays}
-- Median days: ${metrics.persistence.medianDays}
+- Median days: ${metrics.persistence.medianDays}${
+    metrics.persistence.rework
+      ? `
+- **Rework rate (${metrics.persistence.rework.windowDays}d):** ${(metrics.persistence.rework.rate * 100).toFixed(1)}% — ${metrics.persistence.rework.reworked} of ${metrics.persistence.rework.determined} files with a determined outcome${metrics.persistence.rework.undetermined > 0 ? ` (${metrics.persistence.rework.undetermined} too recent to judge)` : ''}`
+      : ''
+  }
 
 | 0–1d | 2–7d | 8–30d | 31–90d | 90d+ |
 |---:|---:|---:|---:|---:|

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { Command } from 'commander';
+import { createRequire } from 'module';
 import { createCollectCommand } from './commands/collect.js';
 import { createInstallHooksCommand } from './commands/install-hooks.js';
 import { createFetchPRsCommand } from './commands/fetch-prs.js';
@@ -8,12 +9,16 @@ import { createAnalyzeCommand } from './commands/analyze.js';
 import { createReportCommand } from './commands/report.js';
 import { createCommentCommand } from './commands/comment.js';
 
+// Report the real package version: a hardcoded '0.0.0' left users unable to
+// tell which build they were running.
+const { version } = createRequire(import.meta.url)('../package.json') as { version: string };
+
 const program = new Command();
 
 program
   .name('aida')
   .description('AIDA (AI Development Accounting) - Metrics for AI-assisted development')
-  .version('0.0.0');
+  .version(version);
 
 // Add commands
 program.addCommand(createCollectCommand());

--- a/packages/metrics/src/index.test.ts
+++ b/packages/metrics/src/index.test.ts
@@ -77,6 +77,36 @@ describe('calculateMetrics attribution coverage', () => {
     expect(metrics.persistence.commitsConsidered).toBe(1);
   });
 
+  it('reports recent-window coverage alongside all-time (#52)', () => {
+    const recent = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString();
+    const old = new Date(Date.now() - 400 * 24 * 60 * 60 * 1000).toISOString();
+    const metrics = calculateMetrics(
+      makeStream([
+        // Old, untagged: drags all-time coverage down forever
+        makeCommit({ hash: 'o1', tags: unknownTags, authorDate: old }),
+        makeCommit({ hash: 'o2', tags: unknownTags, authorDate: old }),
+        makeCommit({ hash: 'o3', tags: unknownTags, authorDate: old }),
+        // Recent, tagged: current hygiene is perfect
+        makeCommit({ hash: 'r1', tags: aiTags, authorDate: recent }),
+      ])
+    );
+
+    expect(metrics.attribution.coverage).toBe(0.25); // all-time: bleak
+    expect(metrics.attribution.belowThreshold).toBe(true);
+    expect(metrics.attribution.recent?.coverage).toBe(1); // recent: perfect
+    expect(metrics.attribution.recent?.commitsTotal).toBe(1);
+    expect(metrics.attribution.recent?.belowThreshold).toBe(false);
+  });
+
+  it('has a null recent block when the window contains no commits', () => {
+    const old = new Date(Date.now() - 400 * 24 * 60 * 60 * 1000).toISOString();
+    const metrics = calculateMetrics(
+      makeStream([makeCommit({ hash: 'o1', tags: aiTags, authorDate: old })]),
+      { coverageWindowDays: 30 }
+    );
+    expect(metrics.attribution.recent).toBeNull();
+  });
+
   it('flags belowThreshold using a custom coverageThreshold', () => {
     const metrics = calculateMetrics(
       makeStream([

--- a/packages/metrics/src/index.ts
+++ b/packages/metrics/src/index.ts
@@ -15,10 +15,14 @@ export * from './cohort.js';
 export * from './persistence.js';
 export * from './pr-acceptance.js';
 
+export const DEFAULT_COVERAGE_WINDOW_DAYS = 90;
+
 export interface MetricsOptions {
   // Prior applied to 'unknown' commits: which cohort (if any) they join.
   defaultAttribution?: 'ai' | 'human' | 'unknown';
   coverageThreshold?: number;
+  // Window for the actionable coverage figure (#52)
+  coverageWindowDays?: number;
   // Optional PR outcomes from `aida fetch-prs` (#51)
   prStream?: PRStream | null;
 }
@@ -32,7 +36,12 @@ export function calculateMetrics(
   commitStream: CommitStream,
   options: MetricsOptions = {}
 ): Metrics {
-  const { defaultAttribution = 'unknown', coverageThreshold = 0.7, prStream = null } = options;
+  const {
+    defaultAttribution = 'unknown',
+    coverageThreshold = 0.7,
+    coverageWindowDays = DEFAULT_COVERAGE_WINDOW_DAYS,
+    prStream = null,
+  } = options;
 
   const counts = { ai: 0, human: 0, automated: 0, unknown: 0 };
   const modes = { none: 0, autocomplete: 0, assisted: 0, agent: 0, unknown: 0 };
@@ -46,6 +55,19 @@ export function calculateMetrics(
   // Automated commits have known provenance (#39): they count as covered
   const coverage = total > 0 ? (counts.ai + counts.human + counts.automated) / total : 0;
 
+  // Coverage over a recent window (#52): the number a team can actually move.
+  // All-time coverage is a permanent verdict on history predating adoption.
+  const windowStart = new Date(Date.now() - coverageWindowDays * 24 * 60 * 60 * 1000);
+  const recentCommits = commitStream.commits.filter(
+    (commit) => new Date(commit.authorDate) >= windowStart
+  );
+  const recentCounts = { ai: 0, human: 0, automated: 0, unknown: 0 };
+  for (const commit of recentCommits) recentCounts[commit.tags.attribution]++;
+  const recentCoverage =
+    recentCommits.length > 0
+      ? (recentCounts.ai + recentCounts.human + recentCounts.automated) / recentCommits.length
+      : 0;
+
   const attribution: Attribution = {
     commitsTotal: total,
     ai: counts.ai,
@@ -56,6 +78,19 @@ export function calculateMetrics(
     defaultAttribution,
     coverageThreshold,
     belowThreshold: coverage < coverageThreshold,
+    recent:
+      recentCommits.length > 0
+        ? {
+            windowDays: coverageWindowDays,
+            commitsTotal: recentCommits.length,
+            ai: recentCounts.ai,
+            human: recentCounts.human,
+            automated: recentCounts.automated,
+            unknown: recentCounts.unknown,
+            coverage: round(recentCoverage, 4),
+            belowThreshold: recentCoverage < coverageThreshold,
+          }
+        : null,
     modes,
     modeEvidence,
   };
@@ -134,6 +169,7 @@ export function calculateMetrics(
 
   const caveats = [
     `Attribution coverage is ${(coverage * 100).toFixed(1)}%: metrics only describe commits whose provenance is known.`,
+    'Rework rate is file-level: consecutive commits from one working session touching the same file count as rework, which inflates it for iterative workflows. Files too recent to judge are excluded from both sides. Line-level tracking will refine this.',
     'Persistence is file-level, not line-level.',
     'Persistence is survival: days until the first subsequent modification. Files never modified again are censored at collection time. Migrations and generated files (convention-driven lifecycles) are excluded.',
     'Persistence comparisons are only meaningful between cohorts of similar age and task mix — check the cohorts section before reading the delta.',

--- a/packages/metrics/src/persistence.test.ts
+++ b/packages/metrics/src/persistence.test.ts
@@ -228,6 +228,91 @@ describe('calculatePersistence', () => {
   });
 });
 
+describe('rework rate (#22)', () => {
+  const aiTags: CommitStream['commits'][0]['tags'] = { ai: true, attribution: 'ai', mode: 'agent', modeEvidence: 'inferred', level: 'explicit', sources: [] };
+
+  it('counts a file reworked inside the window', () => {
+    const stream = makeStream([
+      makeCommit({
+        hash: 'a1',
+        authorDate: '2024-01-01T00:00:00.000Z',
+        tags: aiTags,
+        stats: { totalAdditions: 5, totalDeletions: 0, files: [{ path: 'src/a.ts', additions: 5, deletions: 0 }] },
+      }),
+      makeCommit({
+        hash: 'a2',
+        authorDate: '2024-01-03T00:00:00.000Z',
+        tags: aiTags,
+        stats: { totalAdditions: 1, totalDeletions: 1, files: [{ path: 'src/a.ts', additions: 1, deletions: 1, status: 'modified' }] },
+      }),
+    ]);
+    const result = calculatePersistence(stream, undefined, { reworkWindowDays: 7 });
+    expect(result.rework).toEqual({
+      windowDays: 7,
+      reworked: 1,
+      determined: 1,
+      undetermined: 0,
+      rate: 1,
+    });
+  });
+
+  it('does not count a file reworked after the window', () => {
+    const stream = makeStream([
+      makeCommit({
+        hash: 'a1',
+        authorDate: '2024-01-01T00:00:00.000Z',
+        tags: aiTags,
+        stats: { totalAdditions: 5, totalDeletions: 0, files: [{ path: 'src/a.ts', additions: 5, deletions: 0 }] },
+      }),
+      makeCommit({
+        hash: 'a2',
+        authorDate: '2024-02-01T00:00:00.000Z',
+        tags: aiTags,
+        stats: { totalAdditions: 1, totalDeletions: 1, files: [{ path: 'src/a.ts', additions: 1, deletions: 1, status: 'modified' }] },
+      }),
+    ]);
+    const result = calculatePersistence(stream, undefined, { reworkWindowDays: 7 });
+    expect(result.rework?.reworked).toBe(0);
+    expect(result.rework?.determined).toBe(1);
+    expect(result.rework?.rate).toBe(0);
+  });
+
+  it('excludes files too recent to judge from both numerator and denominator', () => {
+    // Stream ends 2024-06-01; this file is first touched 2 days before that,
+    // so a 7-day question has no answer for it either way.
+    const stream = makeStream([
+      makeCommit({
+        hash: 'a1',
+        authorDate: '2024-05-30T00:00:00.000Z',
+        tags: aiTags,
+        stats: { totalAdditions: 5, totalDeletions: 0, files: [{ path: 'src/fresh.ts', additions: 5, deletions: 0 }] },
+      }),
+      makeCommit({
+        hash: 'a2',
+        authorDate: '2024-01-01T00:00:00.000Z',
+        tags: aiTags,
+        stats: { totalAdditions: 5, totalDeletions: 0, files: [{ path: 'src/old.ts', additions: 5, deletions: 0 }] },
+      }),
+    ]);
+    const result = calculatePersistence(stream, undefined, { reworkWindowDays: 7 });
+    expect(result.rework?.undetermined).toBe(1); // fresh.ts
+    expect(result.rework?.determined).toBe(1); // old.ts, observed long enough
+    expect(result.rework?.reworked).toBe(0);
+  });
+
+  it('is null when no file has a determined outcome', () => {
+    const stream = makeStream([
+      makeCommit({
+        hash: 'a1',
+        authorDate: '2024-05-31T00:00:00.000Z',
+        tags: aiTags,
+        stats: { totalAdditions: 1, totalDeletions: 0, files: [{ path: 'src/fresh.ts', additions: 1, deletions: 0 }] },
+      }),
+    ]);
+    expect(calculatePersistence(stream, undefined, { reworkWindowDays: 30 }).rework).toBeNull();
+  });
+});
+
 describe('calculateBaselinePersistence', () => {
   it('measures persistence over human-attributed commits only, ignoring AI commits', () => {
     const stream = makeStream([

--- a/packages/metrics/src/persistence.ts
+++ b/packages/metrics/src/persistence.ts
@@ -12,8 +12,12 @@ export const DEFAULT_PERSISTENCE_EXCLUDED_CATEGORIES: FileCategory[] = [
   'generated',
 ];
 
+export const DEFAULT_REWORK_WINDOW_DAYS = 7;
+
 export interface PersistenceOptions {
   excludeCategories?: FileCategory[];
+  // Window for the rework rate (#22)
+  reworkWindowDays?: number;
   // End of the observation window, used to measure censored files (never
   // modified again). Defaults to the stream's collection time.
   observationEnd?: Date;
@@ -38,6 +42,7 @@ export function calculatePersistence(
   const {
     excludeCategories = DEFAULT_PERSISTENCE_EXCLUDED_CATEGORIES,
     observationEnd = new Date(commitStream.generatedAt),
+    reworkWindowDays = DEFAULT_REWORK_WINDOW_DAYS,
   } = options;
   const excluded = new Set<FileCategory>(excludeCategories);
 
@@ -50,6 +55,7 @@ export function calculatePersistence(
     censored: 0,
     avgDays: 0,
     medianDays: 0,
+    rework: null,
     buckets: { d0_1: 0, d2_7: 0, d8_30: 0, d31_90: 0, d90_plus: 0 },
   };
 
@@ -96,14 +102,31 @@ export function calculatePersistence(
 
   const survivalDays: number[] = [];
   let censored = 0;
+  // Rework accounting (#22). A file counts only when its outcome within the
+  // window is *determined*: either it was reworked in time, or it was
+  // observed for the full window without being touched. A file first seen
+  // two days ago cannot answer a seven-day question either way.
+  let reworked = 0;
+  let determined = 0;
+  let undetermined = 0;
   for (const lifecycle of lifecycles.values()) {
     if (lifecycle.firstTargetIndex < 0) continue; // excluded category
+    const observedDays = Math.max(0, daysBetween(lifecycle.firstTargetDate, observationEnd));
+
     if (lifecycle.eventDate) {
-      survivalDays.push(daysBetween(lifecycle.firstTargetDate, lifecycle.eventDate));
+      const survived = daysBetween(lifecycle.firstTargetDate, lifecycle.eventDate);
+      survivalDays.push(survived);
+      determined++;
+      if (survived < reworkWindowDays) reworked++;
     } else {
       // Never modified again: survived to the end of the observation window
       censored++;
-      survivalDays.push(Math.max(0, daysBetween(lifecycle.firstTargetDate, observationEnd)));
+      survivalDays.push(observedDays);
+      if (observedDays >= reworkWindowDays) {
+        determined++; // observed long enough to say "not reworked"
+      } else {
+        undetermined++; // too recent to judge
+      }
     }
   }
 
@@ -125,6 +148,16 @@ export function calculatePersistence(
     censored,
     avgDays: Math.round(avgDays * 100) / 100,
     medianDays: Math.round(medianDays * 100) / 100,
+    rework:
+      determined > 0
+        ? {
+            windowDays: reworkWindowDays,
+            reworked,
+            determined,
+            undetermined,
+            rate: Math.round((reworked / determined) * 10000) / 10000,
+          }
+        : null,
     buckets: {
       d0_1: survivalDays.filter((days) => days <= 1).length,
       d2_7: survivalDays.filter((days) => days >= 2 && days <= 7).length,

--- a/packages/metrics/src/schema/metrics.ts
+++ b/packages/metrics/src/schema/metrics.ts
@@ -2,6 +2,20 @@ import { z } from 'zod';
 
 // Attribution coverage (#34): the headline metric. Every other number in this
 // file is only as trustworthy as this block says it is.
+// Coverage over a recent window (#52). All-time coverage is a verdict on the
+// past that a team cannot change; the actionable question is "are we tagging
+// now?". Reported alongside all-time, never instead of it.
+export const RecentCoverage = z.object({
+  windowDays: z.number().int().positive(),
+  commitsTotal: z.number().int().nonnegative(),
+  ai: z.number().int().nonnegative(),
+  human: z.number().int().nonnegative(),
+  automated: z.number().int().nonnegative(),
+  unknown: z.number().int().nonnegative(),
+  coverage: z.number().min(0).max(1),
+  belowThreshold: z.boolean(),
+});
+
 export const Attribution = z.object({
   commitsTotal: z.number().int().nonnegative(),
   ai: z.number().int().nonnegative(),
@@ -13,7 +27,9 @@ export const Attribution = z.object({
   coverage: z.number().min(0).max(1), // (ai + human + automated) / total
   defaultAttribution: z.enum(['ai', 'human', 'unknown']), // prior applied to unknown commits
   coverageThreshold: z.number().min(0).max(1),
-  belowThreshold: z.boolean(),
+  belowThreshold: z.boolean(), // all-time; see `recent` for the actionable one
+  // Null when the window contains no commits (#52)
+  recent: RecentCoverage.nullable(),
   // Autonomy axis (#25): commit counts per mode and per mode-evidence level
   modes: z.object({
     none: z.number().int().nonnegative(),
@@ -34,6 +50,18 @@ export const Attribution = z.object({
 // at the observation end (they survived the window — the best outcome).
 // Migrations and generated files are excluded by default: their lifecycle is
 // convention-driven and carries no quality signal.
+// Rework rate (#22): share of AI-touched files modified again within a short
+// window. Right-censoring matters here: a file first touched two days ago
+// and not yet reworked has no *determined* outcome for a 7-day window, so it
+// counts in neither numerator nor denominator.
+export const Rework = z.object({
+  windowDays: z.number().int().positive(),
+  reworked: z.number().int().nonnegative(),
+  determined: z.number().int().nonnegative(), // files whose outcome is known
+  undetermined: z.number().int().nonnegative(), // observed for less than the window
+  rate: z.number().min(0).max(1),
+});
+
 export const Persistence = z.object({
   commitsConsidered: z.number().int().nonnegative(),
   filesConsidered: z.number().int().nonnegative(),
@@ -41,6 +69,8 @@ export const Persistence = z.object({
   censored: z.number().int().nonnegative(), // files that survived the whole window
   avgDays: z.number().nonnegative(),
   medianDays: z.number().nonnegative(),
+  // Null when no file has a determined outcome in the window (#22)
+  rework: Rework.nullable(),
   buckets: z.object({
     d0_1: z.number().int().nonnegative(),
     d2_7: z.number().int().nonnegative(),
@@ -171,6 +201,8 @@ export const Metrics = z.object({
 });
 
 export type Attribution = z.infer<typeof Attribution>;
+export type RecentCoverage = z.infer<typeof RecentCoverage>;
+export type Rework = z.infer<typeof Rework>;
 export type AgeStats = z.infer<typeof AgeStats>;
 export type FileCategory = z.infer<typeof FileCategory>;
 export type CategoryCounts = z.infer<typeof CategoryCounts>;


### PR DESCRIPTION
Closes #52, closes #22. Two metrics plus a release-readiness fix.

## Windowed coverage (#52)

All-time coverage is a verdict on the past a team cannot change — adopt trailers today and you still read a low number for years. `attribution.recent` adds coverage over a recent window (default 90 days, `--coverage-window`), and **the recent figure drives the warning**, because it answers *"are we tagging now?"*.

All-time stays reported, and `belowThreshold` keeps its existing all-time meaning — the behavioural change lives in the report layer, so the schema change is purely additive and `schemaVersion` stays 1. (The #53 contract working as designed.)

## Rework rate (#22)

Share of AI-touched files modified again within a short window (default 7 days) — the "tests and source get rewritten when the code moves" signal from the r/devtools thread.

**Right-censoring is handled explicitly**, consistent with the persistence fix: a file first touched two days ago and not yet reworked has no determined answer to a seven-day question, so it counts in neither numerator nor denominator, and the number set aside is reported.

### Dogfood, and an honest reading of it

> **Rework rate (7d):** 55.3% — 52 of 94 files with a determined outcome (2 too recent to judge)

55% looks alarming and mostly **isn't a quality signal**: this repo is built in rapid iterative sessions where consecutive commits touch the same files, and file-level rework cannot tell that apart from "the code was wrong". That limit is in the caveats and the README rather than buried — and it is precisely the argument for line-level tracking (#23), which is what turns this number into signal.

I'd rather ship it with the caveat than not measure it, but it should not go in front of a stakeholder in this form yet.

## Fix: version reporting

`aida --version` reported a hardcoded `0.0.0` regardless of the installed build — surfaced while diagnosing why `install-hooks` appeared missing (the globally installed CLI predates #61). It now reports the real package version, which matters for a release people can trust.

## Testing

148 tests pass (core 82, metrics 43, cli 23). New: rework inside/outside the window, censoring exclusion from both sides, null when nothing is determined; recent-vs-all-time divergence, null recent window. Typecheck and lint clean, dogfooded end-to-end.

Co-Authored-By: Claude <noreply@anthropic.com>
