### PR TITLE
feat: age-normalized fair comparison (#29), within-category comparison (#36), outcome correlation (#26)

### DIFF
--- a/.changeset/fair-comparison-outcome-correlation.md
+++ b/.changeset/fair-comparison-outcome-correlation.md
@@ -1,0 +1,18 @@
+---
+'@aida-dev/core': minor
+'@aida-dev/metrics': minor
+'@aida-dev/cli': minor
+---
+
+Age-normalized fair comparison (#29), within-category comparison (#36), outcome correlation (#26)
+
+**Fair comparison (#29)** — the raw AI vs Baseline table can be misleading when one cohort's commits are systematically older than the other's: an older cohort accumulates persistence simply from clock time. `metrics.json` gains `fairComparison`, recomputing both cohorts' persistence with each file's observation window capped to the younger cohort's average commit age. Reported alongside the raw comparison, never in place of it; null under the same condition as `baseline`.
+
+**Within-category comparison (#36 step 2)** — a pooled delta can hide a task-mix confound (AI mostly writing tests, humans mostly writing source). `metrics.json` gains `byCategory`: persistence per file category (source/tests/migrations/config/docs/generated) for each cohort, with a delta only where both sides touched that category. Always present, useful even without a baseline.
+
+**Outcome correlation (#26)**, scoped to what git can answer — no incidents, no SAST, both would need network access this tool deliberately doesn't have:
+
+- `commit-stream.json`: new `revertsCommit` field, parsed from the full commit body at collect time (`git revert` writes "This reverts commit \<sha\>." — the only reliable link back to what was reverted).
+- `metrics.json` gains `outcomeCorrelation`: reverts resolved and attributed to the **reverted** commit's cohort/mode; hotfix-pattern commits (`fix`/`hotfix`/`patch`) linked to the closest prior touch of the same file(s) within a window (default 7 days, `--hotfix-window`) and attributed to that antecedent's cohort/mode. Always present, a repo-level property rather than a cohort comparison.
+
+All three fields are additive; `schemaVersion` stays unchanged per the #53 contract.

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ aida report --out-dir ./aida-output
 - `--default-attribution <value>` - Prior for unattributed commits: `ai` | `human` | `unknown`
 - `--coverage-threshold <fraction>` - Coverage below this flags metrics as low-confidence (default: 0.7)
 - `--coverage-window <days>` - Window for the actionable coverage figure (default: 90)
+- `--hotfix-window <days>` - Window for linking a hotfix to its likely antecedent (default: 7)
 - `--out-dir <path>` - Output directory (default: ./aida-output)
 - `--verbose` - Verbose logging
 
@@ -469,6 +470,27 @@ The `metrics.json` output includes `baseline` (human cohort) and `delta` (AI min
 The markdown report renders a side-by-side comparison table at the top.  
 If no commits are attributed `human` and no `defaultAttribution` prior assigns the unknowns, `baseline` and `delta` are `null`: AIDA does not invent a comparison cohort.
 
+### Fair Comparison (age-normalized)
+
+The raw AI vs Baseline table can be misleading when one cohort's commits are systematically older or younger than the other's — an older cohort accumulates persistence simply from having existed longer, not from better code ([#29](https://github.com/ceccode/AIDA-Metrics/issues/29)).
+
+`metrics.json` gains `fairComparison`: both cohorts' persistence recomputed with each file's observation window **capped** to `capDays` — the younger cohort's average commit age — so neither side gets credit for clock time it hasn't actually had. Reported alongside the raw comparison, never in place of it. Null under the same condition as `baseline` (no human-attributed commits and no prior).
+
+### Within-Category Comparison
+
+A pooled AI-vs-baseline delta can hide a task-mix confound: if AI mostly touches tests and humans mostly touch source, the delta reflects *what* each cohort worked on, not code quality ([#36](https://github.com/ceccode/AIDA-Metrics/issues/36)).
+
+`metrics.json` gains `byCategory`: persistence computed separately per file category (`source` / `tests` / `migrations` / `config` / `docs` / `generated`) for each cohort, with a delta only where both sides touched that category. Always present — useful even without a baseline, e.g. to compare AI-written tests against AI-written source within the same repo.
+
+### Outcome Correlation
+
+Whether AI-generated code causes more rework is the highest-value question for engineering leadership — but most of it (incidents, vulnerabilities) lives outside git, in PagerDuty/Jira/SAST tools, and pulling those in would need network access AIDA deliberately doesn't have for its core commands ([#26](https://github.com/ceccode/AIDA-Metrics/issues/26)). Scoped to what git itself can answer:
+
+- **Reverts**: a `git revert` writes "This reverts commit \<sha\>." into the generated commit's body — parsed at collect time into `revertsCommit`. `metrics.json`'s `outcomeCorrelation.reverts` reports how many were found and resolved, broken down by the **reverted** commit's attribution and autonomy mode.
+- **Hotfixes**: commits matching a `fix`/`hotfix`/`patch` subject convention. Each is linked to the most recent prior commit that touched the same file(s), within a window (default 7 days, `--hotfix-window`) — the closest antecedent across all its files, so a hotfix touching several files links to whichever was most recently disturbed. `outcomeCorrelation.hotfixes` reports totals, how many were linked, and the antecedent's attribution/mode.
+
+Both are always present in `metrics.json` (never gated on a baseline cohort — they're a property of the repo, not a comparison) and rendered in the report only when at least one is non-zero.
+
 ### Known Limits
 
 These metrics are honest approximations, not ground truth. Read the numbers with these caveats in mind:
@@ -477,8 +499,9 @@ These metrics are honest approximations, not ground truth. Read the numbers with
 - **Git can't see discarded work** — squash merges and deleted branches erase unmerged commits, which is why the merge ratio was removed entirely rather than patched ([#20](https://github.com/ceccode/AIDA-Metrics/issues/20)). PR acceptance ([#51](https://github.com/ceccode/AIDA-Metrics/issues/51)) answers the question from the forge API instead.
 - **The attribution manifest does not apply to PR commits** — manifest entries are keyed by hash, and a squash-merged PR's original commits have different hashes from what landed on the default branch. PR-level attribution therefore relies on trailers alone, so a repo that adopted trailers late will see more `unknown` PRs than `unknown` commits.
 - **Persistence and rework are file-level** — one AI-touched line marks the whole file. `aida blame` ([#23](https://github.com/ceccode/AIDA-Metrics/issues/23)) gives exact per-line attribution for the living codebase; the file-level figures remain as the fast path.
-- **Cohort age skews persistence** — older commits have had more time to accumulate survival. The report now shows each cohort's age so you can judge fairness; normalization is still open ([#29](https://github.com/ceccode/AIDA-Metrics/issues/29)).
-- **Task mix skews persistence** — AI is often pointed at boilerplate, tests, and migrations, which survive longer because nobody has a reason to touch them. The report now shows each cohort's file-category mix; within-category comparison is still open ([#36](https://github.com/ceccode/AIDA-Metrics/issues/36)).
+- **Cohort age skews raw persistence** — older commits have had more time to accumulate survival. The report shows each cohort's age, and the fair comparison ([#29](https://github.com/ceccode/AIDA-Metrics/issues/29)) caps both sides to the same observation window so a stale delta can't pass as a quality signal.
+- **Task mix skews pooled persistence** — AI is often pointed at boilerplate, tests, and migrations, which survive longer because nobody has a reason to touch them. The within-category comparison ([#36](https://github.com/ceccode/AIDA-Metrics/issues/36)) compares like with like instead of pooling.
+- **Outcome correlation is git-only** — hotfix linking is a heuristic (closest prior touch within a window, not proven causation), and a chained hotfix attributes to the immediately preceding fix rather than the original commit. Incidents and vulnerabilities aren't represented at all ([#26](https://github.com/ceccode/AIDA-Metrics/issues/26)).
 
 ## Output Files
 
@@ -603,7 +626,8 @@ Bitbucket is currently out of scope ([#17](https://github.com/ceccode/AIDA-Metri
 - **v0.18** ✅ Commit-time mode stamping via git hook — `AI-Mode` trailer, `declared` evidence at the source ([#61](https://github.com/ceccode/AIDA-Metrics/issues/61)).  
 - **v0.19** ✅ Windowed coverage ([#52](https://github.com/ceccode/AIDA-Metrics/issues/52)) and rework rate with censoring ([#22](https://github.com/ceccode/AIDA-Metrics/issues/22)).  
 - **v0.20** ✅ GitLab CI provider — MR comments with note reuse ([#16](https://github.com/ceccode/AIDA-Metrics/issues/16)).  
-- **v0.21** ✅ Line-level survival via `aida blame` — exact per-line attribution, binaries excluded ([#23](https://github.com/ceccode/AIDA-Metrics/issues/23)).  
+- **v0.21** ✅ Line-level survival via `aida blame` — exact per-line attribution, binaries excluded ([#23](https://github.com/ceccode/AIDA-Metrics/issues/23)).
+- **v0.22** ✅ Age-normalized fair comparison ([#29](https://github.com/ceccode/AIDA-Metrics/issues/29)), within-category comparison ([#36](https://github.com/ceccode/AIDA-Metrics/issues/36)), git-scoped outcome correlation — reverts and hotfixes ([#26](https://github.com/ceccode/AIDA-Metrics/issues/26)).  
 - **Next** → Autonomy as primary axis ([#25](https://github.com/ceccode/AIDA-Metrics/issues/25) step 3, once declared data accumulates), outcome correlation restricted to git-detectable reverts and hotfixes ([#26](https://github.com/ceccode/AIDA-Metrics/issues/26)).  
 - **Next** → Rework rate ([#22](https://github.com/ceccode/AIDA-Metrics/issues/22)), line-level persistence via blame ([#23](https://github.com/ceccode/AIDA-Metrics/issues/23)).  
 - **Next** → Outcome correlation ([#26](https://github.com/ceccode/AIDA-Metrics/issues/26)), cost metrics ([#27](https://github.com/ceccode/AIDA-Metrics/issues/27)).  

--- a/packages/cli/src/commands/analyze.ts
+++ b/packages/cli/src/commands/analyze.ts
@@ -43,6 +43,10 @@ export function createAnalyzeCommand(): Command {
       '--coverage-window <days>',
       'Window in days for the actionable coverage figure (default: 90)'
     )
+    .option(
+      '--hotfix-window <days>',
+      'Window in days for linking a hotfix to its likely antecedent (default: 7)'
+    )
     .option('--verbose', 'Verbose logging', false)
     .action(async (options) => {
       const config = CLIConfig.parse(options);
@@ -126,12 +130,23 @@ export function createAnalyzeCommand(): Command {
           logger.info(`Blame data loaded: ${blameStream.totalLines} lines`);
         }
 
+        const hotfixWindowDays = options.hotfixWindow ? Number(options.hotfixWindow) : undefined;
+        if (
+          hotfixWindowDays !== undefined &&
+          (!Number.isInteger(hotfixWindowDays) || hotfixWindowDays <= 0)
+        ) {
+          throw new Error(
+            `Invalid --hotfix-window "${options.hotfixWindow}": expected a positive integer`
+          );
+        }
+
         const metrics = calculateMetrics(commitStream, {
           defaultAttribution,
           coverageThreshold,
           coverageWindowDays,
           prStream,
           blameStream,
+          hotfixWindowDays,
         });
 
         const outputPath = join(config.outDir, 'metrics.json');
@@ -163,6 +178,12 @@ export function createAnalyzeCommand(): Command {
           logger.info(
             `PR acceptance overall: ${(metrics.prAcceptance.overall.acceptanceRate * 100).toFixed(1)}%` +
               (ai ? ` · AI PRs: ${(ai.acceptanceRate * 100).toFixed(1)}% (${ai.total})` : '')
+          );
+        }
+        const oc = metrics.outcomeCorrelation;
+        if (oc.reverts.total > 0 || oc.hotfixes.total > 0) {
+          logger.info(
+            `Outcome correlation: ${oc.reverts.resolved}/${oc.reverts.total} reverts resolved, ${oc.hotfixes.linked}/${oc.hotfixes.total} hotfixes linked`
           );
         }
         if (!metrics.baseline) {

--- a/packages/cli/src/commands/e2e.test.ts
+++ b/packages/cli/src/commands/e2e.test.ts
@@ -66,6 +66,13 @@ describe('collect → analyze → report end to end', () => {
     expect(attributions).toEqual(['ai', 'unknown']);
   });
 
+  it('always includes outcomeCorrelation, even with no reverts or hotfixes', async () => {
+    await run(createAnalyzeCommand(), ['--out-dir', outDir]);
+    const metrics = JSON.parse(readFileSync(join(outDir, 'metrics.json'), 'utf-8'));
+    expect(metrics.outcomeCorrelation.reverts.total).toBe(0);
+    expect(metrics.outcomeCorrelation.hotfixes.total).toBe(0);
+  });
+
   it('analyzes into versioned metrics with every block populated', async () => {
     await run(createAnalyzeCommand(), ['--out-dir', outDir]);
 

--- a/packages/cli/src/commands/report.ts
+++ b/packages/cli/src/commands/report.ts
@@ -40,6 +40,18 @@ function generateMarkdownReport(metrics: Metrics): string {
     ? 'Human baseline (assumed)'
     : 'Human baseline';
 
+  const fc = metrics.fairComparison;
+  const fairComparisonSection = fc
+    ? `
+**Age-normalized (fair) comparison** — both cohorts capped to ${fc.capDays} days of observation (the younger cohort's average commit age), so neither side gets credit for time it hasn't had:
+
+| Metric | AI commits (capped) | ${baselineLabel} (capped) | Delta |
+|---|---:|---:|---:|
+| Avg persistence (days) | ${fc.ai.avgDays} | ${fc.baseline.avgDays} | ${formatDelta(fc.delta.avgPersistenceDays, '')} |
+| Median persistence (days) | ${fc.ai.medianDays} | ${fc.baseline.medianDays} | ${formatDelta(fc.delta.medianPersistenceDays, '')} |
+`
+    : '';
+
   const comparisonSection = metrics.baseline && metrics.delta
     ? `## AI vs Baseline
 
@@ -48,7 +60,7 @@ function generateMarkdownReport(metrics: Metrics): string {
 | Commits | ${metrics.persistence.commitsConsidered} | ${metrics.baseline.persistence.commitsConsidered} | — |
 | Avg persistence (days) | ${metrics.persistence.avgDays} | ${metrics.baseline.persistence.avgDays} | ${formatDelta(metrics.delta.avgPersistenceDays, '')} |
 | Median persistence (days) | ${metrics.persistence.medianDays} | ${metrics.baseline.persistence.medianDays} | ${formatDelta(metrics.delta.medianPersistenceDays, '')} |
-`
+${fairComparisonSection}`
     : `## AI vs Baseline
 
 **No baseline available** — no commits are attributed as human, so there is nothing honest to compare against. If unattributed commits in this repo are human-authored, set \`"defaultAttribution": "human"\` in \`.aida.json\`.
@@ -64,6 +76,25 @@ function generateMarkdownReport(metrics: Metrics): string {
 
   const aiCtx = metrics.cohorts.ai;
   const baseCtx = metrics.cohorts.baseline;
+
+  function categoryRow(cat: (typeof categories)[number]) {
+    const c = metrics.byCategory[cat];
+    if (!c.ai && !c.baseline) return null;
+    return `| ${cat} | ${c.ai ? `${c.ai.avgDays}d (${c.ai.filesConsidered} files)` : '—'} | ${c.baseline ? `${c.baseline.avgDays}d (${c.baseline.filesConsidered} files)` : '—'} | ${c.deltaAvgDays !== null ? formatDelta(c.deltaAvgDays, '') : '—'} |`;
+  }
+  const categoryRows = categories.map(categoryRow).filter(Boolean);
+  const byCategorySection =
+    categoryRows.length > 0
+      ? `
+
+**Within-category comparison** — avg persistence per file category, instead of pooling everything (a mismatched task mix can't masquerade as a quality difference):
+
+| Category | AI avg persistence | Baseline avg persistence | Delta |
+|---|---:|---:|---:|
+${categoryRows.join('\n')}
+`
+      : '';
+
   const fairnessSection = `## Cohort Fairness
 
 Persistence comparisons are only meaningful between cohorts of similar **age** and **task mix**.
@@ -74,7 +105,7 @@ Persistence comparisons are only meaningful between cohorts of similar **age** a
 | Avg age (days) | ${aiCtx.age?.avgAgeDays ?? '—'} | ${baseCtx.age?.avgAgeDays ?? '—'} |
 | Median age (days) | ${aiCtx.age?.medianAgeDays ?? '—'} | ${baseCtx.age?.medianAgeDays ?? '—'} |
 ${categories.map((cat) => `| Files: ${cat} | ${mixCell(aiCtx.taskMix, cat)} | ${mixCell(baseCtx.taskMix, cat)} |`).join('\n')}
-`;
+${byCategorySection}`;
 
   const modeOrder = ['agent', 'assisted', 'autocomplete', 'none', 'unknown'] as const;
   const modeRows = modeOrder
@@ -118,6 +149,29 @@ Approximate survival of AI-introduced lines: **${(ls.approxSurvivalRate * 100).t
 
 `
     : '';
+
+  const oc = metrics.outcomeCorrelation;
+  function outcomeRow(label: string, counts: { ai: number; human: number; automated: number; unknown: number }) {
+    const total = counts.ai + counts.human + counts.automated + counts.unknown;
+    if (total === 0) return null;
+    return `| ${label} | ${counts.ai} | ${counts.human} | ${counts.automated} | ${counts.unknown} |`;
+  }
+  const outcomeRows = [
+    outcomeRow(`Reverted commits (${oc.reverts.resolved}/${oc.reverts.total} resolved)`, oc.reverts.byAttribution),
+    outcomeRow(`Hotfix antecedents (${oc.hotfixes.linked}/${oc.hotfixes.total} linked, ${oc.hotfixes.windowDays}d window)`, oc.hotfixes.byAttribution),
+  ].filter(Boolean);
+  const outcomeSection =
+    outcomeRows.length > 0
+      ? `## Outcome Correlation
+
+Reverts and hotfix-pattern commits, linked back to the attribution of the commit(s) they respond to — scoped to what git itself can answer (no incidents, no SAST).
+
+| Metric | ai | human | automated | unknown |
+|---|---:|---:|---:|---:|
+${outcomeRows.join('\n')}
+
+`
+      : '';
 
   const acc = metrics.prAcceptance;
   function accRow(label: string, stats: { total: number; merged: number; closed: number; acceptanceRate: number } | null) {
@@ -168,7 +222,7 @@ ${recentLine}
 **Autonomy:** agent ${a.modes.agent} · assisted ${a.modes.assisted} · autocomplete ${a.modes.autocomplete} · none ${a.modes.none} · unknown ${a.modes.unknown} — evidence: declared ${a.modeEvidence.declared} / inferred ${a.modeEvidence.inferred} / none ${a.modeEvidence.none}
 ${coverageWarning}${priorNote}
 ${comparisonSection}
-${byModeSection}${lineSection}${prSection}${fairnessSection}
+${byModeSection}${lineSection}${outcomeSection}${prSection}${fairnessSection}
 ## Persistence (file-level survival)
 - Commits considered: ${metrics.persistence.commitsConsidered}
 - Files measured: ${metrics.persistence.filesConsidered} (${metrics.persistence.censored} still surviving at collection time; ${metrics.persistence.filesExcluded} excluded: migrations/generated)

--- a/packages/core/src/git/collect.test.ts
+++ b/packages/core/src/git/collect.test.ts
@@ -280,3 +280,32 @@ describe('collectCommits synthetic PR merge (#40)', () => {
     ).toBe(true);
   });
 });
+
+describe('collectCommits revert detection (#26)', () => {
+  it('parses the target sha from a real git revert commit', async () => {
+    const repoPath = mkdtempSync(join(tmpdir(), 'aida-revert-'));
+    try {
+      execSync('git init -q -b main', { cwd: repoPath });
+      execSync('git config user.name test && git config user.email test@example.com', { cwd: repoPath });
+      writeFileSync(join(repoPath, 'app.ts'), 'v1\n');
+      execSync('git add -A && git commit -q -m "feat: introduce bug"', { cwd: repoPath });
+      const targetSha = execSync('git rev-parse HEAD', { cwd: repoPath }).toString().trim();
+
+      execSync(`git revert --no-edit ${targetSha}`, { cwd: repoPath, stdio: 'ignore' });
+
+      const stream = await collectCommits({ repoPath });
+      const revertCommit = stream.commits[0];
+
+      expect(revertCommit.message).toMatch(/^Revert /);
+      expect(revertCommit.revertsCommit).toBe(targetSha);
+      expect(stream.commits[1].revertsCommit).toBeNull();
+    } finally {
+      rmSync(repoPath, { recursive: true, force: true });
+    }
+  });
+
+  it('leaves revertsCommit null for ordinary commits', async () => {
+    const stream = await collectCommits({ repoPath });
+    expect(stream.commits.every((c) => c.revertsCommit === null)).toBe(true);
+  });
+});

--- a/packages/core/src/git/collect.ts
+++ b/packages/core/src/git/collect.ts
@@ -37,6 +37,10 @@ function isSyntheticPRMerge(commit: { parents: string[]; message: string }): boo
   return commit.parents.length > 1 && SYNTHETIC_MERGE_SUBJECT.test(commit.message.split('\n')[0].trim());
 }
 
+// The line `git revert` writes into the body of the revert commit it
+// generates: the only reliable link back to what was reverted (#26).
+const REVERT_TARGET = /This reverts commit ([0-9a-f]{7,40})/i;
+
 export async function detectDefaultBranch(git: SimpleGit): Promise<string> {
   try {
     // Try to get the default branch from origin/HEAD
@@ -201,6 +205,11 @@ export async function collectCommits(options: CollectOptions): Promise<CommitStr
       aiTag = applyManifest(aiTag, rawCommit.hash, manifestIndex, logger);
     }
 
+    // Revert target (#26): only the standard git-generated body line links
+    // a revert back to what it reverted; parsed from the full message,
+    // since the stored `message` field below is subject-only.
+    const revertMatch = rawCommit.message.match(REVERT_TARGET);
+
     const commit: Commit = {
       hash: rawCommit.hash,
       authorName: redactor ? redactor.name(rawCommit.authorName) : rawCommit.authorName,
@@ -212,6 +221,7 @@ export async function collectCommits(options: CollectOptions): Promise<CommitStr
       message: rawCommit.message.split('\n')[0],
       parents: rawCommit.parents,
       inDefaultBranchAncestry: defaultBranchHashes.has(rawCommit.hash),
+      revertsCommit: revertMatch ? revertMatch[1] : null,
       tags: aiTag,
       stats: rawCommit.stats,
     };

--- a/packages/core/src/schema/commit.ts
+++ b/packages/core/src/schema/commit.ts
@@ -18,6 +18,10 @@ export const Commit = z.object({
   message: z.string(),
   parents: z.array(z.string()),
   inDefaultBranchAncestry: z.boolean(), // set during collect
+  // Target of a `git revert` (#26), parsed from the full commit body at
+  // collect time ("This reverts commit <sha>."). Null for non-revert
+  // commits, or when the target isn't in the standard git-generated form.
+  revertsCommit: z.string().nullable().default(null),
   tags: z.object({
     ai: z.boolean(),
     // Four-state attribution (#34, #39). Heuristics emit 'ai' or 'unknown';

--- a/packages/metrics/src/cohort.test.ts
+++ b/packages/metrics/src/cohort.test.ts
@@ -14,6 +14,7 @@ function makeCommit(authorDate: string, files: string[] = []): Commit {
     message: 'commit',
     parents: [],
     inDefaultBranchAncestry: true,
+    revertsCommit: null,
     tags: { ai: false, attribution: 'unknown', mode: 'unknown', modeEvidence: 'none', level: 'none', sources: [] },
     stats: {
       totalAdditions: 1,

--- a/packages/metrics/src/index.test.ts
+++ b/packages/metrics/src/index.test.ts
@@ -13,6 +13,7 @@ function makeCommit(overrides: Partial<Commit> & { hash: string }): Commit {
     message: 'commit',
     parents: [],
     inDefaultBranchAncestry: true,
+    revertsCommit: null,
     tags: { ai: false, attribution: 'unknown', mode: 'unknown', modeEvidence: 'none', level: 'none', sources: [] },
     stats: { totalAdditions: 1, totalDeletions: 0, files: [] },
     ...overrides,
@@ -270,5 +271,140 @@ describe('calculateMetrics baseline cohort', () => {
     expect(metrics.persistence.commitsConsidered).toBe(2); // ai + unknown
     expect(metrics.baseline!.persistence.commitsConsidered).toBe(1); // human only
     expect(metrics.baseline!.assumed).toBe(false);
+  });
+});
+
+describe('fairComparison (#29 age-normalization)', () => {
+  it('is null when there is no baseline cohort', () => {
+    const metrics = calculateMetrics(makeStream([makeCommit({ hash: 'a1', tags: aiTags })]));
+    expect(metrics.fairComparison).toBeNull();
+  });
+
+  it('caps both cohorts to the younger cohort average age, unlike the raw comparison', () => {
+    // Baseline: old commit whose file was never touched again — accumulates
+    // a lot of raw persistence purely from clock time.
+    const oldDate = new Date(Date.now() - 200 * 24 * 60 * 60 * 1000).toISOString();
+    // AI: recent commit, also never touched again.
+    const recentDate = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
+
+    const metrics = calculateMetrics({
+      ...makeStream([
+        makeCommit({
+          hash: 'h1',
+          tags: humanTags,
+          authorDate: oldDate,
+          stats: { totalAdditions: 1, totalDeletions: 0, files: [{ path: 'old.ts', additions: 1, deletions: 0 }] },
+        }),
+        makeCommit({
+          hash: 'a1',
+          tags: aiTags,
+          authorDate: recentDate,
+          stats: { totalAdditions: 1, totalDeletions: 0, files: [{ path: 'new.ts', additions: 1, deletions: 0 }] },
+        }),
+      ]),
+      // Both commits post-date the fixed '2025-01-01' default: the
+      // observation end must be "now" for their persistence to make sense.
+      generatedAt: new Date().toISOString(),
+    });
+
+    // Raw comparison: baseline looks far more "persistent" just because it's old
+    expect(metrics.baseline!.persistence.avgDays).toBeGreaterThan(150);
+    expect(metrics.persistence.avgDays).toBeLessThan(15);
+
+    // Fair comparison: both capped to ~10 days (the AI cohort's average age)
+    expect(metrics.fairComparison).not.toBeNull();
+    expect(metrics.fairComparison!.capDays).toBeCloseTo(10, 0);
+    expect(metrics.fairComparison!.ai.avgDays).toBeLessThanOrEqual(10);
+    expect(metrics.fairComparison!.baseline.avgDays).toBeLessThanOrEqual(10);
+  });
+});
+
+describe('byCategory (#36 step 2 within-category comparison)', () => {
+  it('is computed even without a baseline cohort', () => {
+    const metrics = calculateMetrics(
+      makeStream([
+        makeCommit({
+          hash: 'a1',
+          tags: aiTags,
+          stats: {
+            totalAdditions: 2,
+            totalDeletions: 0,
+            files: [
+              { path: 'src/a.ts', additions: 1, deletions: 0 },
+              { path: 'src/a.test.ts', additions: 1, deletions: 0 },
+            ],
+          },
+        }),
+      ])
+    );
+
+    expect(metrics.byCategory.source.ai?.filesConsidered).toBe(1);
+    expect(metrics.byCategory.tests.ai?.filesConsidered).toBe(1);
+    expect(metrics.byCategory.source.baseline).toBeNull();
+    expect(metrics.byCategory.source.deltaAvgDays).toBeNull();
+    expect(metrics.byCategory.migrations.ai).toBeNull(); // no migration files touched
+  });
+
+  it('computes a delta only when both sides have files in that category', () => {
+    const metrics = calculateMetrics(
+      makeStream([
+        makeCommit({
+          hash: 'a1',
+          tags: aiTags,
+          authorDate: '2025-01-01T00:00:00.000Z',
+          stats: { totalAdditions: 1, totalDeletions: 0, files: [{ path: 'src/a.ts', additions: 1, deletions: 0 }] },
+        }),
+        makeCommit({
+          hash: 'a2',
+          tags: aiTags,
+          authorDate: '2025-01-10T00:00:00.000Z',
+          stats: { totalAdditions: 1, totalDeletions: 0, files: [{ path: 'src/a.ts', additions: 1, deletions: 0, status: 'modified' }] },
+        }),
+        makeCommit({
+          hash: 'h1',
+          tags: humanTags,
+          authorDate: '2025-01-01T00:00:00.000Z',
+          stats: { totalAdditions: 1, totalDeletions: 0, files: [{ path: 'src/b.ts', additions: 1, deletions: 0 }] },
+        }),
+      ])
+    );
+
+    expect(metrics.byCategory.source.ai?.filesConsidered).toBe(1);
+    expect(metrics.byCategory.source.baseline?.filesConsidered).toBe(1);
+    expect(metrics.byCategory.source.deltaAvgDays).not.toBeNull();
+    expect(metrics.byCategory.tests.ai).toBeNull();
+    expect(metrics.byCategory.tests.deltaAvgDays).toBeNull();
+  });
+});
+
+describe('outcomeCorrelation (#26)', () => {
+  it('is always present and reflects reverts/hotfixes end to end via calculateMetrics', () => {
+    const metrics = calculateMetrics(
+      makeStream([
+        makeCommit({
+          hash: 'a1',
+          tags: aiTags,
+          authorDate: '2025-01-01T00:00:00.000Z',
+          stats: { totalAdditions: 1, totalDeletions: 0, files: [{ path: 'app.ts', additions: 1, deletions: 0 }] },
+        }),
+        makeCommit({
+          hash: 'r1',
+          message: 'Revert "feat: a1"',
+          authorDate: '2025-01-02T00:00:00.000Z',
+          revertsCommit: 'a1',
+        }),
+      ]),
+      { hotfixWindowDays: 7 }
+    );
+
+    expect(metrics.outcomeCorrelation.reverts.total).toBe(1);
+    expect(metrics.outcomeCorrelation.reverts.resolved).toBe(1);
+    expect(metrics.outcomeCorrelation.reverts.byAttribution.ai).toBe(1);
+  });
+
+  it('is present (all zero) even for a stream with no reverts or hotfixes', () => {
+    const metrics = calculateMetrics(makeStream([makeCommit({ hash: 'a1', tags: aiTags })]));
+    expect(metrics.outcomeCorrelation.reverts.total).toBe(0);
+    expect(metrics.outcomeCorrelation.hotfixes.total).toBe(0);
   });
 });

--- a/packages/metrics/src/index.ts
+++ b/packages/metrics/src/index.ts
@@ -9,14 +9,24 @@ import {
 import { calculateAgeStats, calculateCategoryCounts } from './cohort.js';
 import { calculateBaselinePersistence, calculatePersistence } from './persistence.js';
 import { calculateLineSurvival } from './line-survival.js';
+import { calculateOutcomeCorrelation } from './outcome-correlation.js';
 import { calculatePRAcceptance } from './pr-acceptance.js';
-import { Attribution, ByMode, Metrics, ModeStats } from './schema/metrics.js';
+import {
+  Attribution,
+  ByCategory,
+  ByMode,
+  CategoryComparison,
+  FileCategory,
+  Metrics,
+  ModeStats,
+} from './schema/metrics.js';
 
 export * from './schema/metrics.js';
 export * from './cohort.js';
 export * from './persistence.js';
 export * from './pr-acceptance.js';
 export * from './line-survival.js';
+export * from './outcome-correlation.js';
 
 export const DEFAULT_COVERAGE_WINDOW_DAYS = 90;
 
@@ -30,6 +40,8 @@ export interface MetricsOptions {
   prStream?: PRStream | null;
   // Optional line-level blame data from `aida blame` (#23)
   blameStream?: BlameStream | null;
+  // Window for linking a hotfix to its likely antecedent (#26)
+  hotfixWindowDays?: number;
 }
 
 function round(value: number, decimals: number): number {
@@ -47,6 +59,7 @@ export function calculateMetrics(
     coverageWindowDays = DEFAULT_COVERAGE_WINDOW_DAYS,
     prStream = null,
     blameStream = null,
+    hotfixWindowDays,
   } = options;
 
   const counts = { ai: 0, human: 0, automated: 0, unknown: 0 };
@@ -170,10 +183,77 @@ export function calculateMetrics(
       }
     : null;
 
+  // Age-normalized comparison (#29): cap both sides to the younger cohort's
+  // average age, so an older cohort can't win on clock time alone. Requires
+  // both cohorts to have a known age (i.e. to be non-empty) — same
+  // precondition as `baseline`.
+  const aiAge = cohorts.ai.age;
+  const baselineAge = cohorts.baseline.age;
+  const fairComparison =
+    baseline && aiAge && baselineAge
+      ? (() => {
+          const capDays = Math.min(aiAge.avgAgeDays, baselineAge.avgAgeDays);
+          const cappedAI = calculatePersistence(commitStream, isAI, { maxObservationDays: capDays });
+          const cappedBaseline = calculateBaselinePersistence(commitStream, isBaseline, {
+            maxObservationDays: capDays,
+          });
+          return {
+            capDays: round(capDays, 2),
+            ai: cappedAI,
+            baseline: cappedBaseline,
+            delta: {
+              avgPersistenceDays: round(cappedAI.avgDays - cappedBaseline.avgDays, 2),
+              medianPersistenceDays: round(cappedAI.medianDays - cappedBaseline.medianDays, 2),
+            },
+          };
+        })()
+      : null;
+
+  // Within-category comparison (#36 step 2): persistence per file category,
+  // AI vs baseline, instead of only reporting the mix. Always computed —
+  // useful even without a baseline cohort, to compare e.g. AI-written tests
+  // against AI-written source within the same repo.
+  const CATEGORIES: FileCategory[] = ['source', 'tests', 'migrations', 'config', 'docs', 'generated'];
+  const byCategory = Object.fromEntries(
+    CATEGORIES.map((category) => {
+      const toLean = (p: ReturnType<typeof calculatePersistence>) =>
+        p.filesConsidered > 0
+          ? { filesConsidered: p.filesConsidered, avgDays: p.avgDays, medianDays: p.medianDays }
+          : null;
+
+      const aiCat = toLean(
+        calculatePersistence(commitStream, isAI, { onlyCategory: category, excludeCategories: [] })
+      );
+      const baselineCat = baseline
+        ? toLean(
+            calculateBaselinePersistence(commitStream, isBaseline, {
+              onlyCategory: category,
+              excludeCategories: [],
+            })
+          )
+        : null;
+
+      const comparison: CategoryComparison = {
+        ai: aiCat,
+        baseline: baselineCat,
+        deltaAvgDays: aiCat && baselineCat ? round(aiCat.avgDays - baselineCat.avgDays, 2) : null,
+        deltaMedianDays:
+          aiCat && baselineCat ? round(aiCat.medianDays - baselineCat.medianDays, 2) : null,
+      };
+      return [category, comparison];
+    })
+  ) as ByCategory;
+
   // PR acceptance (#51): present only when fetch-prs ran
   const prAcceptance = prStream ? calculatePRAcceptance(prStream) : null;
   // Line-level survival (#23): present only when blame ran
   const lineSurvival = blameStream ? calculateLineSurvival(blameStream, commitStream) : null;
+  // Outcome correlation (#26): reverts and hotfixes linked to what they
+  // respond to. Always computed — a repo-level property, not a comparison.
+  const outcomeCorrelation = calculateOutcomeCorrelation(
+    commitStream,
+    hotfixWindowDays !== undefined ? { hotfixWindowDays } : {}
+  );
 
   const caveats = [
     `Attribution coverage is ${(coverage * 100).toFixed(1)}%: metrics only describe commits whose provenance is known.`,
@@ -182,6 +262,7 @@ export function calculateMetrics(
     'Persistence is survival: days until the first subsequent modification. Files never modified again are censored at collection time. Migrations and generated files (convention-driven lifecycles) are excluded.',
     'Persistence comparisons are only meaningful between cohorts of similar age and task mix — check the cohorts section before reading the delta.',
     'AI tagging uses heuristic patterns; false positives/negatives possible.',
+    'Outcome correlation only covers what git can see: reverts resolved by hash and hotfix-pattern commits linked to the most recent prior touch of the same file(s). Incidents, SAST findings, and reverts/hotfixes outside the collected window are not represented.',
   ];
   if (prAcceptance?.truncated) {
     caveats.push(
@@ -201,6 +282,11 @@ export function calculateMetrics(
   if (!prAcceptance) {
     caveats.push(
       "PR acceptance is unavailable: run 'aida fetch-prs' to measure whether AI work is accepted. Git history alone cannot answer that."
+    );
+  }
+  if (fairComparison) {
+    caveats.push(
+      `Fair comparison caps both cohorts' observation window to ${fairComparison.capDays} days (the younger cohort's average commit age) — the raw AI vs Baseline table above does not, and may simply reflect one cohort having existed longer.`
     );
   }
   if (baseline?.assumed) {
@@ -227,6 +313,9 @@ export function calculateMetrics(
     persistence,
     cohorts,
     byMode,
+    fairComparison,
+    byCategory,
+    outcomeCorrelation,
     prAcceptance,
     lineSurvival,
     baseline,

--- a/packages/metrics/src/line-survival.test.ts
+++ b/packages/metrics/src/line-survival.test.ts
@@ -14,6 +14,7 @@ function makeCommit(hash: string, tags: Partial<Commit['tags']>, additions = 0):
     message: 'commit',
     parents: [],
     inDefaultBranchAncestry: true,
+    revertsCommit: null,
     tags: {
       ai: false,
       attribution: 'unknown',

--- a/packages/metrics/src/outcome-correlation.test.ts
+++ b/packages/metrics/src/outcome-correlation.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect } from 'vitest';
+import { Commit, CommitStream } from '@aida-dev/core';
+import { calculateOutcomeCorrelation } from './outcome-correlation.js';
+
+function makeCommit(overrides: Partial<Commit> & { hash: string }): Commit {
+  return {
+    authorName: 'Test',
+    authorEmail: 'test@example.com',
+    authorDate: '2025-01-01T00:00:00.000Z',
+    committerName: 'Test',
+    committerEmail: 'test@example.com',
+    committerDate: '2025-01-01T00:00:00.000Z',
+    message: 'commit',
+    parents: [],
+    inDefaultBranchAncestry: true,
+    revertsCommit: null,
+    tags: { ai: false, attribution: 'unknown', mode: 'unknown', modeEvidence: 'none', level: 'none', sources: [] },
+    stats: { totalAdditions: 1, totalDeletions: 0, files: [] },
+    ...overrides,
+  };
+}
+
+function makeStream(commits: Commit[]): CommitStream {
+  return {
+    schemaVersion: 1,
+    repoPath: '/test',
+    defaultBranch: 'main',
+    generatedAt: '2025-02-01T00:00:00.000Z',
+    aiPatterns: [],
+    commits,
+  };
+}
+
+const aiTags: Commit['tags'] = { ai: true, attribution: 'ai', mode: 'agent', modeEvidence: 'inferred', level: 'explicit', sources: [] };
+const humanTags: Commit['tags'] = { ai: false, attribution: 'human', mode: 'none', modeEvidence: 'declared', level: 'none', sources: [] };
+
+describe('reverts', () => {
+  it('attributes a resolved revert to the reverted commit, not the revert itself', () => {
+    const result = calculateOutcomeCorrelation(
+      makeStream([
+        makeCommit({ hash: 'a1', tags: aiTags }),
+        makeCommit({ hash: 'r1', tags: humanTags, revertsCommit: 'a1' }),
+      ])
+    );
+    expect(result.reverts.total).toBe(1);
+    expect(result.reverts.resolved).toBe(1);
+    expect(result.reverts.byAttribution.ai).toBe(1); // a1's cohort, not r1's
+    expect(result.reverts.byMode.agent).toBe(1);
+  });
+
+  it('counts an unresolvable revert target without failing', () => {
+    const result = calculateOutcomeCorrelation(
+      makeStream([makeCommit({ hash: 'r1', revertsCommit: 'not-in-stream' })])
+    );
+    expect(result.reverts.total).toBe(1);
+    expect(result.reverts.resolved).toBe(0);
+    expect(result.reverts.byAttribution.ai).toBe(0);
+  });
+
+  it('reports zero reverts when none are present', () => {
+    const result = calculateOutcomeCorrelation(makeStream([makeCommit({ hash: 'a1' })]));
+    expect(result.reverts.total).toBe(0);
+    expect(result.reverts.resolved).toBe(0);
+  });
+});
+
+describe('hotfixes', () => {
+  it('links a hotfix to the most recent prior touch of the same file, within the window', () => {
+    const result = calculateOutcomeCorrelation(
+      makeStream([
+        makeCommit({
+          hash: 'a1',
+          tags: aiTags,
+          authorDate: '2025-01-01T00:00:00.000Z',
+          stats: { totalAdditions: 1, totalDeletions: 0, files: [{ path: 'app.ts', additions: 1, deletions: 0 }] },
+        }),
+        makeCommit({
+          hash: 'f1',
+          message: 'fix: null pointer',
+          authorDate: '2025-01-03T00:00:00.000Z',
+          stats: { totalAdditions: 1, totalDeletions: 0, files: [{ path: 'app.ts', additions: 1, deletions: 0, status: 'modified' }] },
+        }),
+      ]),
+      { hotfixWindowDays: 7 }
+    );
+    expect(result.hotfixes.total).toBe(1);
+    expect(result.hotfixes.linked).toBe(1);
+    expect(result.hotfixes.byAttribution.ai).toBe(1); // a1's cohort
+  });
+
+  it('does not link a hotfix to a touch outside the window', () => {
+    const result = calculateOutcomeCorrelation(
+      makeStream([
+        makeCommit({
+          hash: 'a1',
+          tags: aiTags,
+          authorDate: '2025-01-01T00:00:00.000Z',
+          stats: { totalAdditions: 1, totalDeletions: 0, files: [{ path: 'app.ts', additions: 1, deletions: 0 }] },
+        }),
+        makeCommit({
+          hash: 'f1',
+          message: 'fix: something unrelated by now',
+          authorDate: '2025-02-01T00:00:00.000Z',
+          stats: { totalAdditions: 1, totalDeletions: 0, files: [{ path: 'app.ts', additions: 1, deletions: 0, status: 'modified' }] },
+        }),
+      ]),
+      { hotfixWindowDays: 7 }
+    );
+    expect(result.hotfixes.total).toBe(1);
+    expect(result.hotfixes.linked).toBe(0);
+  });
+
+  it('picks the closest antecedent when a hotfix touches multiple files', () => {
+    const result = calculateOutcomeCorrelation(
+      makeStream([
+        makeCommit({
+          hash: 'old',
+          tags: humanTags,
+          authorDate: '2025-01-01T00:00:00.000Z',
+          stats: { totalAdditions: 1, totalDeletions: 0, files: [{ path: 'a.ts', additions: 1, deletions: 0 }] },
+        }),
+        makeCommit({
+          hash: 'recent',
+          tags: aiTags,
+          authorDate: '2025-01-05T00:00:00.000Z',
+          stats: { totalAdditions: 1, totalDeletions: 0, files: [{ path: 'b.ts', additions: 1, deletions: 0 }] },
+        }),
+        makeCommit({
+          hash: 'f1',
+          message: 'hotfix: both',
+          authorDate: '2025-01-06T00:00:00.000Z',
+          stats: {
+            totalAdditions: 2,
+            totalDeletions: 0,
+            files: [
+              { path: 'a.ts', additions: 1, deletions: 0, status: 'modified' },
+              { path: 'b.ts', additions: 1, deletions: 0, status: 'modified' },
+            ],
+          },
+        }),
+      ]),
+      { hotfixWindowDays: 30 }
+    );
+    // b.ts (recent, 1 day gap) is closer than a.ts (old, 5 day gap)
+    expect(result.hotfixes.byAttribution.ai).toBe(1);
+    expect(result.hotfixes.byAttribution.human).toBe(0);
+  });
+
+  it('recognizes conventional-commit fix and hotfix prefixes, ignores unrelated commits', () => {
+    const result = calculateOutcomeCorrelation(
+      makeStream([
+        makeCommit({ hash: 'c1', message: 'fix(auth): token refresh' }),
+        makeCommit({ hash: 'c2', message: 'hotfix: rollback bad deploy' }),
+        makeCommit({ hash: 'c3', message: 'feat: add dashboard' }),
+      ])
+    );
+    expect(result.hotfixes.total).toBe(2);
+  });
+
+  it('lets a chained hotfix attribute to the immediately preceding hotfix', () => {
+    const result = calculateOutcomeCorrelation(
+      makeStream([
+        makeCommit({
+          hash: 'a1',
+          tags: aiTags,
+          authorDate: '2025-01-01T00:00:00.000Z',
+          stats: { totalAdditions: 1, totalDeletions: 0, files: [{ path: 'app.ts', additions: 1, deletions: 0 }] },
+        }),
+        makeCommit({
+          hash: 'f1',
+          tags: humanTags,
+          message: 'fix: first attempt',
+          authorDate: '2025-01-02T00:00:00.000Z',
+          stats: { totalAdditions: 1, totalDeletions: 0, files: [{ path: 'app.ts', additions: 1, deletions: 0, status: 'modified' }] },
+        }),
+        makeCommit({
+          hash: 'f2',
+          message: 'fix: actually fix it this time',
+          authorDate: '2025-01-03T00:00:00.000Z',
+          stats: { totalAdditions: 1, totalDeletions: 0, files: [{ path: 'app.ts', additions: 1, deletions: 0, status: 'modified' }] },
+        }),
+      ]),
+      { hotfixWindowDays: 7 }
+    );
+    expect(result.hotfixes.total).toBe(2);
+    expect(result.hotfixes.linked).toBe(2);
+    // f1 links to a1 (ai); f2 links to f1 (human), not back to a1
+    expect(result.hotfixes.byAttribution.ai).toBe(1);
+    expect(result.hotfixes.byAttribution.human).toBe(1);
+  });
+
+  it('reports zero hotfixes when none are present', () => {
+    const result = calculateOutcomeCorrelation(makeStream([makeCommit({ hash: 'a1' })]));
+    expect(result.hotfixes.total).toBe(0);
+    expect(result.hotfixes.linked).toBe(0);
+  });
+});

--- a/packages/metrics/src/outcome-correlation.ts
+++ b/packages/metrics/src/outcome-correlation.ts
@@ -1,0 +1,112 @@
+import { Commit, CommitStream, daysBetween } from '@aida-dev/core';
+import { HotfixStats, OutcomeCorrelation, RevertStats } from './schema/metrics.js';
+
+// Outcome correlation (#26), scoped to what git can actually answer.
+//
+// The original ask also wanted incidents (PagerDuty/Jira/Slack) and SAST
+// findings — dropped: fetching those would need network access this tool
+// deliberately doesn't have (the same reasoning that scoped fetch-prs, #51,
+// to its own opt-in command). What's left is git-detectable and exact:
+// reverts and hotfix-pattern commits, linked back to the attribution/mode
+// of the commit(s) they respond to.
+
+export const DEFAULT_HOTFIX_WINDOW_DAYS = 7;
+
+// Conventional-commit fix prefixes, plus explicit hotfix/patch language.
+const HOTFIX_SUBJECT = /^(fix|hotfix|patch)(\(|:|\s|$)/i;
+
+function emptyAttributionCounts() {
+  return { ai: 0, human: 0, automated: 0, unknown: 0 };
+}
+function emptyModeCounts() {
+  return { none: 0, autocomplete: 0, assisted: 0, agent: 0, unknown: 0 };
+}
+
+function calculateReverts(commitStream: CommitStream): RevertStats {
+  const byHash = new Map(commitStream.commits.map((c) => [c.hash, c]));
+  let total = 0;
+  let resolved = 0;
+  const byAttribution = emptyAttributionCounts();
+  const byMode = emptyModeCounts();
+
+  for (const commit of commitStream.commits) {
+    if (!commit.revertsCommit) continue;
+    total++;
+    const target = byHash.get(commit.revertsCommit);
+    // Not every revert target is in the collected window (e.g. --since, or
+    // the target predates collection) — that's expected, not an error.
+    if (!target) continue;
+    resolved++;
+    byAttribution[target.tags.attribution]++;
+    byMode[target.tags.mode]++;
+  }
+
+  return { total, resolved, byAttribution, byMode };
+}
+
+// A hotfix's "cause" is approximated as the most recent commit that touched
+// the same file(s) beforehand, within the window. When a hotfix touches
+// several files, the closest antecedent across all of them wins — the file
+// most recently disturbed is the most likely trigger.
+function calculateHotfixes(
+  commitStream: CommitStream,
+  windowDays: number
+): HotfixStats {
+  const sorted = [...commitStream.commits].sort(
+    (a, b) => new Date(a.authorDate).getTime() - new Date(b.authorDate).getTime()
+  );
+
+  const lastTouch = new Map<string, { date: Date; commit: Commit }>();
+  let total = 0;
+  let linked = 0;
+  const byAttribution = emptyAttributionCounts();
+  const byMode = emptyModeCounts();
+
+  for (const commit of sorted) {
+    if (HOTFIX_SUBJECT.test(commit.message)) {
+      total++;
+      let antecedent: Commit | null = null;
+      let smallestGap = Infinity;
+
+      for (const file of commit.stats.files) {
+        const prior = lastTouch.get(file.path);
+        if (!prior) continue;
+        const gapDays = daysBetween(prior.date, new Date(commit.authorDate));
+        if (gapDays <= windowDays && gapDays < smallestGap) {
+          smallestGap = gapDays;
+          antecedent = prior.commit;
+        }
+      }
+
+      if (antecedent) {
+        linked++;
+        byAttribution[antecedent.tags.attribution]++;
+        byMode[antecedent.tags.mode]++;
+      }
+    }
+
+    // Update touch history after checking: a hotfix can't be its own
+    // antecedent, but it does become one for a later hotfix (a chain of
+    // fixes attributes to the immediately preceding touch, not the origin).
+    for (const file of commit.stats.files) {
+      if (file.status === 'deleted') {
+        lastTouch.delete(file.path);
+      } else {
+        lastTouch.set(file.path, { date: new Date(commit.authorDate), commit });
+      }
+    }
+  }
+
+  return { windowDays, total, linked, byAttribution, byMode };
+}
+
+export function calculateOutcomeCorrelation(
+  commitStream: CommitStream,
+  options: { hotfixWindowDays?: number } = {}
+): OutcomeCorrelation {
+  const { hotfixWindowDays = DEFAULT_HOTFIX_WINDOW_DAYS } = options;
+  return {
+    reverts: calculateReverts(commitStream),
+    hotfixes: calculateHotfixes(commitStream, hotfixWindowDays),
+  };
+}

--- a/packages/metrics/src/persistence.test.ts
+++ b/packages/metrics/src/persistence.test.ts
@@ -14,6 +14,7 @@ function makeCommit(overrides: Partial<CommitStream['commits'][0]>): CommitStrea
     message: 'test commit',
     parents: [],
     inDefaultBranchAncestry: true,
+    revertsCommit: null,
     tags: { ai: false, attribution: 'unknown' as const, mode: 'unknown' as const, modeEvidence: 'none' as const, level: 'none', sources: [] },
     stats: { totalAdditions: 10, totalDeletions: 0, files: [] },
     ...overrides,
@@ -346,5 +347,123 @@ describe('calculateBaselinePersistence', () => {
     const result = calculateBaselinePersistence(stream);
     expect(result.commitsConsidered).toBe(0);
     expect(result.avgDays).toBe(0);
+  });
+});
+
+describe('maxObservationDays (#29 age-normalization)', () => {
+  const aiTags = { ai: true, attribution: 'ai' as const, mode: 'agent' as const, modeEvidence: 'inferred' as const, level: 'explicit' as const, sources: [] };
+
+  it('caps survival for a file reworked after the cap, treating it as censored at the cap', () => {
+    const stream = makeStream([
+      makeCommit({
+        hash: 'a1',
+        authorDate: '2024-01-01T00:00:00.000Z',
+        tags: aiTags,
+        stats: { totalAdditions: 5, totalDeletions: 0, files: [{ path: 'foo.ts', additions: 5, deletions: 0 }] },
+      }),
+      // Real rework happens 30 days later — outside a 10-day cap
+      makeCommit({
+        hash: 'a2',
+        authorDate: '2024-01-31T00:00:00.000Z',
+        tags: aiTags,
+        stats: { totalAdditions: 1, totalDeletions: 0, files: [{ path: 'foo.ts', additions: 1, deletions: 0, status: 'modified' }] },
+      }),
+    ]);
+    const uncapped = calculatePersistence(stream);
+    expect(uncapped.avgDays).toBe(30); // sees the real rework
+
+    const capped = calculatePersistence(stream, undefined, { maxObservationDays: 10 });
+    expect(capped.avgDays).toBe(10); // cap cuts observation off before the event
+    expect(capped.censored).toBe(1); // treated as "no event observed", not as the real rework
+  });
+
+  it('does not cap survival for an event that happens within the cap', () => {
+    const stream = makeStream([
+      makeCommit({
+        hash: 'a1',
+        authorDate: '2024-01-01T00:00:00.000Z',
+        tags: aiTags,
+        stats: { totalAdditions: 5, totalDeletions: 0, files: [{ path: 'foo.ts', additions: 5, deletions: 0 }] },
+      }),
+      makeCommit({
+        hash: 'a2',
+        authorDate: '2024-01-03T00:00:00.000Z',
+        tags: aiTags,
+        stats: { totalAdditions: 1, totalDeletions: 0, files: [{ path: 'foo.ts', additions: 1, deletions: 0, status: 'modified' }] },
+      }),
+    ]);
+    const result = calculatePersistence(stream, undefined, { maxObservationDays: 10 });
+    expect(result.avgDays).toBe(2); // real event, well inside the cap
+    expect(result.censored).toBe(0);
+  });
+
+  it('caps a censored (never-touched-again) file at the cap instead of the full window', () => {
+    const stream = makeStream([
+      makeCommit({
+        hash: 'a1',
+        authorDate: '2024-01-01T00:00:00.000Z', // stream ends 2024-06-01: 152 days uncapped
+        tags: aiTags,
+        stats: { totalAdditions: 5, totalDeletions: 0, files: [{ path: 'stable.ts', additions: 5, deletions: 0 }] },
+      }),
+    ]);
+    const result = calculatePersistence(stream, undefined, { maxObservationDays: 20 });
+    expect(result.avgDays).toBe(20);
+    expect(result.censored).toBe(1);
+  });
+
+  it('leaves uncapped behaviour untouched when maxObservationDays is not set', () => {
+    const stream = makeStream([
+      makeCommit({
+        hash: 'a1',
+        authorDate: '2024-01-01T00:00:00.000Z',
+        tags: aiTags,
+        stats: { totalAdditions: 5, totalDeletions: 0, files: [{ path: 'stable.ts', additions: 5, deletions: 0 }] },
+      }),
+    ]);
+    expect(calculatePersistence(stream).avgDays).toBe(152);
+  });
+});
+
+describe('onlyCategory (#36 within-category comparison)', () => {
+  const aiTags = { ai: true, attribution: 'ai' as const, mode: 'agent' as const, modeEvidence: 'inferred' as const, level: 'explicit' as const, sources: [] };
+
+  it('restricts consideration to a single category, bypassing the default exclusions', () => {
+    const stream = makeStream([
+      makeCommit({
+        hash: 'a1',
+        authorDate: '2024-01-01T00:00:00.000Z',
+        tags: aiTags,
+        stats: {
+          totalAdditions: 3,
+          totalDeletions: 0,
+          files: [
+            { path: 'src/app.ts', additions: 1, deletions: 0 },
+            { path: 'src/app.test.ts', additions: 1, deletions: 0 },
+            { path: 'db/migrations/001.sql', additions: 1, deletions: 0 },
+          ],
+        },
+      }),
+    ]);
+
+    const sourceOnly = calculatePersistence(stream, undefined, {
+      onlyCategory: 'source',
+      excludeCategories: [],
+    });
+    expect(sourceOnly.filesConsidered).toBe(1);
+    expect(sourceOnly.filesExcluded).toBe(2);
+
+    const testsOnly = calculatePersistence(stream, undefined, {
+      onlyCategory: 'tests',
+      excludeCategories: [],
+    });
+    expect(testsOnly.filesConsidered).toBe(1);
+
+    // Migrations are excluded by default everywhere else, but onlyCategory
+    // explicitly asks for them — the caller gets real data, not zero.
+    const migrationsOnly = calculatePersistence(stream, undefined, {
+      onlyCategory: 'migrations',
+      excludeCategories: [],
+    });
+    expect(migrationsOnly.filesConsidered).toBe(1);
   });
 });

--- a/packages/metrics/src/persistence.ts
+++ b/packages/metrics/src/persistence.ts
@@ -21,6 +21,16 @@ export interface PersistenceOptions {
   // End of the observation window, used to measure censored files (never
   // modified again). Defaults to the stream's collection time.
   observationEnd?: Date;
+  // Age-normalization (#29): cap each file's observation window to at most
+  // this many days from its first target-cohort touch. Without this, an
+  // older cohort accumulates persistence simply by having existed longer —
+  // capping both cohorts to the same span (typically the younger cohort's
+  // age) makes the comparison fair rather than a clock-time artifact.
+  maxObservationDays?: number;
+  // Task-mix stratification (#36): restrict file consideration to a single
+  // category, bypassing excludeCategories (the caller is explicitly asking
+  // for that category's own data, generated/migrations included).
+  onlyCategory?: FileCategory;
 }
 
 interface FileLifecycle {
@@ -43,6 +53,8 @@ export function calculatePersistence(
     excludeCategories = DEFAULT_PERSISTENCE_EXCLUDED_CATEGORIES,
     observationEnd = new Date(commitStream.generatedAt),
     reworkWindowDays = DEFAULT_REWORK_WINDOW_DAYS,
+    maxObservationDays,
+    onlyCategory,
   } = options;
   const excluded = new Set<FileCategory>(excludeCategories);
 
@@ -75,7 +87,9 @@ export function calculatePersistence(
     if (!isTarget(commit)) return;
     for (const file of commit.stats.files) {
       if (lifecycles.has(file.path)) continue;
-      if (excluded.has(categorizeFile(file.path))) {
+      const category = categorizeFile(file.path);
+      const isExcluded = onlyCategory ? category !== onlyCategory : excluded.has(category);
+      if (isExcluded) {
         filesExcluded++;
         lifecycles.set(file.path, { firstTargetIndex: -1, firstTargetDate: new Date(0), eventDate: null });
         continue;
@@ -111,15 +125,31 @@ export function calculatePersistence(
   let undetermined = 0;
   for (const lifecycle of lifecycles.values()) {
     if (lifecycle.firstTargetIndex < 0) continue; // excluded category
-    const observedDays = Math.max(0, daysBetween(lifecycle.firstTargetDate, observationEnd));
 
-    if (lifecycle.eventDate) {
+    // Age-normalization (#29): the window we're allowed to look through for
+    // this file closes at either the real observation end, or capDays after
+    // its first touch — whichever is sooner. An event beyond that point is
+    // treated as not-yet-observed, exactly like a file with no event at all.
+    const effectiveEnd =
+      maxObservationDays !== undefined
+        ? new Date(
+            Math.min(
+              observationEnd.getTime(),
+              lifecycle.firstTargetDate.getTime() + maxObservationDays * 24 * 60 * 60 * 1000
+            )
+          )
+        : observationEnd;
+    const observedDays = Math.max(0, daysBetween(lifecycle.firstTargetDate, effectiveEnd));
+
+    if (lifecycle.eventDate && lifecycle.eventDate <= effectiveEnd) {
       const survived = daysBetween(lifecycle.firstTargetDate, lifecycle.eventDate);
       survivalDays.push(survived);
       determined++;
       if (survived < reworkWindowDays) reworked++;
     } else {
-      // Never modified again: survived to the end of the observation window
+      // No event within the effective window: censored there, whether
+      // because the file was never touched again or the cap cut us off
+      // before we could see what happens next.
       censored++;
       survivalDays.push(observedDays);
       if (observedDays >= reworkWindowDays) {

--- a/packages/metrics/src/schema/metrics.ts
+++ b/packages/metrics/src/schema/metrics.ts
@@ -125,6 +125,87 @@ export const Delta = z.object({
   medianPersistenceDays: z.number(),
 });
 
+// Age-normalized comparison (#29): the AI vs Baseline table above can be
+// misleading when one cohort's commits are systematically older or younger
+// — an old cohort accumulates persistence simply from clock time, not code
+// quality. This recomputes both sides with each file's observation window
+// capped to `capDays` (the younger cohort's average commit age), so neither
+// side gets credit for time it hasn't actually had. Null when there's no
+// baseline cohort to compare against, same condition as `baseline`.
+export const FairComparison = z.object({
+  capDays: z.number().nonnegative(),
+  ai: Persistence,
+  baseline: Persistence,
+  delta: Delta,
+});
+
+// Within-category comparison (#36 step 2): persistence computed separately
+// per file category instead of pooled, so a mismatched task mix between
+// cohorts (e.g. AI writes mostly tests, humans write mostly source) can't
+// masquerade as a quality difference. Each side is null when that cohort has
+// no files in the category; delta only when both sides are present.
+export const CategoryPersistence = z.object({
+  filesConsidered: z.number().int().nonnegative(),
+  avgDays: z.number().nonnegative(),
+  medianDays: z.number().nonnegative(),
+});
+
+export const CategoryComparison = z.object({
+  ai: CategoryPersistence.nullable(),
+  baseline: CategoryPersistence.nullable(),
+  deltaAvgDays: z.number().nullable(),
+  deltaMedianDays: z.number().nullable(),
+});
+
+export const ByCategory = z.object({
+  source: CategoryComparison,
+  tests: CategoryComparison,
+  migrations: CategoryComparison,
+  config: CategoryComparison,
+  docs: CategoryComparison,
+  generated: CategoryComparison,
+});
+
+// Outcome correlation (#26), scoped to what git itself can answer: reverts
+// and hotfix-pattern commits, linked back to the attribution/mode of the
+// commit(s) they respond to. Incidents and SAST findings are out of scope —
+// they'd need network access this tool deliberately doesn't have.
+const AttributionCounts = z.object({
+  ai: z.number().int().nonnegative(),
+  human: z.number().int().nonnegative(),
+  automated: z.number().int().nonnegative(),
+  unknown: z.number().int().nonnegative(),
+});
+const ModeCounts = z.object({
+  none: z.number().int().nonnegative(),
+  autocomplete: z.number().int().nonnegative(),
+  assisted: z.number().int().nonnegative(),
+  agent: z.number().int().nonnegative(),
+  unknown: z.number().int().nonnegative(),
+});
+
+export const RevertStats = z.object({
+  total: z.number().int().nonnegative(), // revert commits found
+  resolved: z.number().int().nonnegative(), // reverts whose target is in the collected window
+  // Attribution/mode of the REVERTED commit, not the revert itself
+  byAttribution: AttributionCounts,
+  byMode: ModeCounts,
+});
+
+export const HotfixStats = z.object({
+  windowDays: z.number().int().positive(),
+  total: z.number().int().nonnegative(), // commits matching a fix/hotfix pattern
+  linked: z.number().int().nonnegative(), // hotfixes with an antecedent touch inside the window
+  // Attribution/mode of the antecedent commit, not the hotfix itself
+  byAttribution: AttributionCounts,
+  byMode: ModeCounts,
+});
+
+export const OutcomeCorrelation = z.object({
+  reverts: RevertStats,
+  hotfixes: HotfixStats,
+});
+
 // Per-autonomy-level metrics (#25, step 2): the durable comparison in an
 // AI-first world is between autonomy levels, not AI vs human. Automated
 // commits are excluded — automation is not authored code. Null when the
@@ -221,6 +302,15 @@ export const Metrics = z.object({
     baseline: CohortContext,
   }),
   byMode: ByMode,
+  // Age-normalized AI vs Baseline (#29). Same nullability as `baseline`.
+  fairComparison: FairComparison.nullable(),
+  // Per-file-category AI vs Baseline (#36 step 2). Always present; each
+  // category's sides are independently null when that cohort touched no
+  // files of that kind.
+  byCategory: ByCategory,
+  // Reverts and hotfixes linked to the commit(s) they respond to (#26).
+  // Always present — a property of the repo, not a cohort comparison.
+  outcomeCorrelation: OutcomeCorrelation,
   // Null unless `aida fetch-prs` produced a pr-stream.json (#51)
   prAcceptance: PRAcceptance.nullable(),
   // Null unless `aida blame` produced a blame-stream.json (#23)
@@ -243,6 +333,13 @@ export type ModeStats = z.infer<typeof ModeStats>;
 export type ByMode = z.infer<typeof ByMode>;
 export type AcceptanceStats = z.infer<typeof AcceptanceStats>;
 export type PRAcceptance = z.infer<typeof PRAcceptance>;
+export type FairComparison = z.infer<typeof FairComparison>;
+export type CategoryPersistence = z.infer<typeof CategoryPersistence>;
+export type CategoryComparison = z.infer<typeof CategoryComparison>;
+export type ByCategory = z.infer<typeof ByCategory>;
+export type RevertStats = z.infer<typeof RevertStats>;
+export type HotfixStats = z.infer<typeof HotfixStats>;
+export type OutcomeCorrelation = z.infer<typeof OutcomeCorrelation>;
 export type LineSurvival = z.infer<typeof LineSurvival>;
 export type Persistence = z.infer<typeof Persistence>;
 export type Baseline = z.infer<typeof Baseline>;


### PR DESCRIPTION
Closes #29, closes #36, closes #26. **Based directly on `main`** (not stacked on another feature branch) — after the #65/#67 stacking mishap, every PR going forward targets `main` directly and gets verified there before pushing.

## #29 — Age-normalized fair comparison

The raw AI vs Baseline table can be misleading when one cohort's commits are systematically older: an older cohort accumulates persistence simply from having existed longer, not from better code.

`metrics.json` gains `fairComparison`: both cohorts' persistence recomputed with each file's observation window capped to `capDays` (the younger cohort's average commit age). Implementation detail: `calculatePersistence` gained `maxObservationDays`, which bounds the effective end-of-observation per file — an event beyond the cap is treated as not-yet-observed (censored at the cap), exactly like a file with no event at all.

Reported **alongside** the raw comparison, never replacing it — same principle as `recent` coverage (#52).

### Verified on a synthetic fixture (real pipeline, not just unit tests)

Old human commit (200d) + recent AI commit (10d), both files never touched again:

| | Raw | Fair (capped to 11d) |
|---|---:|---:|
| AI avg persistence | 11d | 11d |
| Baseline avg persistence | 201d | 11d |
| **Delta** | **−190d** | **0d** |

The −190d was pure survivorship bias — exactly the artifact we first found dogfooding #34 months ago. The fair comparison correctly shows there's no real difference: neither file was ever reworked.

## #36 step 2 — Within-category comparison

A pooled delta can hide a task-mix confound (AI mostly writes tests, humans mostly write source — the delta reflects *what*, not quality).

`metrics.json` gains `byCategory`: persistence per file category (source/tests/migrations/config/docs/generated), AI vs baseline, delta only where both sides touched that category. Always present — useful even without a baseline (e.g. comparing AI-written tests against AI-written source in an AI-first repo). `calculatePersistence` gained `onlyCategory`, which bypasses the default migrations/generated exclusion since the caller is explicitly asking for that category's own data.

Verified on the same fixture: source and tests categories each show the same −190d → 0d correction as the pooled figure.

## #26 — Outcome correlation, scoped to what git can answer

The original ask also wanted incidents (PagerDuty/Jira) and SAST findings — dropped, same reasoning as scoping `fetch-prs` (#51) to its own command: that needs network access this tool deliberately doesn't have. What's left is git-exact:

- **Reverts**: `git revert` writes `This reverts commit <sha>.` into the generated commit's *body*. Since `Commit.message` stores subject-only, this couldn't be recovered at analyze time — added a `revertsCommit` field parsed from the full message at **collect** time (additive, `schemaVersion` unchanged). `outcomeCorrelation.reverts` attributes each resolved revert to the **reverted** commit's cohort/mode, not the revert's.
- **Hotfixes**: commits matching `fix`/`hotfix`/`patch` conventions, linked to the closest prior commit touching the same file(s) within a window (default 7d, `--hotfix-window`) — attributed to that antecedent's cohort/mode. A hotfix touching multiple files links to whichever file was most recently disturbed.

### Dogfood (this repo)

- 0 reverts in history (clean signal)
- 13 hotfix-pattern commits, **8 linked** to an antecedent within 7 days, all attributed `ai` (this repo is agent-written throughout)

## Testing

193 tests pass (core 90, metrics 69, cli 34). New: capping semantics (event-within-cap vs event-beyond-cap vs no-event, all three distinguished), category filter bypass, `fairComparison`/`byCategory` through `calculateMetrics` on realistic date fixtures, revert parsing against a *real* `git revert` invocation, hotfix linking including the multi-file-closest-antecedent case and hotfix-chains-to-hotfix. Typecheck and lint clean.

Co-Authored-By: Claude <noreply@anthropic.com>
