### PR TITLE
feat: autonomy as the primary axis — involvement × evidence (#25)

### DIFF
--- a/.aida.json
+++ b/.aida.json
@@ -1,3 +1,3 @@
 {
-  "defaultAttribution": "ai"
+  "defaultMode": "agent"
 }

--- a/.changeset/autonomy-primary-axis.md
+++ b/.changeset/autonomy-primary-axis.md
@@ -1,0 +1,23 @@
+---
+'@aida-dev/core': minor
+'@aida-dev/metrics': minor
+'@aida-dev/cli': minor
+---
+
+Autonomy becomes the primary axis: involvement × evidence, three-state attribution demoted to a projection (#25)
+
+For most teams today AI participates in nearly every commit, so "was AI involved?" trends to *yes* and stops discriminating anything. What still separates risk, cost and quality is **at what autonomy level**. This makes that the model rather than a field alongside the old one.
+
+**Two orthogonal axes.** `mode` (`none`/`autocomplete`/`assisted`/`agent`/`unknown`) is what happened; `evidence` (`declared`/`inferred`/`none`) is how we know. They are separate because they fail separately: `mode: unknown, evidence: inferred` is a real state — we know AI participated, we cannot name the level — and the single-axis model had to misreport it as "no evidence", contradicting the `ai` it had just asserted.
+
+**`attribution` is now derived.** `projectAttribution` is the only place the three states are decided, and a tag can only be built through `tagFromAxes`, so the projection cannot drift from the axes it projects. The headline still reads `ai`/`human`/`automated`/`unknown`, labelled as the projection it is. `unknown` is no longer a fourth kind of attribution: it is exactly `evidence: none`, an invariant now covered by tests in both directions.
+
+**Coverage moved to the evidence axis** — the share of commits with any known provenance, declared or inferred. Numerically near-identical to the old `(ai + human + automated) / total` (on babel: 8.7% either way), because automation already carries inferred evidence. The reframe is honest, not a redefinition that flatters the number.
+
+**`automated` is its own flag**, orthogonal to both axes: known provenance, no author, joins no cohort. The redundant `ai` boolean is gone.
+
+**Breaking — `defaultAttribution` is replaced by `defaultMode`.** The prior now names an autonomy level instead of an AI/human label, and one key covers both moments: the commit hook stamps it at commit time (making new commits `declared`), while `aida analyze` applies it as a prior to older commits with no evidence. A prior joins a cohort but is never evidence — it does not touch the tags and does not raise coverage, so a repo leaning on it still reports how little it knows. Because zod strips unknown keys, a config still carrying `defaultAttribution` would silently stop applying and change cohorts on upgrade; `.aida.json` is now rejected with the translation in the message. `--default-attribution` becomes `--default-mode`.
+
+Schema v2 for both `commit-stream.json` and `metrics.json`: rerun `aida collect`.
+
+Dogfooded on this repo: 137 commits, coverage 100% (declared 72 · inferred 65), 100 agent · 37 automated. That run also caught a bug introduced here — the headline table counted automation's `mode: 'none'` as hand-written, contradicting `byMode`, which excludes it. Per-mode counts now exclude automated commits and the report lists them on their own row.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ AIDA provides **tangible, auditable metrics** to distinguish between **AI noise*
 
 - **4-Level AI Detection** — Classifies commits as explicit, implicit, mention, or none across Claude Code, Copilot, ChatGPT, Cursor, Windsurf/Devin, Gemini, Codeium
 - **Configurable Tools** — Add custom AI tools via `.aida.json` or CLI flags
-- **Attribution Coverage** — Four-state provenance (`ai`/`human`/`automated`/`unknown`) with coverage as the headline metric
+- **Autonomy** — Two orthogonal axes: *involvement* (`none`/`autocomplete`/`assisted`/`agent`) and *evidence* (`declared`/`inferred`/`none`), with evidence coverage as the headline metric
 - **Persistence** — Measure how long AI-generated code survives in your codebase
 - **Comparative Baseline** — AI vs non-AI side-by-side with delta, so metrics are interpretable
 - **Fast & Deterministic** — Versioned JSON output schemas, so consumers detect breaking changes instead of reading silent `undefined`s
@@ -203,7 +203,7 @@ aida report --out-dir ./aida-output
 
 #### `aida analyze`
 
-- `--default-attribution <value>` - Prior for unattributed commits: `ai` | `human` | `unknown`
+- `--default-mode <value>` - Prior for commits with no evidence: `none` | `autocomplete` | `assisted` | `agent`
 - `--coverage-threshold <fraction>` - Coverage below this flags metrics as low-confidence (default: 0.7)
 - `--coverage-window <days>` - Window for the actionable coverage figure (default: 90)
 - `--hotfix-window <days>` - Window for linking a hotfix to its likely antecedent (default: 7)
@@ -249,14 +249,14 @@ Requires `GITHUB_TOKEN`. Without it the command refuses to run and PR acceptance
 
 ## AI Detection
 
-AIDA classifies commits into four attribution levels:
+Message heuristics produce a detection **level**, which feeds the two axes above — `explicit` and `implicit` establish AI involvement, `mention` and `none` do not:
 
-| Level        | ai      | Description                                            |
-|--------------|---------|--------------------------------------------------------|
-| **explicit** | `true`  | Clear AI authorship — trailers, `[AI]` tag, creation verbs |
-| **implicit** | `true`  | AI involvement — suggestion/help language               |
-| **mention**  | `false` | Tool referenced but not used — "fix copilot bug"       |
-| **none**     | `false` | No AI reference                                        |
+| Level        | Establishes AI? | Description                                            |
+|--------------|-----------------|--------------------------------------------------------|
+| **explicit** | yes             | Clear AI authorship — trailers, `[AI]` tag, creation verbs |
+| **implicit** | yes             | AI involvement — suggestion/help language               |
+| **mention**  | no              | Tool referenced but not used — "fix copilot bug"       |
+| **none**     | no              | No AI reference                                        |
 
 ### Explicit Detection (high confidence)
 
@@ -368,7 +368,7 @@ Place a `.aida.json` file in your project root to add custom tools, trailer doma
   "trailerDomains": ["mycompany\\.com"],
   "botBlocklist": ["acme-ci-bot"],
   "patterns": ["my-custom-regex"],
-  "defaultAttribution": "unknown",
+  "defaultMode": "assisted",
   "coverageThreshold": 0.7
 }
 ```
@@ -379,7 +379,7 @@ Place a `.aida.json` file in your project root to add custom tools, trailer doma
 | `trailerDomains` | Additional domains for `Co-authored-by` trailer matching |
 | `botBlocklist` | Additional non-AI bots to exclude from `Co-authored-by` trailer matching |
 | `patterns` | Raw regex patterns (treated as explicit) |
-| `defaultAttribution` | Prior applied to unattributed commits at analysis time: `ai`, `human`, or `unknown` (default). With `unknown`, unattributed commits join no cohort — AIDA does not invent a comparison. This repo sets `ai`: it is AI-written with human review. |
+| `defaultMode` | The repo's autonomy level when nothing else determines it. Two moments, one key: the commit hook stamps it as an `AI-Mode:` trailer (making new commits `declared`), and `aida analyze` applies it as a **prior** to older commits with no evidence. A prior joins a cohort but never raises coverage. Absent = no assumption: those commits join no cohort, and AIDA does not invent a comparison. This repo sets `agent`. |
 | `coverageThreshold` | Attribution coverage below this fraction (default `0.7`) flags all metrics as low-confidence |
 | `defaultMode` | Autonomy mode the commit hook stamps when nothing else determines it: `none` \| `autocomplete` \| `assisted` \| `agent` ([#61](https://github.com/ceccode/AIDA-Metrics/issues/61)). Absent means leave unknown rather than guess |
 | `redactAuthors` | Replace author/committer identities in `commit-stream.json` with a per-run salted hash (default `false`; recommended in CI) |
@@ -393,20 +393,33 @@ aida collect --ai-tool "devbot" --ai-tool "codyai"
 aida collect --ai-trailer-domain "mycompany\\.com"
 aida collect --ai-bot-blocklist "acme-ci-bot"
 aida collect --ai-pattern "my-custom-regex"
-aida analyze --default-attribution human --coverage-threshold 0.8
+aida analyze --default-mode none --coverage-threshold 0.8
 ```
 
 ## Metrics
 
-### Attribution Coverage
+### Autonomy
 
-The headline metric ([#34](https://github.com/ceccode/AIDA-Metrics/issues/34)). Every commit gets a four-state attribution: `ai` (explicit/implicit detection or manifest), `human` (explicit declaration via manifest), `automated` (provenance-known automation, [#39](https://github.com/ceccode/AIDA-Metrics/issues/39) — merge commits and known bots auto-detected at collect time, or manifest `excluded_commits`; counts toward coverage, joins no cohort), or `unknown` (no signal — the absence of an AI tag is *not* evidence of human authorship).
+The primary model ([#25](https://github.com/ceccode/AIDA-Metrics/issues/25)). Every commit is described on **two orthogonal axes**:
 
-**Coverage** = share of commits with known provenance (`ai` + `human` + `automated`). It is reported first in every output, because every other number is only as trustworthy as coverage says it is.
+| Axis | Values | Question |
+|---|---|---|
+| **Involvement** (`mode`) | `none` · `autocomplete` · `assisted` · `agent` · `unknown` | What level of AI participated? |
+| **Evidence** | `declared` · `inferred` · `none` | How do we know? |
+
+They are separate because they fail separately. `mode: unknown, evidence: inferred` is a real state — we know AI participated, we cannot say at what level — and the old single-axis model had to misreport it as "no evidence".
+
+`declared` means someone stated it: the `AI-Mode:` trailer written by the commit hook, or the attribution manifest. `inferred` means AIDA concluded it from tool identity or commit structure. Automation ([#39](https://github.com/ceccode/AIDA-Metrics/issues/39) — merge commits, known bots, manifest `excluded_commits`) is a third, orthogonal flag: its provenance is known, so it counts toward coverage, but it joins no autonomy cohort, because automation is not authored code.
+
+**Coverage** = share of commits with any evidence at all (`declared` + `inferred`). It is reported first in every output, because every other number is only as trustworthy as coverage says it is.
+
+**The three-state view survives as a projection.** `ai` (mode above `none`), `human` (declared `none`), `automated`, `unknown` (no evidence) are derived from the axes above — never decided independently — and kept because a headline needs one word. The rich model underneath, the one-line summary on top.
+
+Why the axes and not the binary: for most teams today AI participates in nearly every commit, so "was AI involved?" trends to *yes* and stops discriminating anything. What still separates risk, cost, and quality is **at what autonomy level**.
 
 Coverage is reported over **two windows** ([#52](https://github.com/ceccode/AIDA-Metrics/issues/52)): all-time, and a recent window (default 90 days, `--coverage-window`). The recent figure is the actionable one — it answers *"are we tagging now?"* rather than passing a permanent verdict on history that predates adoption — so it is what drives the low-confidence warning below `coverageThreshold` (default 70%). All-time stays visible as context, never replaced.
 
-`defaultAttribution` lets a team consciously assign unattributed commits to a cohort (`human` for traditional repos, `ai` for AI-first ones). The prior affects cohort metrics but never coverage: unknown stays unknown in the attribution block, and an assumed baseline is labeled as such.
+`defaultMode` lets a team consciously assign no-evidence commits to an autonomy level (`none` for traditional repos, `assisted`/`agent` for AI-first ones). The prior affects cohort metrics but never coverage: an assumption is not evidence, so a repo leaning on it still reports how little it actually knows, and an assumed baseline is labeled as such.
 
 ### By Autonomy Level
 
@@ -469,7 +482,7 @@ File-level survival: days from the first target-cohort touch of a file until the
 Both merge ratio and persistence are computed for the human cohort as well.  
 The `metrics.json` output includes `baseline` (human cohort) and `delta` (AI minus human) sections.  
 The markdown report renders a side-by-side comparison table at the top.  
-If no commits are attributed `human` and no `defaultAttribution` prior assigns the unknowns, `baseline` and `delta` are `null`: AIDA does not invent a comparison cohort.
+If no commits sit at autonomy level `none` and no `defaultMode` prior assigns the no-evidence ones, `baseline` and `delta` are `null`: AIDA does not invent a comparison cohort.
 
 ### Fair Comparison (age-normalized)
 
@@ -646,19 +659,17 @@ Bitbucket is currently out of scope ([#17](https://github.com/ceccode/AIDA-Metri
 - **v0.20** ✅ GitLab CI provider — MR comments with note reuse ([#16](https://github.com/ceccode/AIDA-Metrics/issues/16)).  
 - **v0.21** ✅ Line-level survival via `aida blame` — exact per-line attribution, binaries excluded ([#23](https://github.com/ceccode/AIDA-Metrics/issues/23)).
 - **v0.22** ✅ Age-normalized fair comparison ([#29](https://github.com/ceccode/AIDA-Metrics/issues/29)), within-category comparison ([#36](https://github.com/ceccode/AIDA-Metrics/issues/36)), git-scoped outcome correlation — reverts and hotfixes ([#26](https://github.com/ceccode/AIDA-Metrics/issues/26)).  
-- **Next** → Autonomy as primary axis ([#25](https://github.com/ceccode/AIDA-Metrics/issues/25) step 3, once declared data accumulates), outcome correlation restricted to git-detectable reverts and hotfixes ([#26](https://github.com/ceccode/AIDA-Metrics/issues/26)).  
-- **Next** → Rework rate ([#22](https://github.com/ceccode/AIDA-Metrics/issues/22)), line-level persistence via blame ([#23](https://github.com/ceccode/AIDA-Metrics/issues/23)).  
-- **Next** → Outcome correlation ([#26](https://github.com/ceccode/AIDA-Metrics/issues/26)), cost metrics ([#27](https://github.com/ceccode/AIDA-Metrics/issues/27)).  
-- **Next** → GitLab ([#16](https://github.com/ceccode/AIDA-Metrics/issues/16)) and Bitbucket ([#17](https://github.com/ceccode/AIDA-Metrics/issues/17)) PR comment providers.  
+- **v0.23** ✅ Autonomy as the primary axis — involvement × evidence, with three-state attribution demoted to a derived projection; coverage measured on the evidence axis; `defaultAttribution` replaced by `defaultMode` ([#25](https://github.com/ceccode/AIDA-Metrics/issues/25)). Schema v2.
+- **Next** → Bitbucket PR comment provider ([#17](https://github.com/ceccode/AIDA-Metrics/issues/17)), cost metrics ([#27](https://github.com/ceccode/AIDA-Metrics/issues/27)).  
 - **v1.0** → Dashboard / GitHub Action for continuous tracking.  
 
 ### Direction: from AI detection to AI accountability
 
 In an AI-first world, "was this commit written by AI?" is becoming the wrong question — the honest answer trends toward "yes, mostly". AIDA's direction reflects that:
 
-- **Three-state attribution** — `ai` / `human` / `unknown` instead of forcing unattributed commits into a binary bucket ([#34](https://github.com/ceccode/AIDA-Metrics/issues/34)). Attribution **coverage** becomes the headline metric ("62% attributed · 38% unknown" is a data-quality signal, not something to hide inside a default) — because the unknown bucket grows fastest exactly where the numbers are taken most seriously. A configurable `defaultAttribution` prior will let AI-first teams opt into "AI unless stated otherwise" — consciously, instead of the tool silently assuming either way.
+- **Autonomy as the primary axis** — involvement × evidence ([#25](https://github.com/ceccode/AIDA-Metrics/issues/25)) replaced the three-state attribution as the model; the three states survive as a projection for the headline ([#34](https://github.com/ceccode/AIDA-Metrics/issues/34)). **Coverage** — now measured on the evidence axis — stays the first number in every output ("62% known provenance · 38% no evidence" is a data-quality signal, not something to hide inside a default), because the no-evidence bucket grows fastest exactly where the numbers are taken most seriously. The `defaultMode` prior lets AI-first teams opt into an assumed autonomy level, consciously, without it ever counting as evidence.
 - **Quality over adoption** — the durable question is not "how much code is AI?" but "does AI code hold up?": rework rate ([#22](https://github.com/ceccode/AIDA-Metrics/issues/22)), line-level survival ([#23](https://github.com/ceccode/AIDA-Metrics/issues/23)), outcome correlation ([#26](https://github.com/ceccode/AIDA-Metrics/issues/26)).
-- **Autonomy over the binary** — autocomplete vs assisted vs agent ([#25](https://github.com/ceccode/AIDA-Metrics/issues/25)) is the axis that will replace AI/non-AI.
+- **Autonomy over the binary** — autocomplete vs assisted vs agent ([#25](https://github.com/ceccode/AIDA-Metrics/issues/25)) has replaced AI/non-AI as the model. The binary remains available as a projection, not as the thing being measured.
 - **Shrink the unknown at the source** — the attribution manifest ([#10](https://github.com/ceccode/AIDA-Metrics/issues/10)) makes attribution declarative retroactively; commit-time stamping via git hooks ([#61](https://github.com/ceccode/AIDA-Metrics/issues/61)) makes it automatic going forward. Both shipped.
 - **Cohorts, not people** — AIDA compares groups of commits, never developers. No per-author aggregation will ever ship, and author identity can be redacted from output artifacts ([#35](https://github.com/ceccode/AIDA-Metrics/issues/35), shipped) so the data model doesn't hand anyone a leaderboard for free.
 

--- a/packages/cli/src/commands/analyze.ts
+++ b/packages/cli/src/commands/analyze.ts
@@ -12,6 +12,7 @@ import {
   PR_STREAM_SCHEMA_VERSION,
   assertSchemaVersion,
   fileExists,
+  assertNoRetiredConfigKeys,
   describeError,
 } from '@aida-dev/core';
 import { calculateMetrics } from '@aida-dev/metrics';
@@ -19,13 +20,20 @@ import { join } from 'path';
 import { readFile } from 'fs/promises';
 import { CLIConfig } from '../schema/config.js';
 
+const MODES = ['none', 'autocomplete', 'assisted', 'agent'];
+
 async function loadAidaConfig(repoPath: string): Promise<Partial<AidaConfig>> {
+  let raw: string;
   try {
-    const raw = await readFile(join(repoPath, '.aida.json'), 'utf-8');
-    return AidaConfig.parse(JSON.parse(raw));
+    raw = await readFile(join(repoPath, '.aida.json'), 'utf-8');
   } catch {
-    return {};
+    return {}; // No config file: every setting keeps its default
   }
+  // A present-but-broken config must not be silently ignored — that would
+  // apply defaults the repo explicitly opted out of.
+  const parsed = JSON.parse(raw);
+  assertNoRetiredConfigKeys(parsed);
+  return AidaConfig.parse(parsed);
 }
 
 export function createAnalyzeCommand(): Command {
@@ -33,8 +41,8 @@ export function createAnalyzeCommand(): Command {
     .description('Analyze commit stream and generate metrics.json')
     .option('--out-dir <path>', 'Output directory', './aida-output')
     .option(
-      '--default-attribution <value>',
-      'Prior for unattributed commits: ai | human | unknown (default: unknown, or .aida.json)'
+      '--default-mode <value>',
+      'Prior for commits with no evidence: none | autocomplete | assisted | agent (default: no prior, or .aida.json)'
     )
     .option(
       '--coverage-threshold <fraction>',
@@ -72,11 +80,10 @@ export function createAnalyzeCommand(): Command {
 
         // CLI flags override .aida.json (read from the collected repo's root)
         const fileConfig = await loadAidaConfig(commitStream.repoPath);
-        const defaultAttribution =
-          options.defaultAttribution ?? fileConfig.defaultAttribution ?? 'unknown';
-        if (!['ai', 'human', 'unknown'].includes(defaultAttribution)) {
+        const defaultMode = options.defaultMode ?? fileConfig.defaultMode;
+        if (defaultMode && !MODES.includes(defaultMode)) {
           throw new Error(
-            `Invalid --default-attribution "${defaultAttribution}": expected ai, human, or unknown`
+            `Invalid --default-mode "${defaultMode}": expected ${MODES.join(', ')}`
           );
         }
         const coverageThreshold = options.coverageThreshold
@@ -142,7 +149,7 @@ export function createAnalyzeCommand(): Command {
         }
 
         const metrics = calculateMetrics(commitStream, {
-          defaultAttribution,
+          defaultMode,
           coverageThreshold,
           coverageWindowDays,
           prStream,
@@ -164,7 +171,7 @@ export function createAnalyzeCommand(): Command {
         }
         if (a.recent ? a.recent.belowThreshold : a.belowThreshold) {
           logger.warn(
-            `Coverage is below ${(a.coverageThreshold * 100).toFixed(0)}%: metrics are low-confidence. Tag AI commits or set defaultAttribution.`
+            `Coverage is below ${(a.coverageThreshold * 100).toFixed(0)}%: metrics are low-confidence. Install the commit hook (aida install-hooks), or set defaultMode in .aida.json.`
           );
         }
         logger.info(`Average persistence: ${metrics.persistence.avgDays} days`);

--- a/packages/cli/src/commands/e2e.test.ts
+++ b/packages/cli/src/commands/e2e.test.ts
@@ -59,7 +59,7 @@ describe('collect → analyze → report end to end', () => {
     await run(createCollectCommand(), ['--repo', repoPath, '--out-dir', outDir]);
 
     const stream = JSON.parse(readFileSync(join(outDir, 'commit-stream.json'), 'utf-8'));
-    expect(stream.schemaVersion).toBe(1);
+    expect(stream.schemaVersion).toBe(2);
     expect(stream.commits).toHaveLength(2);
     // The trailer commit is detected as AI, the other stays unknown
     const attributions = stream.commits.map((c: { tags: { attribution: string } }) => c.tags.attribution).sort();
@@ -77,7 +77,7 @@ describe('collect → analyze → report end to end', () => {
     await run(createAnalyzeCommand(), ['--out-dir', outDir]);
 
     const metrics = JSON.parse(readFileSync(join(outDir, 'metrics.json'), 'utf-8'));
-    expect(metrics.schemaVersion).toBe(1);
+    expect(metrics.schemaVersion).toBe(2);
     expect(metrics.attribution.coverage).toBeCloseTo(0.5);
     expect(metrics.attribution.modes.agent).toBe(1);
     expect(metrics.persistence).toHaveProperty('censored');
@@ -94,8 +94,11 @@ describe('collect → analyze → report end to end', () => {
 
     const report = readFileSync(join(outDir, 'report.md'), 'utf-8');
     expect(report).toContain('# AIDA Report');
-    expect(report).toContain('## Attribution Coverage');
-    expect(report).toContain('**Autonomy:**');
+    expect(report).toContain('## Autonomy');
+    // The autonomy breakdown is the primary table (#25), and the three-state
+    // view is labelled as the projection it is
+    expect(report).toContain('| Autonomy level | Commits |');
+    expect(report).toContain('*Three-state view:*');
     expect(report).toContain('## By Autonomy Level');
     expect(report).toContain('## Cohort Fairness');
     expect(report).toContain('## Persistence (file-level survival)');
@@ -114,7 +117,7 @@ describe('collect → analyze → report end to end', () => {
     });
     await run(createCommentCommand(), ['--out-dir', outDir, '--dry-run']);
     logSpy.mockRestore();
-    expect(printed.join('\n')).toContain('## Attribution Coverage');
+    expect(printed.join('\n')).toContain('## Autonomy');
   });
 
   it('applies --redact-authors through the CLI', async () => {
@@ -155,10 +158,9 @@ describe('PR acceptance (#51)', () => {
       const aiCommit = {
         sha: 'a'.repeat(40),
         tags: {
-          ai: true,
-          attribution: 'ai',
+          attribution: 'ai', automated: false,
           mode: 'agent',
-          modeEvidence: 'inferred',
+          evidence: 'inferred',
           level: 'explicit',
           sources: ['trailer'],
         },

--- a/packages/cli/src/commands/install-hooks.test.ts
+++ b/packages/cli/src/commands/install-hooks.test.ts
@@ -111,7 +111,7 @@ describe('the installed hook, running for real', () => {
       const stream = JSON.parse(readFileSync(join(outDir, 'commit-stream.json'), 'utf-8'));
       const commit = stream.commits[0];
       expect(commit.tags.mode).toBe('agent');
-      expect(commit.tags.modeEvidence).toBe('declared');
+      expect(commit.tags.evidence).toBe('declared');
       expect(commit.tags.attribution).toBe('ai');
     } finally {
       rmSync(outDir, { recursive: true, force: true });
@@ -128,7 +128,7 @@ describe('the installed hook, running for real', () => {
       // The first real source of `human` attribution that isn't the manifest
       expect(stream.commits[0].tags.attribution).toBe('human');
       expect(stream.commits[0].tags.mode).toBe('none');
-      expect(stream.commits[0].tags.modeEvidence).toBe('declared');
+      expect(stream.commits[0].tags.evidence).toBe('declared');
     } finally {
       rmSync(outDir, { recursive: true, force: true });
     }

--- a/packages/cli/src/commands/report.ts
+++ b/packages/cli/src/commands/report.ts
@@ -29,12 +29,12 @@ function generateMarkdownReport(metrics: Metrics): string {
   const warnOnRecent = a.recent ? a.recent.belowThreshold : a.belowThreshold;
 
   const coverageWarning = warnOnRecent
-    ? `\n> ⚠️ **Coverage is below ${(a.coverageThreshold * 100).toFixed(0)}%${a.recent ? ` in the last ${a.recent.windowDays} days` : ''}.** Provenance is largely unknown, so every metric below is low-confidence. Install the commit hook (\`aida install-hooks\`), tag AI commits, or set \`defaultAttribution\` in \`.aida.json\`.\n`
+    ? `\n> ⚠️ **Coverage is below ${(a.coverageThreshold * 100).toFixed(0)}%${a.recent ? ` in the last ${a.recent.windowDays} days` : ''}.** Provenance is largely unknown, so every metric below is low-confidence. Install the commit hook (\`aida install-hooks\`) so new commits declare their autonomy mode, or set \`defaultMode\` in \`.aida.json\` for the history that predates it.\n`
     : '';
 
   const priorNote =
-    a.defaultAttribution !== 'unknown' && a.unknown > 0
-      ? `\nUnattributed commits are **assumed \`${a.defaultAttribution}\`** via \`defaultAttribution\` — this is a prior, not observed data.\n`
+    a.defaultMode !== null && a.evidence.none > 0
+      ? `\nCommits with no evidence are **assumed \`${a.defaultMode}\`** via \`defaultMode\` — this is a prior, not observed data, and it does not count toward coverage.\n`
       : '';
 
   const baselineLabel = metrics.baseline?.assumed
@@ -64,7 +64,7 @@ function generateMarkdownReport(metrics: Metrics): string {
 ${fairComparisonSection}`
     : `## AI vs Baseline
 
-**No baseline available** — no commits are attributed as human, so there is nothing honest to compare against. If unattributed commits in this repo are human-authored, set \`"defaultAttribution": "human"\` in \`.aida.json\`.
+**No baseline available** — no commits sit at autonomy level \`none\`, so there is nothing honest to compare against. If the commits with no evidence in this repo were hand-written, set \`"defaultMode": "none"\` in \`.aida.json\`.
 `;
 
   const categories = ['source', 'tests', 'migrations', 'config', 'docs', 'generated'] as const;
@@ -244,15 +244,24 @@ ${[
 **Window:** ${metrics.window.since || 'beginning'} → ${metrics.window.until || 'now'}  
 **Generated:** ${metrics.generatedAt}
 
-## Attribution Coverage
+## Autonomy
 
-**${coveragePct}% of commits have known provenance** — ai: ${a.ai} · human: ${a.human} · automated: ${a.automated} · unknown: ${a.unknown} (${unknownPct}%)
+**${coveragePct}% of commits have known provenance** — declared ${a.evidence.declared} · inferred ${a.evidence.inferred} · no evidence ${a.evidence.none} (${unknownPct}%)
+
+| Autonomy level | Commits |
+|---|---:|
+| agent | ${a.modes.agent} |
+| assisted | ${a.modes.assisted} |
+| autocomplete | ${a.modes.autocomplete} |
+| none (hand-written) | ${a.modes.none} |
+| unknown | ${a.modes.unknown} |
+| _automated (no cohort)_ | ${a.automated} |
 
 ${recentLine}
-**Autonomy:** agent ${a.modes.agent} · assisted ${a.modes.assisted} · autocomplete ${a.modes.autocomplete} · none ${a.modes.none} · unknown ${a.modes.unknown} — evidence: declared ${a.modeEvidence.declared} / inferred ${a.modeEvidence.inferred} / none ${a.modeEvidence.none}
+*Three-state view:* ai ${a.ai} · human ${a.human} · automated ${a.automated} · unknown ${a.unknown} — a projection of the table above, kept for a one-word headline. What AI participation *was* is the question that keeps discriminating once "was AI involved?" is answered yes everywhere.
 ${coverageWarning}${priorNote}
-${comparisonSection}
-${byModeSection}${lineSection}${outcomeSection}${prSection}${fairnessSection}
+${byModeSection}${comparisonSection}
+${lineSection}${outcomeSection}${prSection}${fairnessSection}
 ## Persistence (file-level survival)
 - Commits considered: ${metrics.persistence.commitsConsidered}
 - Files measured: ${metrics.persistence.filesConsidered} (${metrics.persistence.censored} still surviving at collection time; ${metrics.persistence.filesExcluded} excluded: migrations/generated)

--- a/packages/cli/src/providers/github-prs.ts
+++ b/packages/cli/src/providers/github-prs.ts
@@ -1,5 +1,6 @@
 import {
   AITagResult,
+  tagFromAxes,
   Logger,
   PRCommit,
   PR_STREAM_SCHEMA_VERSION,
@@ -143,16 +144,12 @@ export async function fetchClosedPRs(options: FetchPROptions): Promise<PRStream>
 
       const taggedCommits: PRCommit[] = commits.map((commit) => {
         let tags: AITagResult = tagger(commit.commit.message);
-        if (tags.attribution === 'unknown' && (commit.parents?.length ?? 0) > 1) {
+        if (tags.evidence === 'none' && (commit.parents?.length ?? 0) > 1) {
           // Merge commits inside a PR branch are automation, not authored work
-          tags = {
-            ai: false,
-            attribution: 'automated',
-            mode: 'none',
-            modeEvidence: 'inferred',
-            level: 'none',
-            sources: [...tags.sources, 'automated:merge-commit'],
-          };
+          tags = tagFromAxes({ mode: 'none', evidence: 'inferred', automated: true }, 'none', [
+            ...tags.sources,
+            'automated:merge-commit',
+          ]);
         }
         return { sha: commit.sha, tags };
       });

--- a/packages/core/src/git/collect.test.ts
+++ b/packages/core/src/git/collect.test.ts
@@ -90,7 +90,7 @@ describe('collectCommits', () => {
     const head = stream.commits[0];
 
     expect(head.message).toBe('fix: multi-line message');
-    expect(head.tags.ai).toBe(true);
+    expect(head.tags.attribution).toBe('ai');
     expect(head.tags.level).toBe('explicit');
   });
 });
@@ -148,7 +148,7 @@ describe('collectCommits with attribution manifest', () => {
 
     // The bot trailer would tag this explicit ai; excluded declares automation
     expect(byHash[releaseCommit].attribution).toBe('automated');
-    expect(byHash[releaseCommit].ai).toBe(false);
+    expect(byHash[releaseCommit].attribution).not.toBe('ai');
     expect(byHash[releaseCommit].sources).toContain('manifest:excluded');
 
     expect(byHash[plainCommit].attribution).toBe('unknown');
@@ -318,7 +318,7 @@ describe('collectCommits on degenerate repositories', () => {
 
       const stream = await collectCommits({ repoPath: emptyPath });
       expect(stream.commits).toEqual([]);
-      expect(stream.schemaVersion).toBe(1);
+      expect(stream.schemaVersion).toBe(2);
       expect(stream.defaultBranch).toBe('main');
     } finally {
       rmSync(emptyPath, { recursive: true, force: true });

--- a/packages/core/src/git/collect.ts
+++ b/packages/core/src/git/collect.ts
@@ -1,7 +1,7 @@
 import { simpleGit, SimpleGit } from 'simple-git';
 import { Commit, CommitStream } from '../schema/commit.js';
 import { COMMIT_STREAM_SCHEMA_VERSION } from '../schema/version.js';
-import { createAITagger } from '../tags/ai-tags.js';
+import { createAITagger, tagFromAxes } from '../tags/ai-tags.js';
 import { createAutomatedDetector } from '../tags/automated.js';
 import {
   applyManifest,
@@ -228,21 +228,20 @@ export async function collectCommits(options: CollectOptions): Promise<CommitStr
 
     logger?.debug(`Processing commit ${rawCommit.hash}`);
 
-    // Tag AI on the full message (body included, for trailers like Co-Authored-By)
+    // Tag on the full message (body included, for trailers like Co-Authored-By)
     let aiTag = aiTagger(rawCommit.message);
-    // Automated detection only when heuristics found no AI signal:
-    // in-commit evidence wins over structural heuristics
-    if (aiTag.attribution === 'unknown') {
+    // Automated detection only when the message carried no signal at all:
+    // in-commit evidence wins over structural heuristics. Automation sits
+    // beside the autonomy axes rather than on them (#25) — a merge commit
+    // has known provenance and no author, so `mode: none` states that no AI
+    // wrote it while `automated` keeps it out of every cohort.
+    if (aiTag.evidence === 'none') {
       const automatedSource = detectAutomated(rawCommit);
       if (automatedSource) {
-        aiTag = {
-          ai: false,
-          attribution: 'automated',
-          mode: 'none',
-          modeEvidence: 'inferred',
-          level: 'none',
-          sources: [...aiTag.sources, automatedSource],
-        };
+        aiTag = tagFromAxes({ mode: 'none', evidence: 'inferred', automated: true }, 'none', [
+          ...aiTag.sources,
+          automatedSource,
+        ]);
       }
     }
     // Manifest declarations beat structural heuristics

--- a/packages/core/src/schema/aida-config.test.ts
+++ b/packages/core/src/schema/aida-config.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { AidaConfig, assertNoRetiredConfigKeys } from './aida-config.js';
+
+describe('assertNoRetiredConfigKeys', () => {
+  // zod strips unknown keys, so a config still carrying the retired prior
+  // would parse cleanly and quietly stop applying — changing which commits
+  // join which cohort on the day a repo upgrades, with no warning at all.
+  it('refuses a config that still uses defaultAttribution', () => {
+    expect(() => assertNoRetiredConfigKeys({ defaultAttribution: 'ai' })).toThrow(/defaultMode/);
+  });
+
+  it('names the replacement value for each retired one', () => {
+    expect(() => assertNoRetiredConfigKeys({ defaultAttribution: 'human' })).toThrow(
+      /"defaultMode": "none"/
+    );
+    expect(() => assertNoRetiredConfigKeys({ defaultAttribution: 'ai' })).toThrow(
+      /"defaultMode": "assisted"/
+    );
+  });
+
+  it('accepts a migrated config, and anything without the key', () => {
+    expect(() => assertNoRetiredConfigKeys({ defaultMode: 'agent' })).not.toThrow();
+    expect(() => assertNoRetiredConfigKeys({})).not.toThrow();
+    expect(() => assertNoRetiredConfigKeys(null)).not.toThrow();
+  });
+
+  it('parses a migrated config into the expected shape', () => {
+    const config = AidaConfig.parse({ defaultMode: 'agent' });
+    expect(config.defaultMode).toBe('agent');
+    expect(config).not.toHaveProperty('defaultAttribution');
+  });
+});

--- a/packages/core/src/schema/aida-config.ts
+++ b/packages/core/src/schema/aida-config.ts
@@ -5,13 +5,17 @@ export const AidaConfig = z.object({
   trailerDomains: z.array(z.string()).default([]),
   botBlocklist: z.array(z.string()).default([]),
   patterns: z.array(z.string()).default([]),
-  // Prior applied to 'unknown' commits at analysis time (#34).
-  // 'unknown' (default) = no assumption: unknown commits join no cohort.
-  defaultAttribution: z.enum(['ai', 'human', 'unknown']).default('unknown'),
-  // Attribution coverage below this fraction flags all metrics as low-confidence.
+  // Evidence coverage below this fraction flags all metrics as low-confidence.
   coverageThreshold: z.number().min(0).max(1).default(0.7),
-  // Repo-wide autonomy mode stamped by the commit hook when nothing else
-  // determines it (#61). Absent means: leave unknown rather than guess.
+  // The repo's autonomy mode when nothing else determines it (#25, #61).
+  // One key, applied at two moments:
+  //   - at commit time, the hook stamps it as an `AI-Mode:` trailer, so the
+  //     commit carries `evidence: declared` from then on;
+  //   - at analysis time, it is a PRIOR for commits with `evidence: none` —
+  //     history predating the hook. A prior joins a cohort but is never
+  //     evidence: it does not touch the tags and does not raise coverage,
+  //     so a repo leaning on it still reports how little it actually knows.
+  // Absent means: leave unknown rather than guess.
   defaultMode: z.enum(['none', 'autocomplete', 'assisted', 'agent']).optional(),
   // Replace author/committer identities with a per-run salted hash (#35).
   // Recommended in CI, where commit-stream.json leaves the machine.
@@ -19,3 +23,26 @@ export const AidaConfig = z.object({
 });
 
 export type AidaConfig = z.infer<typeof AidaConfig>;
+
+// `defaultAttribution` was the prior on the axis #25 retired. zod strips
+// unknown keys, so leaving it in place would silently change a repo's
+// cohorts the day it upgrades — the exact failure this project keeps
+// finding. Refuse the file instead, with the translation in the message.
+const RETIRED_TO_MODE: Record<string, string> = {
+  ai: 'assisted', // or autocomplete/agent — only the repo knows which
+  human: 'none',
+  unknown: '(remove the key: no prior)',
+};
+
+export function assertNoRetiredConfigKeys(raw: unknown): void {
+  if (!raw || typeof raw !== 'object' || !('defaultAttribution' in raw)) return;
+
+  const old = String((raw as { defaultAttribution: unknown }).defaultAttribution);
+  const suggestion = RETIRED_TO_MODE[old] ?? 'assisted';
+  throw new Error(
+    `.aida.json uses "defaultAttribution", which was replaced by "defaultMode" in schema v2 (#25): ` +
+      `the prior now names an autonomy level, not an AI/human label. ` +
+      `Replace "defaultAttribution": "${old}" with "defaultMode": "${suggestion}". ` +
+      `Leaving it would silently change which commits join which cohort.`
+  );
+}

--- a/packages/core/src/schema/commit.ts
+++ b/packages/core/src/schema/commit.ts
@@ -22,15 +22,25 @@ export const Commit = z.object({
   // collect time ("This reverts commit <sha>."). Null for non-revert
   // commits, or when the target isn't in the standard git-generated form.
   revertsCommit: z.string().nullable().default(null),
+  // Two orthogonal axes (#25). `mode` is what happened, `evidence` is how we
+  // know it; everything else here is derived from them.
   tags: z.object({
-    ai: z.boolean(),
-    // Four-state attribution (#34, #39). Heuristics emit 'ai' or 'unknown';
-    // 'human' requires an explicit declaration (manifest, #10); 'automated'
-    // is provenance-known automation (merge commits, bots, manifest-excluded).
-    attribution: z.enum(['ai', 'human', 'automated', 'unknown']),
-    // Autonomy axis (#25): what level of AI participated, and how we know
+    // PRIMARY AXIS — involvement. The question that still discriminates risk
+    // once "was AI involved?" trends to yes everywhere.
     mode: z.enum(['none', 'autocomplete', 'assisted', 'agent', 'unknown']),
-    modeEvidence: z.enum(['declared', 'inferred', 'none']),
+    // PRIMARY AXIS — evidence. 'declared' = stated at commit time (AI-Mode
+    // trailer, manifest); 'inferred' = derived from tool identity or
+    // structure; 'none' = no signal, which is what `unknown` used to mean.
+    evidence: z.enum(['declared', 'inferred', 'none']),
+    // Automation with known provenance (#39): merge commits, release bots.
+    // Orthogonal to the two axes — automation is not authored code, so it
+    // joins no autonomy cohort regardless of what mode it would infer.
+    automated: z.boolean(),
+    // DERIVED — the three-state projection (#34), kept because a headline
+    // needs one word. See `projectAttribution`: it is a view of the axes
+    // above, never an independent judgement.
+    attribution: z.enum(['ai', 'human', 'automated', 'unknown']),
+    // DERIVED — strength of the message heuristic that fired, if any
     level: z.enum(['explicit', 'implicit', 'mention', 'none']),
     sources: z.array(z.string()), // which heuristic matched
   }),

--- a/packages/core/src/schema/pr.ts
+++ b/packages/core/src/schema/pr.ts
@@ -18,11 +18,12 @@ export const PR_STREAM_SCHEMA_VERSION = 1;
 
 export const PRCommit = z.object({
   sha: z.string(),
+  // Same two-axis shape as a Commit's tags (#25)
   tags: z.object({
-    ai: z.boolean(),
-    attribution: z.enum(['ai', 'human', 'automated', 'unknown']),
     mode: z.enum(['none', 'autocomplete', 'assisted', 'agent', 'unknown']),
-    modeEvidence: z.enum(['declared', 'inferred', 'none']),
+    evidence: z.enum(['declared', 'inferred', 'none']),
+    automated: z.boolean(),
+    attribution: z.enum(['ai', 'human', 'automated', 'unknown']),
     level: z.enum(['explicit', 'implicit', 'mention', 'none']),
     sources: z.array(z.string()),
   }),

--- a/packages/core/src/schema/version.ts
+++ b/packages/core/src/schema/version.ts
@@ -12,8 +12,14 @@
 //     one DOES bump it.
 //   - Readers refuse a version they don't understand, with a fix in the
 //     message, instead of parsing it half-way.
-export const COMMIT_STREAM_SCHEMA_VERSION = 1;
-export const METRICS_SCHEMA_VERSION = 1;
+// v2 (#25): `tags` is now two orthogonal axes — `mode` (involvement) and
+// `evidence` (how we know) — with `attribution` demoted to a derived
+// projection of them. `modeEvidence` was renamed `evidence`, `automated`
+// became its own boolean, and the redundant `ai` boolean was dropped.
+export const COMMIT_STREAM_SCHEMA_VERSION = 2;
+// v2 (#25): coverage is measured on the evidence axis, and the prior is
+// `defaultMode` (an autonomy level) rather than `defaultAttribution`.
+export const METRICS_SCHEMA_VERSION = 2;
 
 export class SchemaVersionError extends Error {
   constructor(

--- a/packages/core/src/tags/ai-tags.test.ts
+++ b/packages/core/src/tags/ai-tags.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { createAITagger } from './ai-tags.js';
+import { createAITagger , projectAttribution } from './ai-tags.js';
 
 describe('AI Tagging', () => {
   const tagger = createAITagger();
@@ -16,14 +16,14 @@ describe('AI Tagging', () => {
 
       cases.forEach((message) => {
         const result = tagger(message);
-        expect(result.ai).toBe(true);
+        expect(result.attribution).toBe('ai');
         expect(result.level).toBe('explicit');
       });
     });
 
     it('should classify [AI] tag as explicit', () => {
       const result = tagger('[AI] automated code generation');
-      expect(result.ai).toBe(true);
+      expect(result.attribution).toBe('ai');
       expect(result.level).toBe('explicit');
       expect(result.sources).toContain('tag:[ai]');
     });
@@ -39,7 +39,7 @@ describe('AI Tagging', () => {
 
       cases.forEach((message) => {
         const result = tagger(message);
-        expect(result.ai).toBe(true);
+        expect(result.attribution).toBe('ai');
         expect(result.level).toBe('explicit');
       });
     });
@@ -51,7 +51,7 @@ Generated with Claude Code
 Co-Authored-By: Claude <noreply@anthropic.com>`;
 
       const result = tagger(claudeCommit);
-      expect(result.ai).toBe(true);
+      expect(result.attribution).toBe('ai');
       expect(result.level).toBe('explicit');
     });
   });
@@ -67,7 +67,7 @@ Co-Authored-By: Claude <noreply@anthropic.com>`;
 
       cases.forEach((message) => {
         const result = tagger(message);
-        expect(result.ai).toBe(true);
+        expect(result.attribution).toBe('ai');
         expect(result.level).toBe('implicit');
       });
     });
@@ -85,7 +85,7 @@ Co-Authored-By: Claude <noreply@anthropic.com>`;
 
       cases.forEach((message) => {
         const result = tagger(message);
-        expect(result.ai).toBe(false);
+        expect(result.attribution).not.toBe('ai');
         expect(result.level).toBe('mention');
       });
     });
@@ -98,7 +98,7 @@ Co-Authored-By: Claude <noreply@anthropic.com>`;
 
       cases.forEach((message) => {
         const result = tagger(message);
-        expect(result.ai).toBe(false);
+        expect(result.attribution).not.toBe('ai');
         expect(result.level).toBe('mention');
       });
     });
@@ -115,7 +115,7 @@ Co-Authored-By: Claude <noreply@anthropic.com>`;
 
       cases.forEach((message) => {
         const result = tagger(message);
-        expect(result.ai).toBe(false);
+        expect(result.attribution).not.toBe('ai');
         expect(result.level).toBe('none');
       });
     });
@@ -124,20 +124,20 @@ Co-Authored-By: Claude <noreply@anthropic.com>`;
   describe('edge cases', () => {
     it('should not match human Co-authored-by', () => {
       const result = tagger('feat: new feature\n\nCo-authored-by: John <john@example.com>');
-      expect(result.ai).toBe(false);
+      expect(result.attribution).not.toBe('ai');
       expect(result.level).toBe('none');
     });
 
     it('should handle custom patterns as explicit', () => {
       const customTagger = createAITagger({ patterns: ['custom-ai-tool'] });
       const result = customTagger('fix: custom-ai-tool generated code');
-      expect(result.ai).toBe(true);
+      expect(result.attribution).toBe('ai');
       expect(result.level).toBe('explicit');
     });
 
     it('should prioritize explicit over mention context', () => {
       const result = tagger('fix: generated with claude');
-      expect(result.ai).toBe(true);
+      expect(result.attribution).toBe('ai');
       expect(result.level).toBe('explicit');
     });
   });
@@ -152,7 +152,7 @@ Co-Authored-By: Claude <noreply@anthropic.com>`;
 
       cases.forEach((message) => {
         const result = tagger(message);
-        expect(result.ai).toBe(false);
+        expect(result.attribution).not.toBe('ai');
         expect(result.level).toBe('none');
       });
     });
@@ -161,7 +161,7 @@ Co-Authored-By: Claude <noreply@anthropic.com>`;
       const result = tagger(
         'feat: new feature\n\nCo-authored-by: copilot[bot] <copilot@github.com>'
       );
-      expect(result.ai).toBe(true);
+      expect(result.attribution).toBe('ai');
       expect(result.level).toBe('explicit');
     });
 
@@ -170,7 +170,7 @@ Co-Authored-By: Claude <noreply@anthropic.com>`;
       const result = customTagger(
         'chore: automated\n\nCo-authored-by: acme-bot <bot@github.com>'
       );
-      expect(result.ai).toBe(false);
+      expect(result.attribution).not.toBe('ai');
       expect(result.level).toBe('none');
     });
 
@@ -181,7 +181,7 @@ Co-Authored-By: Claude <noreply@anthropic.com>`;
 Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
 Co-authored-by: Claude <noreply@anthropic.com>`
       );
-      expect(result.ai).toBe(true);
+      expect(result.attribution).toBe('ai');
       expect(result.level).toBe('explicit');
     });
   });
@@ -208,7 +208,7 @@ Co-authored-by: Claude <noreply@anthropic.com>`
       const customTagger = createAITagger({ patterns: [], trailerDomains: ['mycompany\\.com'] });
 
       const result = customTagger('feat: new feature\n\nCo-authored-by: Bot <bot@mycompany.com>');
-      expect(result.ai).toBe(true);
+      expect(result.attribution).toBe('ai');
       expect(result.level).toBe('explicit');
     });
   });
@@ -219,7 +219,7 @@ Co-authored-by: Claude <noreply@anthropic.com>`
         'fix: bug\n\nGenerated with Claude Code\nCo-Authored-By: Claude <noreply@anthropic.com>'
       );
       expect(result.mode).toBe('agent');
-      expect(result.modeEvidence).toBe('inferred');
+      expect(result.evidence).toBe('inferred');
     });
 
     it('infers autocomplete from copilot and assisted from IDE tools', () => {
@@ -228,18 +228,22 @@ Co-authored-by: Claude <noreply@anthropic.com>`
       expect(tagger('feat: written using chatgpt').mode).toBe('assisted');
     });
 
-    it('leaves mode unknown with no evidence for anonymous AI signals', () => {
+    // The two axes exist precisely for this state: we concluded AI
+    // participated, we cannot say at what level. The old single-axis model
+    // had to call it `evidence: 'none'`, which contradicted the 'ai' it had
+    // just asserted — and made coverage disagree with attribution.
+    it('reports an anonymous AI signal as inferred evidence with an unknown mode', () => {
       const result = tagger('[AI] automated change');
-      expect(result.ai).toBe(true);
+      expect(result.attribution).toBe('ai');
       expect(result.mode).toBe('unknown');
-      expect(result.modeEvidence).toBe('none');
+      expect(result.evidence).toBe('inferred');
     });
 
     it('never infers a mode for non-AI commits', () => {
       const result = tagger('fix: update claude detection pattern'); // mention only
-      expect(result.ai).toBe(false);
+      expect(result.attribution).not.toBe('ai');
       expect(result.mode).toBe('unknown');
-      expect(result.modeEvidence).toBe('none');
+      expect(result.evidence).toBe('none');
     });
   });
 
@@ -250,7 +254,7 @@ Co-authored-by: Claude <noreply@anthropic.com>`
       );
       // The Copilot trailer would infer autocomplete; the declaration wins
       expect(result.mode).toBe('agent');
-      expect(result.modeEvidence).toBe('declared');
+      expect(result.evidence).toBe('declared');
       expect(result.attribution).toBe('ai');
       expect(result.sources).toContain('trailer:AI-Mode');
     });
@@ -258,9 +262,9 @@ Co-authored-by: Claude <noreply@anthropic.com>`
     it('treats AI-Mode: none as a declaration of human authorship', () => {
       const result = tagger('fix: hand written\n\nAI-Mode: none');
       expect(result.attribution).toBe('human');
-      expect(result.ai).toBe(false);
+      expect(result.attribution).not.toBe('ai');
       expect(result.mode).toBe('none');
-      expect(result.modeEvidence).toBe('declared');
+      expect(result.evidence).toBe('declared');
     });
 
     it('accepts every documented mode, case-insensitively', () => {
@@ -273,7 +277,7 @@ Co-authored-by: Claude <noreply@anthropic.com>`
     it('ignores an unrecognized mode value rather than trusting it', () => {
       const result = tagger('feat: x\n\nAI-Mode: wizard');
       expect(result.mode).toBe('unknown');
-      expect(result.modeEvidence).toBe('none');
+      expect(result.evidence).toBe('none');
     });
   });
 
@@ -302,13 +306,13 @@ describe('github.com is not an AI signal by itself (external-repo false positive
     ];
     for (const message of cases) {
       const result = tagger(message);
-      expect(result.ai).toBe(false);
+      expect(result.attribution).not.toBe('ai');
       expect(result.attribution).toBe('unknown');
     }
   });
 
   it('still flags AI bots hosted on github.com via the tool-name rule', () => {
-    expect(tagger('feat: x\n\nCo-authored-by: copilot[bot] <copilot@github.com>').ai).toBe(true);
+    expect(tagger('feat: x\n\nCo-authored-by: copilot[bot] <copilot@github.com>').attribution).toBe('ai');
   });
 
   it('classifies copilot-swe-agent as an agent, not autocomplete', () => {
@@ -339,7 +343,7 @@ describe('an unnamed bot co-author is not an AI signal (external-repo false posi
     ];
     for (const message of cases) {
       const result = tagger(message);
-      expect(result.ai).toBe(false);
+      expect(result.attribution).not.toBe('ai');
       expect(result.attribution).toBe('unknown');
     }
   });
@@ -348,7 +352,7 @@ describe('an unnamed bot co-author is not an AI signal (external-repo false posi
   // so any co-author whose name merely contains "bot" was read as AI.
   it('does not flag a human whose name contains "bot"', () => {
     const result = tagger('Fix parser\n\nCo-authored-by: Tim Abbott <tabbott@example.com>');
-    expect(result.ai).toBe(false);
+    expect(result.attribution).not.toBe('ai');
     expect(result.attribution).toBe('unknown');
   });
 
@@ -362,8 +366,56 @@ describe('an unnamed bot co-author is not an AI signal (external-repo false posi
     ];
     for (const message of detected) {
       const result = tagger(message);
-      expect(result.ai).toBe(true);
+      expect(result.attribution).toBe('ai');
       expect(result.mode).not.toBe('unknown');
     }
+  });
+});
+
+describe('two-axis model (#25)', () => {
+  const tagger = createAITagger();
+
+  // The whole point of the refactor: `attribution` is a view, not a second
+  // opinion. If anything ever decides it independently, this fails.
+  it('always agrees with the projection of its own axes', () => {
+    const messages = [
+      'feat: plain commit',
+      '[AI] anonymous signal',
+      'feat: generated by copilot',
+      'feat: x\n\nCo-authored-by: Claude <noreply@anthropic.com>',
+      'chore: release\n\nAI-Mode: none',
+      'feat: y\n\nAI-Mode: agent',
+      'fix: update cursor detection pattern',
+    ];
+    for (const message of messages) {
+      const result = tagger(message);
+      expect(result.attribution).toBe(projectAttribution(result));
+    }
+  });
+
+  // `unknown` used to be a fourth kind of attribution. It is now exactly one
+  // thing: the absence of evidence. Coverage depends on this holding.
+  it('ties attribution unknown to evidence none, in both directions', () => {
+    const withoutEvidence = tagger('feat: plain commit');
+    expect(withoutEvidence.evidence).toBe('none');
+    expect(withoutEvidence.attribution).toBe('unknown');
+
+    const withEvidence = tagger('feat: y\n\nAI-Mode: assisted');
+    expect(withEvidence.evidence).not.toBe('none');
+    expect(withEvidence.attribution).not.toBe('unknown');
+  });
+
+  it('reads AI-Mode: none as a human declaration, not as absent evidence', () => {
+    const result = tagger('chore: hand-written\n\nAI-Mode: none');
+    expect(result.mode).toBe('none');
+    expect(result.evidence).toBe('declared');
+    expect(result.attribution).toBe('human');
+  });
+
+  it('never marks a message-tagged commit as automated', () => {
+    // Automation is orthogonal: it is set at collect time from commit
+    // structure and authorship, never from message heuristics.
+    expect(tagger('Merge branch main').automated).toBe(false);
+    expect(tagger('feat: y\n\nAI-Mode: agent').automated).toBe(false);
   });
 });

--- a/packages/core/src/tags/ai-tags.ts
+++ b/packages/core/src/tags/ai-tags.ts
@@ -1,21 +1,45 @@
 export type AILevel = 'explicit' | 'implicit' | 'mention' | 'none';
 
-// Four-state attribution (#34, #39). Message heuristics can only ever
-// produce 'ai' or 'unknown': the absence of an AI signal is not evidence of
-// human authorship. 'human' requires an explicit declaration (manifest,
-// #10). 'automated' is provenance-known automation — merge commits, release
-// bots — detected at collect time or declared via the manifest; it counts
-// toward coverage but joins no cohort.
-export type Attribution = 'ai' | 'human' | 'automated' | 'unknown';
-
-// Autonomy axis (#25): what level of AI participated. The durable dimension
-// in an AI-first world, where "was AI involved" trends toward "yes".
+// PRIMARY AXIS 1 — involvement (#25): what level of AI participated. The
+// durable dimension in an AI-first world, where "was AI involved" trends
+// toward "yes" and stops discriminating anything.
 export type AIMode = 'none' | 'autocomplete' | 'assisted' | 'agent' | 'unknown';
 
-// How we know the mode: 'declared' = explicit statement (manifest mode
-// field, future commit-time hooks); 'inferred' = derived from tool identity
-// via MODE_BY_TOOL — real signal, our conclusion; 'none' = no signal at all.
-export type ModeEvidence = 'declared' | 'inferred' | 'none';
+// PRIMARY AXIS 2 — evidence (#25): how we know. 'declared' = someone stated
+// it (AI-Mode trailer, manifest); 'inferred' = we concluded it from tool
+// identity or commit structure — real signal, our conclusion; 'none' = no
+// signal at all, which is what the old `attribution: 'unknown'` meant.
+//
+// The two axes are orthogonal: `mode: 'unknown', evidence: 'inferred'` is a
+// real state — we know AI participated, we cannot say at what level.
+export type Evidence = 'declared' | 'inferred' | 'none';
+
+// DERIVED — the three-state projection (#34, #39), kept because a headline
+// needs one word. Never decided independently of the axes above: see
+// `projectAttribution`. 'automated' is provenance-known automation (merge
+// commits, release bots) — it counts toward coverage but joins no cohort,
+// because automation is not authored code.
+export type Attribution = 'ai' | 'human' | 'automated' | 'unknown';
+
+export interface AutonomyAxes {
+  mode: AIMode;
+  evidence: Evidence;
+  automated: boolean;
+}
+
+// The whole three-state model, in one function. Everything it reads is on
+// the two primary axes; nothing else in AIDA may decide an attribution.
+export function projectAttribution({ mode, evidence, automated }: AutonomyAxes): Attribution {
+  // Automation is orthogonal to autonomy: known provenance, no author.
+  if (automated) return 'automated';
+  // No signal either way. The absence of evidence is not evidence of a human.
+  if (evidence === 'none') return 'unknown';
+  // Someone stated, or we inferred, that no AI participated.
+  if (mode === 'none') return 'human';
+  // autocomplete | assisted | agent, or 'unknown' with a signal behind it:
+  // AI participated, even where we cannot name the level.
+  return 'ai';
+}
 
 // Tool identity → coarse autonomy mode. Deliberately rough: a trailer names
 // the tool, not the session mode. First match wins; multi-word names before
@@ -51,13 +75,21 @@ export function inferMode(message: string): AIMode {
   return 'unknown';
 }
 
-export interface AITagResult {
-  ai: boolean;
+export interface AITagResult extends AutonomyAxes {
+  // Derived from the axes above by `projectAttribution`
   attribution: Attribution;
-  mode: AIMode;
-  modeEvidence: ModeEvidence;
   level: AILevel;
   sources: string[];
+}
+
+// Single construction point for a tag, so `attribution` can never drift out
+// of agreement with the axes it is supposed to project.
+export function tagFromAxes(
+  axes: AutonomyAxes,
+  level: AILevel,
+  sources: string[]
+): AITagResult {
+  return { ...axes, attribution: projectAttribution(axes), level, sources };
 }
 
 export interface AITagConfig {
@@ -235,33 +267,40 @@ export function createAITagger(
       }
     }
 
-    // A declared mode is itself an AI signal: `AI-Mode: agent` states that an
-    // agent wrote this, and `AI-Mode: none` states a human did (#61).
+    // The two axes are settled here, in order of evidence strength, and the
+    // three-state attribution falls out of them (#25). Nothing below decides
+    // "is this AI?" directly — that question is now a projection.
+
+    // 1. Declared. `AI-Mode: agent` states an agent wrote this; `AI-Mode:
+    //    none` states a human did (#61). A declaration outranks everything.
     const declared = declaredMode(message);
     if (declared) {
       sources.push('trailer:AI-Mode');
-      const declaredAI = declared !== 'none';
-      return {
-        ai: declaredAI,
-        attribution: declaredAI ? 'ai' : 'human',
-        mode: declared,
-        modeEvidence: 'declared',
-        level: declaredAI ? 'explicit' : level,
-        sources,
-      };
+      return tagFromAxes(
+        { mode: declared, evidence: 'declared', automated: false },
+        // A declared mode is itself explicit evidence, except `none`, which
+        // asserts absence and leaves the message heuristics to speak
+        declared === 'none' ? level : 'explicit',
+        sources
+      );
     }
 
-    // ai: true only for explicit and implicit
-    const ai = level === 'explicit' || level === 'implicit';
-    // Mode inference only makes sense once AI involvement is established
-    const mode = ai ? inferMode(message) : 'unknown';
-    return {
-      ai,
-      attribution: ai ? 'ai' : 'unknown',
-      mode,
-      modeEvidence: mode === 'unknown' ? 'none' : 'inferred',
+    // 2. No AI signal in the message. Not a human commit — just no signal,
+    //    which is exactly what `evidence: 'none'` means.
+    const hasAISignal = level === 'explicit' || level === 'implicit';
+    if (!hasAISignal) {
+      return tagFromAxes({ mode: 'unknown', evidence: 'none', automated: false }, level, sources);
+    }
+
+    // 3. AI participated. `inferMode` names the level when the message names
+    //    a tool; when it does not, the level stays 'unknown' while the
+    //    evidence remains 'inferred' — we did conclude something, just not
+    //    the autonomy level. That pairing is the reason the axes are
+    //    separate: the old model had to call this state 'no evidence'.
+    return tagFromAxes(
+      { mode: inferMode(message), evidence: 'inferred', automated: false },
       level,
-      sources,
-    };
+      sources
+    );
   };
 }

--- a/packages/core/src/tags/attribution-manifest.test.ts
+++ b/packages/core/src/tags/attribution-manifest.test.ts
@@ -9,7 +9,7 @@ import {
   loadAttributionManifest,
   unmatchedManifestHashes,
 } from './attribution-manifest.js';
-import { AITagResult } from './ai-tags.js';
+import { AITagResult, tagFromAxes } from './ai-tags.js';
 
 const HASH_AI = 'a'.repeat(40);
 const HASH_HUMAN = 'b'.repeat(40);
@@ -27,21 +27,25 @@ function makeIndex() {
   );
 }
 
-const unknownTag: AITagResult = { ai: false, attribution: 'unknown', mode: 'unknown', modeEvidence: 'none', level: 'none', sources: [] };
-const aiTag: AITagResult = {
-  ai: true,
-  attribution: 'ai',
-  mode: 'unknown',
-  modeEvidence: 'none',
-  level: 'explicit',
-  sources: ['trailer:^AI:\\s*true$'],
-};
+// Built through tagFromAxes so the fixtures cannot encode a state the
+// tagger would never produce — `attribution` is a projection, not a value
+// a test gets to choose independently of the axes.
+const unknownTag: AITagResult = tagFromAxes(
+  { mode: 'unknown', evidence: 'none', automated: false },
+  'none',
+  []
+);
+const aiTag: AITagResult = tagFromAxes(
+  { mode: 'unknown', evidence: 'inferred', automated: false },
+  'explicit',
+  ['trailer:^AI:\\s*true$']
+);
 
 describe('applyManifest precedence', () => {
   it('tags manifest ai_assisted commits as explicit ai with source manifest', () => {
     const result = applyManifest(unknownTag, HASH_AI, makeIndex());
     expect(result.attribution).toBe('ai');
-    expect(result.ai).toBe(true);
+    expect(result.attribution).toBe('ai');
     expect(result.level).toBe('explicit');
     expect(result.sources).toContain('manifest');
   });
@@ -55,7 +59,7 @@ describe('applyManifest precedence', () => {
   it('tags manifest human_authored commits as human when heuristics found nothing', () => {
     const result = applyManifest(unknownTag, HASH_HUMAN, makeIndex());
     expect(result.attribution).toBe('human');
-    expect(result.ai).toBe(false);
+    expect(result.attribution).not.toBe('ai');
     expect(result.sources).toContain('manifest');
   });
 
@@ -75,9 +79,9 @@ describe('applyManifest precedence', () => {
   it('excluded overrides heuristics and declares automation', () => {
     const result = applyManifest(aiTag, HASH_EXCLUDED, makeIndex());
     expect(result.attribution).toBe('automated');
-    expect(result.ai).toBe(false);
+    expect(result.attribution).not.toBe('ai');
     expect(result.mode).toBe('none');
-    expect(result.modeEvidence).toBe('declared');
+    expect(result.evidence).toBe('declared');
     expect(result.sources).toContain('manifest:excluded');
   });
 
@@ -96,7 +100,7 @@ describe('applyManifest precedence', () => {
     );
     const result = applyManifest(unknownTag, HASH_AI, index);
     expect(result.mode).toBe('agent');
-    expect(result.modeEvidence).toBe('declared');
+    expect(result.evidence).toBe('declared');
   });
 
   it('lets an entry-level mode override the manifest-level default', () => {
@@ -111,16 +115,16 @@ describe('applyManifest precedence', () => {
   });
 
   it('keeps the heuristic inferred mode when the manifest declares none', () => {
-    const inferredTag: AITagResult = { ...aiTag, mode: 'agent', modeEvidence: 'inferred' };
+    const inferredTag: AITagResult = { ...aiTag, mode: 'agent', evidence: 'inferred' };
     const result = applyManifest(inferredTag, HASH_AI, makeIndex());
     expect(result.mode).toBe('agent');
-    expect(result.modeEvidence).toBe('inferred');
+    expect(result.evidence).toBe('inferred');
   });
 
   it('declares mode none for human_authored commits', () => {
     const result = applyManifest(unknownTag, HASH_HUMAN, makeIndex());
     expect(result.mode).toBe('none');
-    expect(result.modeEvidence).toBe('declared');
+    expect(result.evidence).toBe('declared');
   });
 
   it('reports manifest hashes that matched no collected commit', () => {

--- a/packages/core/src/tags/attribution-manifest.ts
+++ b/packages/core/src/tags/attribution-manifest.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { readFile } from 'fs/promises';
 import { join } from 'path';
-import { AIMode, AITagResult } from './ai-tags.js';
+import { AIMode, AITagResult, tagFromAxes } from './ai-tags.js';
 import { Logger } from '../utils/log.js';
 
 export const MANIFEST_FILENAME = 'aida-attribution.json';
@@ -98,31 +98,33 @@ export function applyManifest(
 ): AITagResult {
   if (index.excluded.has(hash)) {
     index.matched.add(hash);
-    return {
-      ai: false,
-      // Excluded = declared automation (#39): provenance known, no cohort
-      attribution: 'automated',
-      mode: 'none',
-      modeEvidence: 'declared',
-      level: 'none',
-      sources: [...heuristic.sources, 'manifest:excluded'],
-    };
+    // Excluded = declared automation (#39): provenance known, no cohort
+    return tagFromAxes(
+      { mode: 'none', evidence: 'declared', automated: true },
+      'none',
+      [...heuristic.sources, 'manifest:excluded']
+    );
   }
 
   if (index.ai.has(hash)) {
     index.matched.add(hash);
     const declaredMode = index.ai.get(hash) ?? null;
-    return {
-      ai: true,
-      attribution: 'ai',
-      // A declared mode beats heuristic inference; without one, keep
-      // whatever the heuristics inferred from tool identity.
-      mode: declaredMode ?? heuristic.mode,
-      modeEvidence: declaredMode ? 'declared' : heuristic.modeEvidence,
-      // A manifest declaration is explicit, whatever the heuristics said
-      level: 'explicit',
-      sources: [...heuristic.sources, 'manifest'],
-    };
+    // Precedence on the mode axis: a declared mode beats heuristic
+    // inference; without one, keep whatever the heuristics inferred from
+    // tool identity. When neither names a level, the manifest has still
+    // *declared* that AI participated — the provenance is known, only its
+    // granularity is missing, so the evidence is 'declared' with an unknown
+    // mode rather than no evidence at all (#25).
+    const mode = declaredMode ?? heuristic.mode;
+    const evidence = declaredMode
+      ? 'declared'
+      : heuristic.mode === 'unknown'
+        ? 'declared'
+        : heuristic.evidence;
+    return tagFromAxes({ mode, evidence, automated: false }, 'explicit', [
+      ...heuristic.sources,
+      'manifest',
+    ]);
   }
 
   if (index.human.has(hash)) {
@@ -134,15 +136,11 @@ export function applyManifest(
       );
       return heuristic;
     }
-    return {
-      ai: false,
-      attribution: 'human',
-      // A human declaration is a mode declaration: no AI participated
-      mode: 'none',
-      modeEvidence: 'declared',
-      level: heuristic.level,
-      sources: [...heuristic.sources, 'manifest'],
-    };
+    // A human declaration is a mode declaration: no AI participated
+    return tagFromAxes({ mode: 'none', evidence: 'declared', automated: false }, heuristic.level, [
+      ...heuristic.sources,
+      'manifest',
+    ]);
   }
 
   return heuristic;

--- a/packages/core/src/tags/automated.ts
+++ b/packages/core/src/tags/automated.ts
@@ -3,7 +3,7 @@ import { DEFAULT_BOT_BLOCKLIST } from './ai-tags.js';
 // Automated detection (#39): merge commits and bot-authored commits are
 // automation, not authored code. Their provenance is KNOWN — counting them
 // as 'unknown' misreads a bookkeeping artifact as a data-quality gap, and
-// letting a defaultAttribution prior pull them into a cohort pollutes it.
+// letting a defaultMode prior pull them into a cohort pollutes it.
 // Applied only when message heuristics found no AI signal: in-commit
 // evidence always wins.
 

--- a/packages/metrics/src/cohort.test.ts
+++ b/packages/metrics/src/cohort.test.ts
@@ -15,7 +15,7 @@ function makeCommit(authorDate: string, files: string[] = []): Commit {
     parents: [],
     inDefaultBranchAncestry: true,
     revertsCommit: null,
-    tags: { ai: false, attribution: 'unknown', mode: 'unknown', modeEvidence: 'none', level: 'none', sources: [] },
+    tags: { attribution: 'unknown', automated: false, mode: 'unknown', evidence: 'none', level: 'none', sources: [] },
     stats: {
       totalAdditions: 1,
       totalDeletions: 0,

--- a/packages/metrics/src/index.test.ts
+++ b/packages/metrics/src/index.test.ts
@@ -14,7 +14,7 @@ function makeCommit(overrides: Partial<Commit> & { hash: string }): Commit {
     parents: [],
     inDefaultBranchAncestry: true,
     revertsCommit: null,
-    tags: { ai: false, attribution: 'unknown', mode: 'unknown', modeEvidence: 'none', level: 'none', sources: [] },
+    tags: { attribution: 'unknown', automated: false, mode: 'unknown', evidence: 'none', level: 'none', sources: [] },
     stats: { totalAdditions: 1, totalDeletions: 0, files: [] },
     ...overrides,
   };
@@ -31,9 +31,9 @@ function makeStream(commits: Commit[]): CommitStream {
   };
 }
 
-const aiTags: Commit['tags'] = { ai: true, attribution: 'ai', mode: 'agent', modeEvidence: 'inferred', level: 'explicit', sources: ['tag:[ai]'] };
-const humanTags: Commit['tags'] = { ai: false, attribution: 'human', mode: 'none', modeEvidence: 'declared', level: 'none', sources: [] };
-const unknownTags: Commit['tags'] = { ai: false, attribution: 'unknown', mode: 'unknown', modeEvidence: 'none', level: 'none', sources: [] };
+const aiTags: Commit['tags'] = { attribution: 'ai', automated: false, mode: 'agent', evidence: 'inferred', level: 'explicit', sources: ['tag:[ai]'] };
+const humanTags: Commit['tags'] = { attribution: 'human', automated: false, mode: 'none', evidence: 'declared', level: 'none', sources: [] };
+const unknownTags: Commit['tags'] = { attribution: 'unknown', automated: false, mode: 'unknown', evidence: 'none', level: 'none', sources: [] };
 
 describe('calculateMetrics attribution coverage', () => {
   it('reports coverage as (ai + human) / total', () => {
@@ -56,10 +56,9 @@ describe('calculateMetrics attribution coverage', () => {
 
   it('counts automated commits toward coverage — their provenance is known', () => {
     const automatedTags: Commit['tags'] = {
-      ai: false,
-      attribution: 'automated',
+      attribution: 'automated', automated: true,
       mode: 'none',
-      modeEvidence: 'inferred',
+      evidence: 'inferred',
       level: 'none',
       sources: ['automated:bot'],
     };
@@ -159,31 +158,32 @@ describe('calculateMetrics baseline cohort', () => {
     expect(metrics.delta).not.toBeNull();
   });
 
-  it('assigns unknown commits to the baseline with defaultAttribution: human, marked assumed', () => {
+  it('assigns no-evidence commits to the baseline with defaultMode: none, marked assumed', () => {
     const metrics = calculateMetrics(
       makeStream([
         makeCommit({ hash: 'a1', tags: aiTags }),
         makeCommit({ hash: 'u1', tags: unknownTags }),
         makeCommit({ hash: 'u2', tags: unknownTags }),
       ]),
-      { defaultAttribution: 'human' }
+      { defaultMode: 'none' }
     );
 
     expect(metrics.baseline).not.toBeNull();
     expect(metrics.baseline!.assumed).toBe(true);
     expect(metrics.baseline!.persistence.commitsConsidered).toBe(2);
-    // Coverage still reports the truth: unknown commits stay unknown
+    // A prior joins a cohort but is not evidence: coverage still reports how
+    // little this repo actually knows about itself (#25).
     expect(metrics.attribution.unknown).toBe(2);
+    expect(metrics.attribution.evidence.none).toBe(2);
     expect(metrics.attribution.coverage).toBeCloseTo(1 / 3);
-    expect(metrics.caveats.some((c) => c.includes('assumed human'))).toBe(true);
+    expect(metrics.caveats.some((c) => c.includes("assumed autonomy level 'none'"))).toBe(true);
   });
 
   it('never assigns automated commits to a cohort, even with a prior', () => {
     const excludedTags: Commit['tags'] = {
-      ai: false,
-      attribution: 'automated',
+      attribution: 'automated', automated: true,
       mode: 'none',
-      modeEvidence: 'declared',
+      evidence: 'declared',
       level: 'none',
       sources: ['manifest:excluded'],
     };
@@ -193,7 +193,7 @@ describe('calculateMetrics baseline cohort', () => {
         makeCommit({ hash: 'x1', tags: excludedTags }),
         makeCommit({ hash: 'u1', tags: unknownTags }),
       ]),
-      { defaultAttribution: 'ai' }
+      { defaultMode: 'assisted' }
     );
 
     // prior pulls u1 into the AI cohort, but never x1
@@ -228,18 +228,16 @@ describe('calculateMetrics baseline cohort', () => {
 
   it('computes per-mode stats, excluding automated commits, null for empty modes', () => {
     const assistedTags: Commit['tags'] = {
-      ai: true,
-      attribution: 'ai',
+      attribution: 'ai', automated: false,
       mode: 'assisted',
-      modeEvidence: 'inferred',
+      evidence: 'inferred',
       level: 'implicit',
       sources: ['implicit:x'],
     };
     const automatedTags: Commit['tags'] = {
-      ai: false,
-      attribution: 'automated',
+      attribution: 'automated', automated: true,
       mode: 'none',
-      modeEvidence: 'inferred',
+      evidence: 'inferred',
       level: 'none',
       sources: ['automated:bot'],
     };
@@ -258,17 +256,17 @@ describe('calculateMetrics baseline cohort', () => {
     expect(metrics.byMode.autocomplete).toBeNull();
   });
 
-  it('assigns unknown commits to the AI cohort with defaultAttribution: ai', () => {
+  it('assigns no-evidence commits to the AI cohort with an AI-level defaultMode', () => {
     const metrics = calculateMetrics(
       makeStream([
         makeCommit({ hash: 'a1', tags: aiTags }),
         makeCommit({ hash: 'h1', tags: humanTags }),
         makeCommit({ hash: 'u1', tags: unknownTags }),
       ]),
-      { defaultAttribution: 'ai' }
+      { defaultMode: 'assisted' }
     );
 
-    expect(metrics.persistence.commitsConsidered).toBe(2); // ai + unknown
+    expect(metrics.persistence.commitsConsidered).toBe(2); // ai + no-evidence
     expect(metrics.baseline!.persistence.commitsConsidered).toBe(1); // human only
     expect(metrics.baseline!.assumed).toBe(false);
   });
@@ -406,5 +404,105 @@ describe('outcomeCorrelation (#26)', () => {
     const metrics = calculateMetrics(makeStream([makeCommit({ hash: 'a1', tags: aiTags })]));
     expect(metrics.outcomeCorrelation.reverts.total).toBe(0);
     expect(metrics.outcomeCorrelation.hotfixes.total).toBe(0);
+  });
+});
+
+describe('coverage is the evidence axis (#25)', () => {
+  it('counts declared and inferred provenance, whatever the attribution is', () => {
+    const declaredHuman: Commit['tags'] = {
+      attribution: 'human',
+      automated: false,
+      mode: 'none',
+      evidence: 'declared',
+      level: 'none',
+      sources: ['trailer:AI-Mode'],
+    };
+    // AI participated, level unknown: real evidence, no autonomy level.
+    // The old model had to call this state 'no evidence' and undercounted it.
+    const anonymousAI: Commit['tags'] = {
+      attribution: 'ai',
+      automated: false,
+      mode: 'unknown',
+      evidence: 'inferred',
+      level: 'explicit',
+      sources: ['tag:[ai]'],
+    };
+
+    const metrics = calculateMetrics(
+      makeStream([
+        makeCommit({ hash: 'h1', tags: declaredHuman }),
+        makeCommit({ hash: 'a1', tags: anonymousAI }),
+        makeCommit({ hash: 'u1', tags: unknownTags }),
+        makeCommit({ hash: 'u2', tags: unknownTags }),
+      ])
+    );
+
+    expect(metrics.attribution.evidence).toEqual({ declared: 1, inferred: 1, none: 2 });
+    expect(metrics.attribution.coverage).toBe(0.5);
+  });
+
+  it('is never raised by a prior — an assumption is not evidence', () => {
+    const stream = makeStream([
+      makeCommit({ hash: 'u1', tags: unknownTags }),
+      makeCommit({ hash: 'u2', tags: unknownTags }),
+    ]);
+
+    const withoutPrior = calculateMetrics(stream);
+    const withPrior = calculateMetrics(stream, { defaultMode: 'agent' });
+
+    expect(withoutPrior.attribution.coverage).toBe(0);
+    expect(withPrior.attribution.coverage).toBe(0);
+    // The prior moves cohorts, not knowledge
+    expect(withPrior.byMode.agent?.commits).toBe(2);
+    expect(withoutPrior.byMode.agent).toBeNull();
+  });
+
+  it('keeps automated commits covered — their provenance is known', () => {
+    const automated: Commit['tags'] = {
+      attribution: 'automated',
+      automated: true,
+      mode: 'none',
+      evidence: 'inferred',
+      level: 'none',
+      sources: ['automated:merge-commit'],
+    };
+    const metrics = calculateMetrics(
+      makeStream([makeCommit({ hash: 'm1', tags: automated })]),
+      { defaultMode: 'agent' }
+    );
+
+    expect(metrics.attribution.coverage).toBe(1);
+    // ...but a prior still never drags them into a cohort
+    expect(metrics.byMode.agent).toBeNull();
+    expect(metrics.byMode.none).toBeNull();
+  });
+});
+
+describe('automated commits stay off the autonomy axis (#25/#39)', () => {
+  // Found by dogfooding the two-axis report on this repo: 37 merge/bot
+  // commits carry `mode: 'none'`, and the headline table counted them as
+  // hand-written — while `byMode`, which excludes automation, showed none.
+  // Two tables in one report disagreeing about the same commits.
+  it('excludes automated commits from the per-mode counts', () => {
+    const automated: Commit['tags'] = {
+      attribution: 'automated',
+      automated: true,
+      mode: 'none',
+      evidence: 'inferred',
+      level: 'none',
+      sources: ['automated:merge-commit'],
+    };
+    const metrics = calculateMetrics(
+      makeStream([
+        makeCommit({ hash: 'a1', tags: aiTags }),
+        makeCommit({ hash: 'm1', tags: automated }),
+        makeCommit({ hash: 'm2', tags: automated }),
+      ])
+    );
+
+    expect(metrics.attribution.modes.none).toBe(0);
+    expect(metrics.attribution.automated).toBe(2);
+    // The headline table and the per-level table now describe the same set
+    expect(metrics.byMode.none).toBeNull();
   });
 });

--- a/packages/metrics/src/index.ts
+++ b/packages/metrics/src/index.ts
@@ -1,4 +1,5 @@
 import {
+  AIMode,
   BlameStream,
   Commit,
   CommitStream,
@@ -31,8 +32,9 @@ export * from './outcome-correlation.js';
 export const DEFAULT_COVERAGE_WINDOW_DAYS = 90;
 
 export interface MetricsOptions {
-  // Prior applied to 'unknown' commits: which cohort (if any) they join.
-  defaultAttribution?: 'ai' | 'human' | 'unknown';
+  // Prior for commits with no evidence (#25): which cohort, if any, they
+  // join. Undefined = no assumption.
+  defaultMode?: 'none' | 'autocomplete' | 'assisted' | 'agent';
   coverageThreshold?: number;
   // Window for the actionable coverage figure (#52)
   coverageWindowDays?: number;
@@ -54,7 +56,7 @@ export function calculateMetrics(
   options: MetricsOptions = {}
 ): Metrics {
   const {
-    defaultAttribution = 'unknown',
+    defaultMode,
     coverageThreshold = 0.7,
     coverageWindowDays = DEFAULT_COVERAGE_WINDOW_DAYS,
     prStream = null,
@@ -64,15 +66,22 @@ export function calculateMetrics(
 
   const counts = { ai: 0, human: 0, automated: 0, unknown: 0 };
   const modes = { none: 0, autocomplete: 0, assisted: 0, agent: 0, unknown: 0 };
-  const modeEvidence = { declared: 0, inferred: 0, none: 0 };
+  const evidence = { declared: 0, inferred: 0, none: 0 };
   for (const commit of commitStream.commits) {
     counts[commit.tags.attribution]++;
-    modes[commit.tags.mode]++;
-    modeEvidence[commit.tags.modeEvidence]++;
+    evidence[commit.tags.evidence]++;
+    // Automation is off the autonomy axis (#39). Counting a merge commit's
+    // `mode: 'none'` under "hand-written" would both overstate the human
+    // cohort and contradict `byMode`, which excludes automation — two tables
+    // in the same report disagreeing about the same commits.
+    if (!commit.tags.automated) modes[commit.tags.mode]++;
   }
   const total = commitStream.commits.length;
-  // Automated commits have known provenance (#39): they count as covered
-  const coverage = total > 0 ? (counts.ai + counts.human + counts.automated) / total : 0;
+  // Coverage is the evidence axis (#25): how much of the history has known
+  // provenance, declared or inferred. Automated commits count as covered
+  // because their provenance IS known (#39) — they carry evidence
+  // 'inferred', so they need no special case here any more.
+  const coverage = total > 0 ? (evidence.declared + evidence.inferred) / total : 0;
 
   // Coverage over a recent window (#52): the number a team can actually move.
   // All-time coverage is a permanent verdict on history predating adoption.
@@ -81,11 +90,13 @@ export function calculateMetrics(
     (commit) => new Date(commit.authorDate) >= windowStart
   );
   const recentCounts = { ai: 0, human: 0, automated: 0, unknown: 0 };
-  for (const commit of recentCommits) recentCounts[commit.tags.attribution]++;
+  let recentWithEvidence = 0;
+  for (const commit of recentCommits) {
+    recentCounts[commit.tags.attribution]++;
+    if (commit.tags.evidence !== 'none') recentWithEvidence++;
+  }
   const recentCoverage =
-    recentCommits.length > 0
-      ? (recentCounts.ai + recentCounts.human + recentCounts.automated) / recentCommits.length
-      : 0;
+    recentCommits.length > 0 ? recentWithEvidence / recentCommits.length : 0;
 
   const attribution: Attribution = {
     commitsTotal: total,
@@ -94,7 +105,7 @@ export function calculateMetrics(
     automated: counts.automated,
     unknown: counts.unknown,
     coverage: round(coverage, 4),
-    defaultAttribution,
+    defaultMode: defaultMode ?? null,
     coverageThreshold,
     belowThreshold: coverage < coverageThreshold,
     recent:
@@ -111,18 +122,30 @@ export function calculateMetrics(
           }
         : null,
     modes,
-    modeEvidence,
+    evidence,
   };
 
-  // Cohort membership: unknown commits join a cohort only via the prior.
-  // 'automated' is its own state (#39): it joins no cohort and priors never
-  // touch it — automation is not authored code.
-  const isAI = (commit: Commit) =>
-    commit.tags.attribution === 'ai' ||
-    (defaultAttribution === 'ai' && commit.tags.attribution === 'unknown');
-  const isBaseline = (commit: Commit) =>
-    commit.tags.attribution === 'human' ||
-    (defaultAttribution === 'human' && commit.tags.attribution === 'unknown');
+  // Cohort membership is decided on the mode axis (#25), with the prior
+  // filling in only where there is no evidence at all. Automation joins
+  // nothing and priors never touch it: it is not authored code.
+  //
+  // `effectiveMode` is the one place the prior is applied. It deliberately
+  // does not write back into the tags — a prior is an assumption, and the
+  // moment it looked like evidence, coverage would start flattering itself.
+  const effectiveMode = (commit: Commit): AIMode => {
+    if (commit.tags.automated) return 'unknown';
+    if (commit.tags.evidence === 'none' && defaultMode) return defaultMode;
+    return commit.tags.mode;
+  };
+
+  // The AI cohort is every autonomy level above 'none'; the baseline is the
+  // 'none' cohort. In an AI-first world this is the projection, not the
+  // question — the question is the per-level breakdown below.
+  const isAI = (commit: Commit) => {
+    const mode = effectiveMode(commit);
+    return mode === 'autocomplete' || mode === 'assisted' || mode === 'agent';
+  };
+  const isBaseline = (commit: Commit) => effectiveMode(commit) === 'none';
 
   const persistence = calculatePersistence(commitStream, isAI);
 
@@ -146,8 +169,7 @@ export function calculateMetrics(
   const MODES = ['agent', 'assisted', 'autocomplete', 'none', 'unknown'] as const;
   const byMode = Object.fromEntries(
     MODES.map((mode) => {
-      const isMode = (commit: Commit) =>
-        commit.tags.mode === mode && commit.tags.attribution !== 'automated';
+      const isMode = (commit: Commit) => !commit.tags.automated && effectiveMode(commit) === mode;
       const modeCommits = commitStream.commits.filter(isMode);
       if (modeCommits.length === 0) {
         return [mode, null];
@@ -163,7 +185,7 @@ export function calculateMetrics(
   // No baseline cohort → no baseline, no delta. AIDA does not invent a
   // comparison out of unattributed commits.
   const baselineSize = baselineCommits.length;
-  const baselineAssumed = defaultAttribution === 'human' && counts.unknown > 0;
+  const baselineAssumed = defaultMode === 'none' && evidence.none > 0;
 
   const baseline =
     baselineSize > 0
@@ -256,7 +278,7 @@ export function calculateMetrics(
   );
 
   const caveats = [
-    `Attribution coverage is ${(coverage * 100).toFixed(1)}%: metrics only describe commits whose provenance is known.`,
+    `Evidence coverage is ${(coverage * 100).toFixed(1)}%: metrics only describe commits whose provenance is known, declared or inferred.`,
     'Rework rate is file-level: consecutive commits from one working session touching the same file count as rework, which inflates it for iterative workflows. Files too recent to judge are excluded from both sides. Line-level tracking will refine this.',
     'Persistence is file-level, not line-level.',
     'Persistence is survival: days until the first subsequent modification. Files never modified again are censored at collection time. Migrations and generated files (convention-driven lifecycles) are excluded.',
@@ -292,12 +314,12 @@ export function calculateMetrics(
   }
   if (baseline?.assumed) {
     caveats.push(
-      `Baseline includes ${counts.unknown} unattributed commit(s) assumed human via defaultAttribution — undetected AI usage may leak into it.`
+      `Baseline includes ${evidence.none} commit(s) with no evidence, assumed autonomy level 'none' via defaultMode — undeclared AI usage may leak into it.`
     );
   }
   if (!baseline) {
     caveats.push(
-      'No baseline: no commits are attributed as human. Set defaultAttribution to "human" in .aida.json if unattributed commits in this repo are human-authored.'
+      'No baseline: no commits sit at autonomy level \'none\'. Set defaultMode to "none" in .aida.json if the commits with no evidence in this repo were hand-written.'
     );
   }
 

--- a/packages/metrics/src/line-survival.test.ts
+++ b/packages/metrics/src/line-survival.test.ts
@@ -16,10 +16,9 @@ function makeCommit(hash: string, tags: Partial<Commit['tags']>, additions = 0):
     inDefaultBranchAncestry: true,
     revertsCommit: null,
     tags: {
-      ai: false,
-      attribution: 'unknown',
+      attribution: 'unknown', automated: false,
       mode: 'unknown',
-      modeEvidence: 'none',
+      evidence: 'none',
       level: 'none',
       sources: [],
       ...tags,
@@ -70,9 +69,9 @@ describe('calculateLineSurvival', () => {
     const result = calculateLineSurvival(
       makeBlame({ a1: 300, h1: 100, b1: 50 }),
       makeStream([
-        makeCommit('a1', { ai: true, attribution: 'ai', mode: 'agent', modeEvidence: 'declared' }, 400),
-        makeCommit('h1', { attribution: 'human', mode: 'none', modeEvidence: 'declared' }),
-        makeCommit('b1', { attribution: 'automated', mode: 'none', modeEvidence: 'inferred' }),
+        makeCommit('a1', { attribution: 'ai', automated: false, mode: 'agent', evidence: 'declared' }, 400),
+        makeCommit('h1', { attribution: 'human', automated: false, mode: 'none', evidence: 'declared' }),
+        makeCommit('b1', { attribution: 'automated', automated: true, mode: 'none', evidence: 'inferred' }),
       ])
     );
 
@@ -85,7 +84,7 @@ describe('calculateLineSurvival', () => {
   it('reports lines from commits outside the collected window separately', () => {
     const result = calculateLineSurvival(
       makeBlame({ a1: 100, ancient: 900 }),
-      makeStream([makeCommit('a1', { ai: true, attribution: 'ai', mode: 'agent' }, 100)])
+      makeStream([makeCommit('a1', { attribution: 'ai', automated: false, mode: 'agent' }, 100)])
     );
 
     expect(result.linesOutsideWindow).toBe(900);
@@ -96,7 +95,7 @@ describe('calculateLineSurvival', () => {
   it('derives an approximate survival rate against AI additions', () => {
     const result = calculateLineSurvival(
       makeBlame({ a1: 60 }),
-      makeStream([makeCommit('a1', { ai: true, attribution: 'ai', mode: 'agent' }, 200)])
+      makeStream([makeCommit('a1', { attribution: 'ai', automated: false, mode: 'agent' }, 200)])
     );
     expect(result.introducedByAI).toBe(200);
     expect(result.approxSurvivalRate).toBe(0.3);
@@ -108,7 +107,7 @@ describe('calculateLineSurvival', () => {
     // above 1, so it is capped rather than reported as 400%.
     const result = calculateLineSurvival(
       makeBlame({ a1: 40 }),
-      makeStream([makeCommit('a1', { ai: true, attribution: 'ai', mode: 'agent' }, 10)])
+      makeStream([makeCommit('a1', { attribution: 'ai', automated: false, mode: 'agent' }, 10)])
     );
     expect(result.approxSurvivalRate).toBe(1);
   });
@@ -117,7 +116,7 @@ describe('calculateLineSurvival', () => {
   // reported "1.7% of AI lines survive" by dividing survivors found in 453
   // files by additions counted across the entire history.
   it('counts only additions to files blame actually visited', () => {
-    const commit = makeCommit('a1', { ai: true, attribution: 'ai', mode: 'agent' }, 100);
+    const commit = makeCommit('a1', { attribution: 'ai', automated: false, mode: 'agent' }, 100);
     commit.stats.files = [
       { path: 'src/app.ts', status: 'modified', additions: 40, deletions: 0 },
       // Never blamed: excluded as generated, or beyond --max-files
@@ -136,7 +135,7 @@ describe('calculateLineSurvival', () => {
   });
 
   it('does not report a survival rate inflated by unblamed files', () => {
-    const commit = makeCommit('a1', { ai: true, attribution: 'ai', mode: 'agent' }, 1000);
+    const commit = makeCommit('a1', { attribution: 'ai', automated: false, mode: 'agent' }, 1000);
     commit.stats.files = [
       { path: 'src/app.ts', status: 'modified', additions: 10, deletions: 0 },
       { path: 'other/huge.ts', status: 'modified', additions: 990, deletions: 0 },
@@ -162,7 +161,7 @@ describe('calculateLineSurvival', () => {
   it('carries the truncation flag and file counters through', () => {
     const result = calculateLineSurvival(
       makeBlame({ a1: 10 }, { truncated: true, filesSkipped: 2, filesExcluded: 5 }),
-      makeStream([makeCommit('a1', { ai: true, attribution: 'ai', mode: 'agent' }, 10)])
+      makeStream([makeCommit('a1', { attribution: 'ai', automated: false, mode: 'agent' }, 10)])
     );
     expect(result.truncated).toBe(true);
     expect(result.filesSkipped).toBe(2);

--- a/packages/metrics/src/outcome-correlation.test.ts
+++ b/packages/metrics/src/outcome-correlation.test.ts
@@ -14,7 +14,7 @@ function makeCommit(overrides: Partial<Commit> & { hash: string }): Commit {
     parents: [],
     inDefaultBranchAncestry: true,
     revertsCommit: null,
-    tags: { ai: false, attribution: 'unknown', mode: 'unknown', modeEvidence: 'none', level: 'none', sources: [] },
+    tags: { attribution: 'unknown', automated: false, mode: 'unknown', evidence: 'none', level: 'none', sources: [] },
     stats: { totalAdditions: 1, totalDeletions: 0, files: [] },
     ...overrides,
   };
@@ -31,8 +31,8 @@ function makeStream(commits: Commit[]): CommitStream {
   };
 }
 
-const aiTags: Commit['tags'] = { ai: true, attribution: 'ai', mode: 'agent', modeEvidence: 'inferred', level: 'explicit', sources: [] };
-const humanTags: Commit['tags'] = { ai: false, attribution: 'human', mode: 'none', modeEvidence: 'declared', level: 'none', sources: [] };
+const aiTags: Commit['tags'] = { attribution: 'ai', automated: false, mode: 'agent', evidence: 'inferred', level: 'explicit', sources: [] };
+const humanTags: Commit['tags'] = { attribution: 'human', automated: false, mode: 'none', evidence: 'declared', level: 'none', sources: [] };
 
 describe('reverts', () => {
   it('attributes a resolved revert to the reverted commit, not the revert itself', () => {
@@ -253,10 +253,9 @@ describe('outcome rates against the base rate', () => {
 
   it('excludes automated commits from the base rate — they are not authored work', () => {
     const automatedTags: Commit['tags'] = {
-      ai: false,
-      attribution: 'automated',
+      attribution: 'automated', automated: true,
       mode: 'none',
-      modeEvidence: 'inferred',
+      evidence: 'inferred',
       level: 'none',
       sources: ['automated:bot'],
     };

--- a/packages/metrics/src/persistence.test.ts
+++ b/packages/metrics/src/persistence.test.ts
@@ -15,7 +15,7 @@ function makeCommit(overrides: Partial<CommitStream['commits'][0]>): CommitStrea
     parents: [],
     inDefaultBranchAncestry: true,
     revertsCommit: null,
-    tags: { ai: false, attribution: 'unknown' as const, mode: 'unknown' as const, modeEvidence: 'none' as const, level: 'none', sources: [] },
+    tags: { attribution: 'unknown' as const, automated: false, mode: 'unknown' as const, evidence: 'none' as const, level: 'none', sources: [] },
     stats: { totalAdditions: 10, totalDeletions: 0, files: [] },
     ...overrides,
   };
@@ -45,12 +45,12 @@ describe('calculatePersistence', () => {
     const stream = makeStream([
       makeCommit({
         hash: 'a1',
-        tags: { ai: true, attribution: 'ai' as const, mode: 'agent' as const, modeEvidence: 'inferred' as const, level: 'explicit', sources: ['tag:[ai]'] },
+        tags: { attribution: 'ai' as const, automated: false, mode: 'agent' as const, evidence: 'inferred' as const, level: 'explicit', sources: ['tag:[ai]'] },
         stats: { totalAdditions: 5, totalDeletions: 0, files: [{ path: 'foo.ts', additions: 5, deletions: 0 }] },
       }),
       makeCommit({
         hash: 'a2',
-        tags: { ai: false, attribution: 'unknown' as const, mode: 'unknown' as const, modeEvidence: 'none' as const, level: 'none', sources: [] },
+        tags: { attribution: 'unknown' as const, automated: false, mode: 'unknown' as const, evidence: 'none' as const, level: 'none', sources: [] },
       }),
     ]);
     const result = calculatePersistence(stream);
@@ -62,7 +62,7 @@ describe('calculatePersistence', () => {
       makeCommit({
         hash: 'a1',
         authorDate: '2024-01-01T00:00:00.000Z',
-        tags: { ai: true, attribution: 'ai' as const, mode: 'agent' as const, modeEvidence: 'inferred' as const, level: 'explicit', sources: ['tag:[ai]'] },
+        tags: { attribution: 'ai' as const, automated: false, mode: 'agent' as const, evidence: 'inferred' as const, level: 'explicit', sources: ['tag:[ai]'] },
         stats: {
           totalAdditions: 5,
           totalDeletions: 0,
@@ -72,7 +72,7 @@ describe('calculatePersistence', () => {
       makeCommit({
         hash: 'a2',
         authorDate: '2024-01-11T00:00:00.000Z',
-        tags: { ai: false, attribution: 'unknown' as const, mode: 'unknown' as const, modeEvidence: 'none' as const, level: 'none', sources: [] },
+        tags: { attribution: 'unknown' as const, automated: false, mode: 'unknown' as const, evidence: 'none' as const, level: 'none', sources: [] },
         stats: {
           totalAdditions: 2,
           totalDeletions: 1,
@@ -92,7 +92,7 @@ describe('calculatePersistence', () => {
       makeCommit({
         hash: 'a1',
         authorDate: '2024-01-01T00:00:00.000Z',
-        tags: { ai: true, attribution: 'ai' as const, mode: 'agent' as const, modeEvidence: 'inferred' as const, level: 'explicit', sources: ['tag:[ai]'] },
+        tags: { attribution: 'ai' as const, automated: false, mode: 'agent' as const, evidence: 'inferred' as const, level: 'explicit', sources: ['tag:[ai]'] },
         stats: {
           totalAdditions: 5,
           totalDeletions: 0,
@@ -103,7 +103,7 @@ describe('calculatePersistence', () => {
       makeCommit({
         hash: 'a2',
         authorDate: '2024-01-01T00:00:00.000Z',
-        tags: { ai: true, attribution: 'ai' as const, mode: 'agent' as const, modeEvidence: 'inferred' as const, level: 'explicit', sources: ['tag:[ai]'] },
+        tags: { attribution: 'ai' as const, automated: false, mode: 'agent' as const, evidence: 'inferred' as const, level: 'explicit', sources: ['tag:[ai]'] },
         stats: {
           totalAdditions: 5,
           totalDeletions: 0,
@@ -114,7 +114,7 @@ describe('calculatePersistence', () => {
       makeCommit({
         hash: 'a3',
         authorDate: '2024-01-06T00:00:00.000Z',
-        tags: { ai: false, attribution: 'unknown' as const, mode: 'unknown' as const, modeEvidence: 'none' as const, level: 'none', sources: [] },
+        tags: { attribution: 'unknown' as const, automated: false, mode: 'unknown' as const, evidence: 'none' as const, level: 'none', sources: [] },
         stats: {
           totalAdditions: 2,
           totalDeletions: 0,
@@ -136,7 +136,7 @@ describe('calculatePersistence', () => {
       makeCommit({
         hash: 'a1',
         authorDate: '2024-01-01T00:00:00.000Z',
-        tags: { ai: true, attribution: 'ai' as const, mode: 'agent' as const, modeEvidence: 'inferred' as const, level: 'explicit', sources: ['tag:[ai]'] },
+        tags: { attribution: 'ai' as const, automated: false, mode: 'agent' as const, evidence: 'inferred' as const, level: 'explicit', sources: ['tag:[ai]'] },
         stats: {
           totalAdditions: 5,
           totalDeletions: 0,
@@ -151,7 +151,7 @@ describe('calculatePersistence', () => {
   });
 
   it('ends the survival clock at the first subsequent touch, same cohort included', () => {
-    const aiTags: CommitStream['commits'][0]['tags'] = { ai: true, attribution: 'ai', mode: 'agent', modeEvidence: 'inferred', level: 'explicit', sources: ['tag:[ai]'] };
+    const aiTags: CommitStream['commits'][0]['tags'] = { attribution: 'ai', automated: false, mode: 'agent', evidence: 'inferred', level: 'explicit', sources: ['tag:[ai]'] };
     const stream = makeStream([
       makeCommit({
         hash: 'a1',
@@ -182,7 +182,7 @@ describe('calculatePersistence', () => {
       makeCommit({
         hash: 'a1',
         authorDate: '2024-01-01T00:00:00.000Z',
-        tags: { ai: true, attribution: 'ai' as const, mode: 'agent' as const, modeEvidence: 'inferred' as const, level: 'explicit', sources: ['tag:[ai]'] },
+        tags: { attribution: 'ai' as const, automated: false, mode: 'agent' as const, evidence: 'inferred' as const, level: 'explicit', sources: ['tag:[ai]'] },
         stats: {
           totalAdditions: 3,
           totalDeletions: 0,
@@ -204,7 +204,7 @@ describe('calculatePersistence', () => {
       makeCommit({
         hash: 'a1',
         authorDate: '2024-01-01T00:00:00.000Z',
-        tags: { ai: true, attribution: 'ai' as const, mode: 'agent' as const, modeEvidence: 'inferred' as const, level: 'explicit', sources: ['tag:[ai]'] },
+        tags: { attribution: 'ai' as const, automated: false, mode: 'agent' as const, evidence: 'inferred' as const, level: 'explicit', sources: ['tag:[ai]'] },
         stats: {
           totalAdditions: 5,
           totalDeletions: 0,
@@ -214,7 +214,7 @@ describe('calculatePersistence', () => {
       makeCommit({
         hash: 'a2',
         authorDate: '2024-01-20T00:00:00.000Z',
-        tags: { ai: false, attribution: 'unknown' as const, mode: 'unknown' as const, modeEvidence: 'none' as const, level: 'none', sources: [] },
+        tags: { attribution: 'unknown' as const, automated: false, mode: 'unknown' as const, evidence: 'none' as const, level: 'none', sources: [] },
         stats: {
           totalAdditions: 0,
           totalDeletions: 5,
@@ -230,7 +230,7 @@ describe('calculatePersistence', () => {
 });
 
 describe('rework rate (#22)', () => {
-  const aiTags: CommitStream['commits'][0]['tags'] = { ai: true, attribution: 'ai', mode: 'agent', modeEvidence: 'inferred', level: 'explicit', sources: [] };
+  const aiTags: CommitStream['commits'][0]['tags'] = { attribution: 'ai', automated: false, mode: 'agent', evidence: 'inferred', level: 'explicit', sources: [] };
 
   it('counts a file reworked inside the window', () => {
     const stream = makeStream([
@@ -320,13 +320,13 @@ describe('calculateBaselinePersistence', () => {
       makeCommit({
         hash: 'h1',
         authorDate: '2024-01-01T00:00:00.000Z',
-        tags: { ai: false, attribution: 'human' as const, mode: 'none' as const, modeEvidence: 'declared' as const, level: 'none', sources: [] },
+        tags: { attribution: 'human' as const, automated: false, mode: 'none' as const, evidence: 'declared' as const, level: 'none', sources: [] },
         stats: { totalAdditions: 5, totalDeletions: 0, files: [{ path: 'foo.ts', additions: 5, deletions: 0 }] },
       }),
       makeCommit({
         hash: 'ai1',
         authorDate: '2024-01-06T00:00:00.000Z',
-        tags: { ai: true, attribution: 'ai' as const, mode: 'agent' as const, modeEvidence: 'inferred' as const, level: 'explicit', sources: ['tag:[ai]'] },
+        tags: { attribution: 'ai' as const, automated: false, mode: 'agent' as const, evidence: 'inferred' as const, level: 'explicit', sources: ['tag:[ai]'] },
         stats: { totalAdditions: 2, totalDeletions: 0, files: [{ path: 'foo.ts', additions: 2, deletions: 0, status: 'modified' }] },
       }),
     ]);
@@ -340,7 +340,7 @@ describe('calculateBaselinePersistence', () => {
     const stream = makeStream([
       makeCommit({
         hash: 'ai1',
-        tags: { ai: true, attribution: 'ai' as const, mode: 'agent' as const, modeEvidence: 'inferred' as const, level: 'explicit', sources: ['tag:[ai]'] },
+        tags: { attribution: 'ai' as const, automated: false, mode: 'agent' as const, evidence: 'inferred' as const, level: 'explicit', sources: ['tag:[ai]'] },
         stats: { totalAdditions: 1, totalDeletions: 0, files: [{ path: 'x.ts', additions: 1, deletions: 0 }] },
       }),
     ]);
@@ -351,7 +351,7 @@ describe('calculateBaselinePersistence', () => {
 });
 
 describe('maxObservationDays (#29 age-normalization)', () => {
-  const aiTags = { ai: true, attribution: 'ai' as const, mode: 'agent' as const, modeEvidence: 'inferred' as const, level: 'explicit' as const, sources: [] };
+  const aiTags = { attribution: 'ai' as const, automated: false, mode: 'agent' as const, evidence: 'inferred' as const, level: 'explicit' as const, sources: [] };
 
   it('caps survival for a file reworked after the cap, treating it as censored at the cap', () => {
     const stream = makeStream([
@@ -425,7 +425,7 @@ describe('maxObservationDays (#29 age-normalization)', () => {
 });
 
 describe('onlyCategory (#36 within-category comparison)', () => {
-  const aiTags = { ai: true, attribution: 'ai' as const, mode: 'agent' as const, modeEvidence: 'inferred' as const, level: 'explicit' as const, sources: [] };
+  const aiTags = { attribution: 'ai' as const, automated: false, mode: 'agent' as const, evidence: 'inferred' as const, level: 'explicit' as const, sources: [] };
 
   it('restricts consideration to a single category, bypassing the default exclusions', () => {
     const stream = makeStream([

--- a/packages/metrics/src/pr-acceptance.test.ts
+++ b/packages/metrics/src/pr-acceptance.test.ts
@@ -9,10 +9,10 @@ function commit(
   return {
     sha: 'a'.repeat(40),
     tags: {
-      ai: attribution === 'ai',
       attribution,
+      automated: attribution === 'automated',
       mode,
-      modeEvidence: mode === 'unknown' ? 'none' : 'inferred',
+      evidence: mode === 'unknown' ? 'none' : 'inferred',
       level: attribution === 'ai' ? 'explicit' : 'none',
       sources: [],
     },

--- a/packages/metrics/src/schema/metrics.ts
+++ b/packages/metrics/src/schema/metrics.ts
@@ -24,8 +24,15 @@ export const Attribution = z.object({
   // Counts toward coverage, joins no cohort, untouched by priors.
   automated: z.number().int().nonnegative(),
   unknown: z.number().int().nonnegative(),
-  coverage: z.number().min(0).max(1), // (ai + human + automated) / total
-  defaultAttribution: z.enum(['ai', 'human', 'unknown']), // prior applied to unknown commits
+  // Coverage is the EVIDENCE axis (#25): the share of commits whose
+  // provenance is known at all, declared or inferred. Identical in spirit to
+  // the old (ai + human + automated) / total, but stated on the axis that
+  // actually carries the meaning — `unknown` is no longer a fourth kind of
+  // attribution, it is the absence of evidence.
+  coverage: z.number().min(0).max(1), // (declared + inferred) / total
+  // Prior applied to commits with no evidence; null when none is configured.
+  // A prior joins a cohort but never raises coverage (#25).
+  defaultMode: z.enum(['none', 'autocomplete', 'assisted', 'agent']).nullable(),
   coverageThreshold: z.number().min(0).max(1),
   belowThreshold: z.boolean(), // all-time; see `recent` for the actionable one
   // Null when the window contains no commits (#52)
@@ -38,7 +45,7 @@ export const Attribution = z.object({
     agent: z.number().int().nonnegative(),
     unknown: z.number().int().nonnegative(),
   }),
-  modeEvidence: z.object({
+  evidence: z.object({
     declared: z.number().int().nonnegative(),
     inferred: z.number().int().nonnegative(),
     none: z.number().int().nonnegative(),
@@ -114,7 +121,7 @@ export const CohortContext = z.object({
 });
 
 export const Baseline = z.object({
-  // True when the cohort includes 'unknown' commits via defaultAttribution:
+  // True when the cohort includes no-evidence commits via defaultMode:
   // the baseline is an assumption, not observed attribution.
   assumed: z.boolean(),
   persistence: Persistence,
@@ -339,7 +346,7 @@ export const Metrics = z.object({
   prAcceptance: PRAcceptance.nullable(),
   // Null unless `aida blame` produced a blame-stream.json (#23)
   lineSurvival: LineSurvival.nullable(),
-  // Null when no commit is attributed 'human' and no defaultAttribution prior
+  // Null when no commit sits at autonomy level 'none' and no defaultMode prior
   // assigns the unknowns: AIDA does not invent a comparison cohort.
   baseline: Baseline.nullable(),
   delta: Delta.nullable(),


### PR DESCRIPTION
Closes #25.

For most teams AI now participates in nearly every commit, so *"was AI involved?"* trends to **yes** and stops discriminating anything. What still separates risk, cost and quality is **at what autonomy level**. This promotes that from a field alongside the old model to the model itself.

Most of #25's migration path was already shipped — manifest `mode`, the tool→mode table, the commit hook, per-mode persistence. What was missing is the part that makes mode *primary*: the tagger still ran `level → ai → attribution` and inferred mode only afterwards, as an accessory of the attribution it had already decided.

## The two axes

| Axis | Values | Question |
|---|---|---|
| **Involvement** (`mode`) | `none` · `autocomplete` · `assisted` · `agent` · `unknown` | What level of AI participated? |
| **Evidence** | `declared` · `inferred` · `none` | How do we know? |

They are separate because they fail separately. `mode: unknown, evidence: inferred` is a real state — we know AI participated, we cannot name the level. The single-axis model had to call it `evidence: 'none'`, contradicting the `ai` it had just asserted and making coverage disagree with attribution.

## `attribution` is now a projection

`projectAttribution` is the only place the three states are decided, and `tagFromAxes` the only way to build a tag — so the projection cannot drift from the axes it projects. A test asserts the agreement across every detection path.

`unknown` stops being a fourth kind of attribution and becomes exactly `evidence: none`, tested in both directions. `automated` becomes its own orthogonal flag: known provenance, no author, no cohort. The redundant `ai` boolean is gone.

The headline still reads `ai`/`human`/`automated`/`unknown` — labelled in the report as the projection it is.

## Coverage moved to the evidence axis

Share of commits with any known provenance, declared or inferred. Numerically near-identical to the old `(ai + human + automated) / total` — **8.7% either way on babel** — because automation already carried inferred evidence. The reframe is honest, not a redefinition that flatters the number.

## Breaking: `defaultAttribution` → `defaultMode`

The prior now names an autonomy level. One key covers both moments: the hook stamps it at commit time (new commits become `declared`), `aida analyze` applies it as a prior to history with no evidence.

**A prior is never evidence.** It does not touch the tags and does not raise coverage, so a repo leaning on it still reports how little it actually knows.

zod strips unknown keys, so a config still carrying `defaultAttribution` would silently stop applying and change cohorts on upgrade — the exact failure mode this project keeps finding. `.aida.json` is now **rejected** with the translation in the message:

```
.aida.json uses "defaultAttribution", which was replaced by "defaultMode" in schema v2 (#25):
the prior now names an autonomy level, not an AI/human label. Replace "defaultAttribution": "ai"
with "defaultMode": "assisted". Leaving it would silently change which commits join which cohort.
```

That guard caught this repo's own config on the first run. `--default-attribution` becomes `--default-mode`. Schema v2 for both `commit-stream.json` and `metrics.json` — rerun `aida collect`.

## Dogfood (before → after, this repo)

| | before | after |
|---|---|---|
| Coverage | 100% | 100% — **declared 72 · inferred 65** |
| Headline | ai 100 · human 0 · automated 37 · unknown 0 | unchanged, now labelled a projection |
| Autonomy table | — | agent 100 · automated 37 (own row) |

Coverage is unchanged here because this repo has full manifest + hook coverage; the new view is what it adds — 72 commits *declared* vs 65 *inferred* was not previously visible.

**The dogfood run caught a bug this PR introduced.** The headline table counted automation's `mode: 'none'` under "none (hand-written)" — 37 commits — while `By Autonomy Level` excludes automation and showed none: two tables in one report disagreeing about the same commits. Per-mode counts now exclude automated commits, which get their own row. Regression test added.

## Tests

229 → 230 passing (was 205 at the start of the external-repo work). New coverage:

- the projection agrees with its axes across every detection path
- `attribution: unknown` ⟺ `evidence: none`, both directions
- an anonymous AI signal is `inferred` evidence with `unknown` mode
- a prior joins a cohort but never raises coverage
- automated commits stay covered, stay out of every cohort, and out of the per-mode counts
- the retired config key is refused, with the right replacement value

🤖 Generated with [Claude Code](https://claude.com/claude-code)