### PR TITLE
feat: GitLab CI provider for aida comment (#16)

### DIFF
--- a/.changeset/gitlab-provider.md
+++ b/.changeset/gitlab-provider.md
@@ -1,0 +1,13 @@
+---
+'@aida-dev/cli': minor
+---
+
+GitLab CI provider for `aida comment` (#16)
+
+`aida comment` now auto-detects GitLab CI and posts the report as a merge request note, finding and updating its own note by marker on re-runs instead of adding a new one — the same behaviour as the GitHub provider.
+
+- Uses `CI_MERGE_REQUEST_IID`, `CI_PROJECT_ID` and `CI_API_V4_URL`, so self-managed instances work without configuration.
+- Requires `GITLAB_TOKEN` (project or group access token with the `api` scope). `CI_JOB_TOKEN` cannot post notes and is deliberately not used as a fallback: the command fails with that explanation instead of an opaque 401.
+- Token patterns are scrubbed from any surfaced API error.
+
+PR-scoped collection (`--pr`) already supported GitLab, so `collect → analyze → report → comment` now works end to end there.

--- a/README.md
+++ b/README.md
@@ -514,19 +514,30 @@ Or use `--since` for time-based analysis:
 | Monthly audit | `90d` | Management/finance reporting |
 | Full history | *(omit)* | One-time baseline analysis |
 
-### GitLab CI
+### GitLab CI (with MR comments)
 
 ```yaml
 aida_analysis:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+  variables:
+    GITLAB_TOKEN: $AIDA_GITLAB_TOKEN
   script:
     - npm install -g @aida-dev/cli
-    - aida collect --since 30d && aida analyze && aida report
+    - aida collect --pr --redact-authors
+    - aida analyze
+    - aida report
+    - aida comment
   artifacts:
     paths:
       - aida-output/
 ```
 
-> GitLab MR comments coming soon — see [#16](https://github.com/ceccode/AIDA-Metrics/issues/16). Bitbucket: [#17](https://github.com/ceccode/AIDA-Metrics/issues/17).
+`aida comment` auto-detects GitLab CI and posts the report as a merge request note, updating its own note on re-runs instead of adding new ones ([#16](https://github.com/ceccode/AIDA-Metrics/issues/16)).
+
+**Token**: set `GITLAB_TOKEN` to a project or group access token with the `api` scope. The built-in `CI_JOB_TOKEN` cannot post notes, so it is deliberately not used as a fallback — the command fails with that explanation rather than an opaque 401.
+
+Bitbucket is currently out of scope ([#17](https://github.com/ceccode/AIDA-Metrics/issues/17) closed); the `CIProvider` interface stays provider-agnostic if someone wants to add it.
 
 ## Repository Structure
 
@@ -561,7 +572,8 @@ aida_analysis:
 - **v0.17** ✅ PR acceptance rate via forge APIs — opt-in `aida fetch-prs`, the honest successor to merge ratio ([#51](https://github.com/ceccode/AIDA-Metrics/issues/51)).  
 - **v0.18** ✅ Commit-time mode stamping via git hook — `AI-Mode` trailer, `declared` evidence at the source ([#61](https://github.com/ceccode/AIDA-Metrics/issues/61)).  
 - **v0.19** ✅ Windowed coverage ([#52](https://github.com/ceccode/AIDA-Metrics/issues/52)) and rework rate with censoring ([#22](https://github.com/ceccode/AIDA-Metrics/issues/22)).  
-- **Next** → Autonomy as primary axis ([#25](https://github.com/ceccode/AIDA-Metrics/issues/25) step 3, once declared data accumulates), windowed coverage ([#52](https://github.com/ceccode/AIDA-Metrics/issues/52)), GitLab ([#16](https://github.com/ceccode/AIDA-Metrics/issues/16)) / Bitbucket ([#17](https://github.com/ceccode/AIDA-Metrics/issues/17)) PR providers.  
+- **v0.20** ✅ GitLab CI provider — MR comments with note reuse ([#16](https://github.com/ceccode/AIDA-Metrics/issues/16)).  
+- **Next** → Line-level persistence via blame ([#23](https://github.com/ceccode/AIDA-Metrics/issues/23)), autonomy as primary axis ([#25](https://github.com/ceccode/AIDA-Metrics/issues/25) step 3, once declared data accumulates), outcome correlation ([#26](https://github.com/ceccode/AIDA-Metrics/issues/26)).  
 - **Next** → Rework rate ([#22](https://github.com/ceccode/AIDA-Metrics/issues/22)), line-level persistence via blame ([#23](https://github.com/ceccode/AIDA-Metrics/issues/23)).  
 - **Next** → Outcome correlation ([#26](https://github.com/ceccode/AIDA-Metrics/issues/26)), cost metrics ([#27](https://github.com/ceccode/AIDA-Metrics/issues/27)).  
 - **Next** → GitLab ([#16](https://github.com/ceccode/AIDA-Metrics/issues/16)) and Bitbucket ([#17](https://github.com/ceccode/AIDA-Metrics/issues/17)) PR comment providers.  

--- a/packages/cli/src/providers/detect.ts
+++ b/packages/cli/src/providers/detect.ts
@@ -1,5 +1,6 @@
 import type { CIProvider } from './types.js';
 import { GitHubProvider } from './github.js';
+import { GitLabProvider } from './gitlab.js';
 
 export function detectProvider(): CIProvider | null {
   // GitHub Actions
@@ -7,11 +8,10 @@ export function detectProvider(): CIProvider | null {
     return new GitHubProvider();
   }
 
-  // GitLab CI — not yet implemented
-  // if (process.env.GITLAB_CI === 'true') { ... }
-
-  // Bitbucket Pipelines — not yet implemented
-  // if (process.env.BITBUCKET_PIPELINE_UUID) { ... }
+  // GitLab CI (#16)
+  if (process.env.GITLAB_CI === 'true') {
+    return new GitLabProvider();
+  }
 
   // Azure DevOps — not yet implemented
   // if (process.env.TF_BUILD === 'True') { ... }

--- a/packages/cli/src/providers/gitlab.test.ts
+++ b/packages/cli/src/providers/gitlab.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { GitLabProvider } from './gitlab.js';
+import { detectProvider } from './detect.js';
+
+const ENV_KEYS = [
+  'GITLAB_CI',
+  'GITLAB_TOKEN',
+  'CI_PROJECT_ID',
+  'CI_PROJECT_PATH',
+  'CI_MERGE_REQUEST_IID',
+  'CI_API_V4_URL',
+  'GITHUB_ACTIONS',
+];
+
+let savedEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  savedEnv = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+  for (const key of ENV_KEYS) delete process.env[key];
+});
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  vi.unstubAllGlobals();
+});
+
+interface FetchInit {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string;
+}
+
+function mockFetch(handlers: Array<(url: string, init?: FetchInit) => Response>) {
+  const calls: Array<{ url: string; init?: FetchInit }> = [];
+  let index = 0;
+  vi.stubGlobal('fetch', (url: string, init?: FetchInit) => {
+    calls.push({ url, init });
+    const handler = handlers[Math.min(index, handlers.length - 1)];
+    index++;
+    return Promise.resolve(handler(url, init));
+  });
+  return calls;
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status });
+}
+
+describe('detectProvider', () => {
+  it('selects GitLab when running in GitLab CI', () => {
+    process.env.GITLAB_CI = 'true';
+    expect(detectProvider()?.name).toBe('gitlab');
+  });
+
+  it('still selects GitHub when running in GitHub Actions', () => {
+    process.env.GITHUB_ACTIONS = 'true';
+    expect(detectProvider()?.name).toBe('github');
+  });
+
+  it('returns null outside a known CI', () => {
+    expect(detectProvider()).toBeNull();
+  });
+});
+
+describe('GitLabProvider.getPRIdentifier', () => {
+  it('returns the MR iid on a merge_request pipeline', () => {
+    process.env.CI_PROJECT_ID = '42';
+    process.env.CI_PROJECT_PATH = 'group/project';
+    process.env.CI_MERGE_REQUEST_IID = '7';
+
+    expect(new GitLabProvider().getPRIdentifier()).toEqual({
+      provider: 'gitlab',
+      prNumber: '7',
+      repo: 'group/project',
+    });
+  });
+
+  it('returns null on a branch pipeline, where there is no MR', () => {
+    process.env.CI_PROJECT_ID = '42';
+    expect(new GitLabProvider().getPRIdentifier()).toBeNull();
+  });
+});
+
+describe('GitLabProvider.postComment', () => {
+  beforeEach(() => {
+    process.env.CI_PROJECT_ID = '42';
+    process.env.CI_MERGE_REQUEST_IID = '7';
+    process.env.CI_API_V4_URL = 'https://gitlab.example.com/api/v4';
+  });
+
+  it('creates a note when none carries the marker', async () => {
+    process.env.GITLAB_TOKEN = 'glpat-secret';
+    const calls = mockFetch([
+      () => json([{ id: 1, body: 'unrelated comment' }]),
+      () => json({ id: 2 }, 201),
+    ]);
+
+    await new GitLabProvider().postComment('# AIDA Report');
+
+    expect(calls).toHaveLength(2);
+    expect(calls[1].init?.method).toBe('POST');
+    expect(calls[1].url).toContain('/projects/42/merge_requests/7/notes');
+    expect(String(calls[1].init?.body)).toContain('aida-metrics-report');
+  });
+
+  it('updates the existing AIDA note instead of adding another', async () => {
+    process.env.GITLAB_TOKEN = 'glpat-secret';
+    const calls = mockFetch([
+      () => json([{ id: 99, body: '<!-- aida-metrics-report -->\nold report' }]),
+      () => json({ id: 99 }),
+    ]);
+
+    await new GitLabProvider().postComment('# AIDA Report');
+
+    expect(calls[1].init?.method).toBe('PUT');
+    expect(calls[1].url).toContain('/notes/99');
+  });
+
+  it('authenticates with PRIVATE-TOKEN', async () => {
+    process.env.GITLAB_TOKEN = 'glpat-secret';
+    const calls = mockFetch([() => json([]), () => json({ id: 1 }, 201)]);
+
+    await new GitLabProvider().postComment('report');
+
+    const headers = calls[0].init?.headers ?? {};
+    expect(headers['PRIVATE-TOKEN']).toBe('glpat-secret');
+  });
+
+  it('explains that CI_JOB_TOKEN cannot post notes when the token is missing', async () => {
+    await expect(new GitLabProvider().postComment('report')).rejects.toThrow(
+      /GITLAB_TOKEN is required.*CI_JOB_TOKEN cannot post notes/s
+    );
+  });
+
+  it('never leaks the token through an API error body', async () => {
+    process.env.GITLAB_TOKEN = 'glpat-supersecret';
+    mockFetch([
+      () => json([]),
+      () => new Response('denied for glpat-supersecret via PRIVATE-TOKEN: glpat-supersecret', { status: 403 }),
+    ]);
+
+    await expect(new GitLabProvider().postComment('report')).rejects.toThrow(
+      /\[REDACTED\]/
+    );
+    await expect(new GitLabProvider().postComment('report')).rejects.not.toThrow(
+      /supersecret/
+    );
+  });
+});

--- a/packages/cli/src/providers/gitlab.ts
+++ b/packages/cli/src/providers/gitlab.ts
@@ -1,0 +1,133 @@
+import type { CIProvider, PRIdentifier } from './types.js';
+
+// GitLab CI provider for `aida comment` (#16).
+//
+// Mirrors the GitHub provider: find an existing AIDA note by marker and
+// update it, or create one — so re-running on a pushed branch edits the
+// same note instead of spamming the merge request.
+
+const MARKER = '<!-- aida-metrics-report -->';
+
+function sanitizeErrorBody(text: string, maxLength = 200): string {
+  // GitLab tokens: glpat- (PAT), gloas- (OAuth), plus the CI job token
+  let sanitized = text
+    .replace(/gl(pat|oas|soat|ptt|rt)-[A-Za-z0-9_-]+/g, '[REDACTED]')
+    .replace(/Bearer\s+[A-Za-z0-9._-]+/gi, 'Bearer [REDACTED]')
+    .replace(/(PRIVATE-TOKEN|JOB-TOKEN)\s*:?\s*[A-Za-z0-9._-]+/gi, '$1: [REDACTED]');
+  if (sanitized.length > maxLength) {
+    sanitized = sanitized.slice(0, maxLength) + '...(truncated)';
+  }
+  return sanitized;
+}
+
+export class GitLabProvider implements CIProvider {
+  name = 'gitlab';
+
+  // GITLAB_TOKEN is a personal/project token; CI_JOB_TOKEN cannot post
+  // notes, so it is deliberately not used as a fallback — failing with a
+  // clear message beats a confusing 401 at post time.
+  private get token(): string {
+    const token = process.env.GITLAB_TOKEN;
+    if (!token) {
+      throw new Error(
+        'GITLAB_TOKEN is required for GitLab MR comments (CI_JOB_TOKEN cannot post notes). ' +
+          'Add a project or group access token with the `api` scope.'
+      );
+    }
+    return token;
+  }
+
+  private get projectId(): string {
+    const id = process.env.CI_PROJECT_ID;
+    if (!id) {
+      throw new Error('CI_PROJECT_ID env var not found. Are you running in GitLab CI?');
+    }
+    return id;
+  }
+
+  private get apiUrl(): string {
+    return process.env.CI_API_V4_URL || 'https://gitlab.com/api/v4';
+  }
+
+  private get headers(): Record<string, string> {
+    return {
+      'PRIVATE-TOKEN': this.token,
+      'Content-Type': 'application/json',
+    };
+  }
+
+  getPRIdentifier(): PRIdentifier | null {
+    // Set on merge_request_event pipelines only — a branch pipeline has no MR
+    const iid = process.env.CI_MERGE_REQUEST_IID;
+    if (!iid) return null;
+
+    return {
+      provider: 'gitlab',
+      prNumber: iid,
+      repo: process.env.CI_PROJECT_PATH || this.projectId,
+    };
+  }
+
+  async postComment(content: string, marker: string = MARKER): Promise<void> {
+    const mr = this.getPRIdentifier();
+    if (!mr) {
+      throw new Error(
+        'Could not determine the merge request IID. Is this a merge_request_event pipeline?'
+      );
+    }
+
+    const markedContent = `${marker}\n${content}`;
+    const existingId = await this.findExistingNote(mr.prNumber, marker);
+
+    if (existingId) {
+      await this.updateNote(mr.prNumber, existingId, markedContent);
+    } else {
+      await this.createNote(mr.prNumber, markedContent);
+    }
+  }
+
+  private notesUrl(iid: string): string {
+    return `${this.apiUrl}/projects/${encodeURIComponent(this.projectId)}/merge_requests/${iid}/notes`;
+  }
+
+  private async findExistingNote(iid: string, marker: string): Promise<number | null> {
+    const response = await fetch(`${this.notesUrl(iid)}?per_page=100`, {
+      headers: this.headers,
+    });
+
+    if (!response.ok) return null;
+
+    const notes = (await response.json()) as Array<{ id: number; body: string }>;
+    return notes.find((note) => note.body.startsWith(marker))?.id ?? null;
+  }
+
+  private async createNote(iid: string, body: string): Promise<void> {
+    const response = await fetch(this.notesUrl(iid), {
+      method: 'POST',
+      headers: this.headers,
+      body: JSON.stringify({ body }),
+    });
+
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(
+        `Failed to create GitLab note: ${response.status} ${sanitizeErrorBody(error)}`
+      );
+    }
+  }
+
+  private async updateNote(iid: string, noteId: number, body: string): Promise<void> {
+    const response = await fetch(`${this.notesUrl(iid)}/${noteId}`, {
+      method: 'PUT',
+      headers: this.headers,
+      body: JSON.stringify({ body }),
+    });
+
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(
+        `Failed to update GitLab note: ${response.status} ${sanitizeErrorBody(error)}`
+      );
+    }
+  }
+}


### PR DESCRIPTION
Closes #16. **Stacked on #64** — merge that first; this retargets to `main` automatically.

## What

`aida comment` now auto-detects GitLab CI and posts the report as a merge request note, finding and updating **its own note by marker** on re-runs instead of piling new ones onto the MR — the same behaviour as the GitHub provider.

- Uses `CI_MERGE_REQUEST_IID`, `CI_PROJECT_ID` and `CI_API_V4_URL`, so **self-managed instances work with no configuration**.
- Requires `GITLAB_TOKEN` (project or group access token, `api` scope). `CI_JOB_TOKEN` **cannot** post notes, so it is deliberately not used as a fallback: the command fails with that explanation rather than an opaque 401 at post time.
- GitLab token patterns (`glpat-`, `gloas-`, …) are scrubbed from any surfaced API error, matching what the GitHub provider does.

PR-scoped collection (`--pr`) already handled GitLab via `CI_MERGE_REQUEST_DIFF_BASE_SHA`, so `collect → analyze → report → comment` now works end to end there. The README gains a working `.gitlab-ci.yml` for the whole loop.

## Scope note

Bitbucket (#17) is closed as out of scope for now, per the decision to focus the release on GitHub + GitLab. The `CIProvider` interface stays provider-agnostic, so it remains a clean contribution for anyone who wants it.

## Testing

158 tests pass (core 82, metrics 43, cli 33). New: provider detection across GitHub/GitLab/neither, MR iid resolution incl. the branch-pipeline case, note creation vs. update-by-marker, `PRIVATE-TOKEN` auth, the missing-token message, and a test asserting the token never appears in a surfaced error. Typecheck and lint clean.

No live GitLab instance was used: the provider is tested against a stubbed `fetch`. Worth a real-instance smoke test before relying on it in production.

Co-Authored-By: Claude <noreply@anthropic.com>
