### PR TITLE
feat: repo-level quality block — quality as a property of the repo (#77 step 1)

### DIFF
--- a/.changeset/repo-level-quality.md
+++ b/.changeset/repo-level-quality.md
@@ -1,0 +1,10 @@
+---
+'@aida-dev/metrics': minor
+'@aida-dev/cli': patch
+---
+
+Repo-level quality block in metrics.json — quality as a property of the repo, not of a cohort (#77, step 1)
+
+First step of the quality-first reframe: `metrics.json` gains a `repo` block with persistence and rework computed over **all authored commits** (everything except automation), cohort-free. It is fully populated at 0% evidence coverage — the normal case per #77's assumption — and is deliberately untouched by the `defaultMode` prior: the prior can move cohorts, but if it could move these numbers, "assume everything is AI" would quietly become "trust the assumption". A test asserts the block is identical with and without the prior.
+
+Additive schema change: new field, no version bump per the #53 contract. The report still renders the cohort views — the report reframe is step 2.

--- a/packages/metrics/src/index.test.ts
+++ b/packages/metrics/src/index.test.ts
@@ -282,8 +282,13 @@ describe('fairComparison (#29 age-normalization)', () => {
     // Baseline: old commit whose file was never touched again — accumulates
     // a lot of raw persistence purely from clock time.
     const oldDate = new Date(Date.now() - 200 * 24 * 60 * 60 * 1000).toISOString();
-    // AI: recent commit, also never touched again.
-    const recentDate = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
+    // AI: recent commit, also never touched again. 9.5 days, not 10:
+    // `daysBetween` ceils, and the age is measured against a `new Date()`
+    // taken inside calculateMetrics, milliseconds AFTER this line — an
+    // exact 10-day offset ceils to 10 or 11 depending on whether that
+    // millisecond has ticked, which made this test flaky under load.
+    // Anywhere strictly inside the (9, 10] interval ceils to 10 stably.
+    const recentDate = new Date(Date.now() - 9.5 * 24 * 60 * 60 * 1000).toISOString();
 
     const metrics = calculateMetrics({
       ...makeStream([
@@ -541,5 +546,68 @@ describe('per-mode cohorts separate observed from assumed (#25)', () => {
     expect(metrics.byMode.agent!.assumed).toBe(0);
     // With no prior the two tables agree exactly
     expect(metrics.byMode.agent!.commits).toBe(metrics.attribution.modes.agent);
+  });
+});
+
+describe('repo-level quality (#77 step 1)', () => {
+  // The quality-first premise: these numbers must mean something on a repo
+  // where nobody declares anything — the normal case, per #77's assumption.
+  it('is fully populated at 0% evidence coverage', () => {
+    const metrics = calculateMetrics(
+      makeStream([
+        makeCommit({ hash: 'u1', tags: unknownTags }),
+        makeCommit({ hash: 'u2', tags: unknownTags }),
+        makeCommit({ hash: 'u3', tags: unknownTags }),
+      ])
+    );
+
+    expect(metrics.attribution.coverage).toBe(0);
+    expect(metrics.repo.commitsAuthored).toBe(3);
+    expect(metrics.repo.persistence.commitsConsidered).toBe(3);
+    // ...while the cohort view is rightly empty: no evidence, no cohorts
+    expect(metrics.persistence.commitsConsidered).toBe(0);
+  });
+
+  // The honesty property: "assume everything is AI" must never become
+  // "trust the assumption". The prior moves cohorts; it must not be able to
+  // move the repo-level numbers by a single unit.
+  it('is byte-identical with and without a defaultMode prior', () => {
+    const commits = [
+      makeCommit({ hash: 'a1', tags: aiTags }),
+      makeCommit({ hash: 'u1', tags: unknownTags }),
+      makeCommit({ hash: 'u2', tags: unknownTags }),
+    ];
+
+    const withoutPrior = calculateMetrics(makeStream(commits));
+    const withPrior = calculateMetrics(makeStream(commits), { defaultMode: 'agent' });
+
+    expect(withPrior.repo).toEqual(withoutPrior.repo);
+    // Sanity: the prior did change the cohort view, so the comparison above
+    // is not vacuous
+    expect(withPrior.persistence.commitsConsidered).not.toBe(
+      withoutPrior.persistence.commitsConsidered
+    );
+  });
+
+  it('excludes automation from authored commits and from persistence', () => {
+    const automated: Commit['tags'] = {
+      attribution: 'automated',
+      automated: true,
+      mode: 'none',
+      evidence: 'inferred',
+      level: 'none',
+      sources: ['automated:merge-commit'],
+    };
+    const metrics = calculateMetrics(
+      makeStream([
+        makeCommit({ hash: 'a1', tags: aiTags }),
+        makeCommit({ hash: 'u1', tags: unknownTags }),
+        makeCommit({ hash: 'm1', tags: automated }),
+      ])
+    );
+
+    expect(metrics.repo.commitsAuthored).toBe(2);
+    expect(metrics.repo.commitsAutomated).toBe(1);
+    expect(metrics.repo.persistence.commitsConsidered).toBe(2);
   });
 });

--- a/packages/metrics/src/index.ts
+++ b/packages/metrics/src/index.ts
@@ -20,6 +20,7 @@ import {
   FileCategory,
   Metrics,
   ModeStats,
+  RepoQuality,
 } from './schema/metrics.js';
 
 export * from './schema/metrics.js';
@@ -146,6 +147,18 @@ export function calculateMetrics(
     return mode === 'autocomplete' || mode === 'assisted' || mode === 'agent';
   };
   const isBaseline = (commit: Commit) => effectiveMode(commit) === 'none';
+
+  // Repo-level quality (#77, step 1): the primary object. Computed over ALL
+  // authored commits — no cohort, no evidence requirement, and deliberately
+  // no `effectiveMode`: the prior must not be able to move these numbers,
+  // or "assume everything is AI" would quietly become "trust the assumption".
+  const isAuthored = (commit: Commit) => !commit.tags.automated;
+  const authoredCount = commitStream.commits.filter(isAuthored).length;
+  const repo: RepoQuality = {
+    commitsAuthored: authoredCount,
+    commitsAutomated: total - authoredCount,
+    persistence: calculatePersistence(commitStream, isAuthored),
+  };
 
   const persistence = calculatePersistence(commitStream, isAI);
 
@@ -336,6 +349,7 @@ export function calculateMetrics(
     repoPath: commitStream.repoPath,
     defaultBranch: commitStream.defaultBranch,
     attribution,
+    repo,
     persistence,
     cohorts,
     byMode,

--- a/packages/metrics/src/schema/metrics.ts
+++ b/packages/metrics/src/schema/metrics.ts
@@ -320,6 +320,20 @@ export const LineSurvival = z.object({
   approxSurvivalRate: z.number().min(0).max(1),
 });
 
+// Repo-level quality (#77, step 1): the quality of the codebase as a
+// property of the REPO, not of a cohort. Everything here is computable at
+// 0% evidence coverage and is untouched by the `defaultMode` prior — the
+// primary object in a world where cohorts are empty by default, with the
+// cohort views below as optional overlays.
+export const RepoQuality = z.object({
+  // Authored commits: everything except automation (merge commits, release
+  // bots). Automation is not authored code, whoever ran it.
+  commitsAuthored: z.number().int().nonnegative(),
+  commitsAutomated: z.number().int().nonnegative(),
+  // Persistence and rework over ALL authored commits, cohort-free
+  persistence: Persistence,
+});
+
 export const Metrics = z.object({
   // Bumped when a field is removed or changes meaning (#53)
   schemaVersion: z.number().int().positive(),
@@ -331,6 +345,8 @@ export const Metrics = z.object({
   repoPath: z.string(),
   defaultBranch: z.string(),
   attribution: Attribution,
+  // Repo-level quality (#77): cohort-free, prior-free, the primary object
+  repo: RepoQuality,
   persistence: Persistence,
   // Fairness context (#29, #36): age and task mix per cohort, so consumers
   // can judge whether the AI-vs-baseline comparison is apples-to-apples.
@@ -380,6 +396,7 @@ export type HotfixStats = z.infer<typeof HotfixStats>;
 export type OutcomeCorrelation = z.infer<typeof OutcomeCorrelation>;
 export type LineSurvival = z.infer<typeof LineSurvival>;
 export type Persistence = z.infer<typeof Persistence>;
+export type RepoQuality = z.infer<typeof RepoQuality>;
 export type Baseline = z.infer<typeof Baseline>;
 export type Delta = z.infer<typeof Delta>;
 export type Metrics = z.infer<typeof Metrics>;


### PR DESCRIPTION
First step of #77's migration path: `metrics.json` gains a `repo` block — persistence and rework computed over **all authored commits** (everything except automation), cohort-free.

## Why this block exists

The quality-first premise: quality numbers must mean something on a repo where nobody declares anything, because that is the normal case. Today every quality metric hangs off a cohort, and cohorts are empty by default — `No baseline cohort` has fired on every repo we have ever pointed AIDA at.

Two properties, both enforced by tests:

- **Valid at 0% evidence coverage.** All-unknown history → `repo` fully populated, cohort views rightly empty.
- **Immune to the prior.** The `defaultMode` prior may move cohorts; it cannot move these numbers by a single unit (asserted byte-identical with and without). If it could, *"assume everything is AI"* would quietly become *"trust the assumption"*.

Automation stays out of both the commit count and the persistence — automation is not authored code, whoever ran it.

## Dogfood

**varano-239** (42.1% coverage — up from 35.3% two days ago, the hook is accumulating):

| | with `defaultMode: agent` | without prior |
|---|---|---|
| cohort persistence | 18 commits, 2.76 avg days | **7 commits, 0.12 avg days** |
| `repo` block | 18 commits, 2.76 avg days, rework 0.84 | **identical** |

The cohort view swings wildly with a one-line config change; the repo block does not move. That instability is exactly what this block is immune to.

**aida-metrics** (100% coverage): `repo` = 104 authored / 40 automated, avg 48.11 days, rework 0.63 — coincides with the AI cohort as it must on a repo where everything is AI.

## Scope

- Additive schema change: new field, **no version bump** per the #53 contract.
- Report untouched — the reframe is step 2 of #77.
- Includes one unrelated test fix, in its own commit: the fair-comparison fixture sat exactly on `daysBetween`'s ceil boundary (a commit aged *exactly* 10 days, measured milliseconds later), so it passed on a warm process and failed under load. Pre-existing on main, surfaced while verifying this PR on a machine at load average 130.

## Tests

248 → 251. Full suite verified green twice on the exact final tree; later runs on the same tree hit environmental timeouts only (git-spawning tests at 5s timeout on a saturated machine, all packages I did not touch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)