### PR TITLE
feat: report reframe — Code Quality opens, coverage becomes a footnote (#77 step 2)

### DIFF
--- a/.changeset/report-quality-first.md
+++ b/.changeset/report-quality-first.md
@@ -1,0 +1,15 @@
+---
+'@aida-dev/metrics': patch
+'@aida-dev/cli': minor
+---
+
+Report reframe: Code Quality opens, autonomy is the lens, coverage becomes a Data Quality footnote (#77 step 2)
+
+The report now leads with what needs no attribution evidence and demotes what does:
+
+- **`## Code Quality` opens the report** — the repo-level block from step 1: persistence, rework and survival buckets over all authored commits. One framing line states the property that makes it first: these numbers do not move with coverage or with the `defaultMode` prior.
+- **`## Autonomy` becomes the lens**, explicitly labelled as depending on attribution evidence. The low-coverage warning is scoped honestly: it used to say *"every metric below is low-confidence"*, which stopped being true the moment repo-level quality existed — it now says the attribution-dependent sections are low-confidence and Code Quality is unaffected. Same scoping applied to the `aida analyze` warning and the metrics caveat.
+- **Coverage moves to `## Data Quality` at the end** — evidence counts and the 90-day window, framed as what gates the autonomy sections, never the report.
+- **The old `## Persistence (file-level survival)` section is gone** — it rendered the *AI cohort's* numbers under a generic-looking heading, the same defect class found on babel and varano (cohort data wearing a repo-level label). Repo-level detail lives in Code Quality; cohort persistence stays in By Autonomy Level and AI vs Baseline, which say what they are.
+
+Dogfooded on varano-239, the freshly adopted repo: the report now opens with persistence/rework figures that are valid at its 59.3% coverage, instead of opening with the coverage shortfall. Incidentally, that run showed the adoption loop working — coverage moved 35.3% → 59.3% since the last look, declared commits 5 → 15.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ AIDA provides **tangible, auditable metrics** to distinguish between **AI noise*
 
 - **4-Level AI Detection** — Classifies commits as explicit, implicit, mention, or none across Claude Code, Copilot, ChatGPT, Cursor, Windsurf/Devin, Gemini, Codeium
 - **Configurable Tools** — Add custom AI tools via `.aida.json` or CLI flags
-- **Autonomy** — Two orthogonal axes: *involvement* (`none`/`autocomplete`/`assisted`/`agent`) and *evidence* (`declared`/`inferred`/`none`), with evidence coverage as the headline metric
+- **Quality First** — Repo-level persistence and rework as the primary object ([#77](https://github.com/ceccode/AIDA-Metrics/issues/77)), valid at any coverage; autonomy as the lens over it
+- **Autonomy** — Two orthogonal axes: *involvement* (`none`/`autocomplete`/`assisted`/`agent`) and *evidence* (`declared`/`inferred`/`none`)
 - **Persistence** — Measure how long AI-generated code survives in your codebase
 - **Comparative Baseline** — AI vs non-AI side-by-side with delta, so metrics are interpretable
 - **Fast & Deterministic** — Versioned JSON output schemas, so consumers detect breaking changes instead of reading silent `undefined`s
@@ -64,8 +65,8 @@ pnpm build
 
 ## Core Metrics
 
-1. **Attribution Coverage**  
-   Share of commits with known provenance (`ai` / `human` / `automated`), reported first because every other number is only as trustworthy as this one.
+1. **Code Quality (repo-level)**  
+   How long code survives and how often it is reworked, as a property of the repo — no attribution evidence required, so it opens the report and means something on any repository.
 
 2. **Persistence**  
    How long AI-generated code survives in the codebase before being rewritten or removed (file-level survival with censoring).
@@ -430,7 +431,7 @@ They are separate because they fail separately. `mode: unknown, evidence: inferr
 
 `declared` means someone stated it: the `AI-Mode:` trailer written by the commit hook, or the attribution manifest. `inferred` means AIDA concluded it from tool identity or commit structure. Automation ([#39](https://github.com/ceccode/AIDA-Metrics/issues/39) — merge commits, known bots, manifest `excluded_commits`) is a third, orthogonal flag: its provenance is known, so it counts toward coverage, but it joins no autonomy cohort, because automation is not authored code.
 
-**Coverage** = share of commits with any evidence at all (`declared` + `inferred`). It is reported first in every output, because every other number is only as trustworthy as coverage says it is.
+**Coverage** = share of commits with any evidence at all (`declared` + `inferred`). Since the quality-first reframe ([#77](https://github.com/ceccode/AIDA-Metrics/issues/77)) it gates the *attribution-dependent* sections, not the report: repo-level Code Quality needs no evidence and opens the report, while coverage lives in a Data Quality section at the end.
 
 **The three-state view survives as a projection.** `ai` (mode above `none`), `human` (declared `none`), `automated`, `unknown` (no evidence) are derived from the axes above — never decided independently — and kept because a headline needs one word. The rich model underneath, the one-line summary on top.
 
@@ -680,6 +681,7 @@ Bitbucket is currently out of scope ([#17](https://github.com/ceccode/AIDA-Metri
 - **v0.22** ✅ Age-normalized fair comparison ([#29](https://github.com/ceccode/AIDA-Metrics/issues/29)), within-category comparison ([#36](https://github.com/ceccode/AIDA-Metrics/issues/36)), git-scoped outcome correlation — reverts and hotfixes ([#26](https://github.com/ceccode/AIDA-Metrics/issues/26)).  
 - **v0.23** ✅ Autonomy as the primary axis — involvement × evidence, with three-state attribution demoted to a derived projection; coverage measured on the evidence axis; `defaultAttribution` replaced by `defaultMode` ([#25](https://github.com/ceccode/AIDA-Metrics/issues/25)). Schema v2.
 - **v0.24** ✅ `--if-git` and a documented `prepare` recipe, so hook installation reaches every clone; the low-coverage warning names a missing hook in a configured repo ([#75](https://github.com/ceccode/AIDA-Metrics/issues/75)).
+- **v0.25** ✅ Quality-first, steps 1–2 ([#77](https://github.com/ceccode/AIDA-Metrics/issues/77)): repo-level `repo` block in `metrics.json` (cohort-free persistence and rework, prior-proof), and the report reframe — Code Quality opens, the autonomy lens follows, coverage demoted to a Data Quality footnote.
 - **Next** → Bitbucket PR comment provider ([#17](https://github.com/ceccode/AIDA-Metrics/issues/17)), cost metrics ([#27](https://github.com/ceccode/AIDA-Metrics/issues/27)).  
 - **v1.0** → Dashboard / GitHub Action for continuous tracking.  
 

--- a/packages/cli/src/commands/analyze.ts
+++ b/packages/cli/src/commands/analyze.ts
@@ -180,8 +180,8 @@ export function createAnalyzeCommand(): Command {
           const hooked = await isAidaHookInstalled(commitStream.repoPath);
           logger.warn(
             configured && !hooked
-              ? `Coverage is below ${threshold}%: metrics are low-confidence. This repo is set up for AIDA (.aida.json) but THIS CLONE has no ${HOOK_NAME} hook, so its commits declare nothing. Run 'aida install-hooks' — or add "prepare": "aida install-hooks --if-git" to package.json so every clone gets it.`
-              : `Coverage is below ${threshold}%: metrics are low-confidence. Install the commit hook (aida install-hooks), or set defaultMode in .aida.json.`
+              ? `Coverage is below ${threshold}%: attribution-dependent metrics are low-confidence (repo-level quality is unaffected). This repo is set up for AIDA (.aida.json) but THIS CLONE has no ${HOOK_NAME} hook, so its commits declare nothing. Run 'aida install-hooks' — or add "prepare": "aida install-hooks --if-git" to package.json so every clone gets it.`
+              : `Coverage is below ${threshold}%: attribution-dependent metrics are low-confidence (repo-level quality is unaffected). Install the commit hook (aida install-hooks), or set defaultMode in .aida.json.`
           );
         }
         logger.info(`Average persistence: ${metrics.persistence.avgDays} days`);

--- a/packages/cli/src/commands/e2e.test.ts
+++ b/packages/cli/src/commands/e2e.test.ts
@@ -94,14 +94,22 @@ describe('collect → analyze → report end to end', () => {
 
     const report = readFileSync(join(outDir, 'report.md'), 'utf-8');
     expect(report).toContain('# AIDA Report');
+    // Quality first (#77 step 2): the repo-level section opens the report,
+    // the autonomy lens follows, coverage sits at the bottom as Data Quality
+    expect(report).toContain('## Code Quality');
     expect(report).toContain('## Autonomy');
+    expect(report).toContain('## Data Quality');
+    expect(report.indexOf('## Code Quality')).toBeLessThan(report.indexOf('## Autonomy'));
+    expect(report.indexOf('## Data Quality')).toBeGreaterThan(report.indexOf('## By Autonomy Level'));
     // The autonomy breakdown is the primary table (#25), and the three-state
     // view is labelled as the projection it is
     expect(report).toContain('| Autonomy level | Commits |');
     expect(report).toContain('*Three-state view:*');
     expect(report).toContain('## By Autonomy Level');
     expect(report).toContain('## Cohort Fairness');
-    expect(report).toContain('## Persistence (file-level survival)');
+    // The old generic-looking persistence section rendered the AI cohort's
+    // numbers under a repo-level label; Code Quality replaced it (#77)
+    expect(report).not.toContain('## Persistence (file-level survival)');
     expect(report).toContain('### Caveats');
     // Removed metric must not resurface anywhere
     expect(report.toLowerCase()).not.toContain('merge ratio');

--- a/packages/cli/src/commands/report.ts
+++ b/packages/cli/src/commands/report.ts
@@ -29,7 +29,7 @@ function generateMarkdownReport(metrics: Metrics): string {
   const warnOnRecent = a.recent ? a.recent.belowThreshold : a.belowThreshold;
 
   const coverageWarning = warnOnRecent
-    ? `\n> ⚠️ **Coverage is below ${(a.coverageThreshold * 100).toFixed(0)}%${a.recent ? ` in the last ${a.recent.windowDays} days` : ''}.** Provenance is largely unknown, so every metric below is low-confidence. Install the commit hook (\`aida install-hooks\`) so new commits declare their autonomy mode, or set \`defaultMode\` in \`.aida.json\` for the history that predates it.\n`
+    ? `\n> ⚠️ **Coverage is below ${(a.coverageThreshold * 100).toFixed(0)}%${a.recent ? ` in the last ${a.recent.windowDays} days` : ''}.** The sections from here down depend on attribution evidence and are low-confidence — the Code Quality section above is unaffected, it needs no evidence. Install the commit hook (\`aida install-hooks\`) so new commits declare their autonomy mode, or set \`defaultMode\` in \`.aida.json\` for the history that predates it.\n`
     : '';
 
   const priorNote =
@@ -232,6 +232,33 @@ ${[
 `
     : '';
 
+  // Code Quality opens the report (#77 step 2): the repo-level block from
+  // step 1, rendered first because it is the only view that needs no
+  // attribution evidence — valid at 0% coverage, untouched by the prior.
+  // It also replaces the old "Persistence (file-level survival)" section,
+  // which rendered the AI cohort's numbers under a generic-looking heading —
+  // the same defect class as the assumed-cohort and automated-mode bugs:
+  // cohort data wearing a repo-level label.
+  const rq = metrics.repo;
+  const rqp = rq.persistence;
+  const codeQualitySection = `## Code Quality
+
+How the code holds up, as a property of the **repo** — measured over all ${rq.commitsAuthored} authored commits (${rq.commitsAutomated} automated excluded). No attribution evidence required: these numbers do not move with coverage or with the \`defaultMode\` prior.
+
+- Files measured: ${rqp.filesConsidered} (${rqp.censored} still surviving at collection time; ${rqp.filesExcluded} excluded: migrations/generated)
+- Average persistence: ${rqp.avgDays} days · median: ${rqp.medianDays}${
+    rqp.rework
+      ? `
+- **Rework rate (${rqp.rework.windowDays}d):** ${(rqp.rework.rate * 100).toFixed(1)}% — ${rqp.rework.reworked} of ${rqp.rework.determined} files with a determined outcome${rqp.rework.undetermined > 0 ? ` (${rqp.rework.undetermined} too recent to judge)` : ''}`
+      : ''
+  }
+
+| 0–1d | 2–7d | 8–30d | 31–90d | 90d+ |
+|---:|---:|---:|---:|---:|
+| ${rqp.buckets.d0_1} | ${rqp.buckets.d2_7} | ${rqp.buckets.d8_30} | ${rqp.buckets.d31_90} | ${rqp.buckets.d90_plus} |
+
+`;
+
   const baselineDetail = metrics.baseline
     ? `## ${baselineLabel}
 - Persistence — commits considered: ${metrics.baseline.persistence.commitsConsidered}, avg: ${metrics.baseline.persistence.avgDays}d, median: ${metrics.baseline.persistence.medianDays}d
@@ -246,10 +273,10 @@ ${[
 **Window:** ${metrics.window.since || 'beginning'} → ${metrics.window.until || 'now'}  
 **Generated:** ${metrics.generatedAt}
 
-## Autonomy
+${codeQualitySection}${lineSection}${outcomeSection}${prSection}## Autonomy
 
-**${coveragePct}% of commits have known provenance** — declared ${a.evidence.declared} · inferred ${a.evidence.inferred} · no evidence ${a.evidence.none} (${unknownPct}%)
-
+The lens over the quality above: **at what level of AI autonomy** the code was written. Everything from here down depends on attribution evidence — see Data Quality below for how much of it this repo has.
+${coverageWarning}
 | Autonomy level | Commits |
 |---|---:|
 | agent | ${a.modes.agent} |
@@ -259,27 +286,14 @@ ${[
 | unknown | ${a.modes.unknown} |
 | _automated (no cohort)_ | ${a.automated} |
 
-${recentLine}
-*Three-state view:* ai ${a.ai} · human ${a.human} · automated ${a.automated} · unknown ${a.unknown} — a projection of the table above, kept for a one-word headline. What AI participation *was* is the question that keeps discriminating once "was AI involved?" is answered yes everywhere.
-${coverageWarning}${priorNote}
+*Three-state view:* ai ${a.ai} · human ${a.human} · automated ${a.automated} · unknown ${a.unknown} — a projection of the table above, kept for a one-word headline.
+${priorNote}
 ${byModeSection}${comparisonSection}
-${lineSection}${outcomeSection}${prSection}${fairnessSection}
-## Persistence (file-level survival)
-- Commits considered: ${metrics.persistence.commitsConsidered}
-- Files measured: ${metrics.persistence.filesConsidered} (${metrics.persistence.censored} still surviving at collection time; ${metrics.persistence.filesExcluded} excluded: migrations/generated)
-- Average days: ${metrics.persistence.avgDays}
-- Median days: ${metrics.persistence.medianDays}${
-    metrics.persistence.rework
-      ? `
-- **Rework rate (${metrics.persistence.rework.windowDays}d):** ${(metrics.persistence.rework.rate * 100).toFixed(1)}% — ${metrics.persistence.rework.reworked} of ${metrics.persistence.rework.determined} files with a determined outcome${metrics.persistence.rework.undetermined > 0 ? ` (${metrics.persistence.rework.undetermined} too recent to judge)` : ''}`
-      : ''
-  }
+${fairnessSection}${baselineDetail}## Data Quality
 
-| 0–1d | 2–7d | 8–30d | 31–90d | 90d+ |
-|---:|---:|---:|---:|---:|
-| ${metrics.persistence.buckets.d0_1} | ${metrics.persistence.buckets.d2_7} | ${metrics.persistence.buckets.d8_30} | ${metrics.persistence.buckets.d31_90} | ${metrics.persistence.buckets.d90_plus} |
-
-${baselineDetail}### Caveats
+**${coveragePct}% of commits carry attribution evidence** — declared ${a.evidence.declared} · inferred ${a.evidence.inferred} · none ${a.evidence.none} (${unknownPct}%). Evidence gates the autonomy sections above, never Code Quality.
+${recentLine}
+### Caveats
 ${metrics.caveats.map((caveat) => `- ${caveat}`).join('\n')}
 `;
 }

--- a/packages/metrics/src/index.ts
+++ b/packages/metrics/src/index.ts
@@ -294,7 +294,7 @@ export function calculateMetrics(
   );
 
   const caveats = [
-    `Evidence coverage is ${(coverage * 100).toFixed(1)}%: metrics only describe commits whose provenance is known, declared or inferred.`,
+    `Evidence coverage is ${(coverage * 100).toFixed(1)}%: attribution-dependent metrics only describe commits whose provenance is known. Repo-level quality (the \`repo\` block) covers all authored commits regardless of evidence.`,
     'Rework rate is file-level: consecutive commits from one working session touching the same file count as rework, which inflates it for iterative workflows. Files too recent to judge are excluded from both sides. Line-level tracking will refine this.',
     'Persistence is file-level, not line-level.',
     'Persistence is survival: days until the first subsequent modification. Files never modified again are censored at collection time. Migrations and generated files (convention-driven lifecycles) are excluded.',


### PR DESCRIPTION
Step 2 of #77's migration path. Step 1 (PR #78) put repo-level quality in `metrics.json`; this makes it what the reader sees first.

## New report shape

| Before | After |
|---|---|
| `## Autonomy` (coverage headline) | **`## Code Quality`** — repo-level persistence, rework, buckets |
| `## By Autonomy Level` | `## Line Survival` / `## Outcome Correlation` / `## PR Acceptance` |
| `## AI vs Baseline` | `## Autonomy` — the lens, labelled evidence-dependent |
| quality sections | `## By Autonomy Level` / `## AI vs Baseline` / `## Cohort Fairness` |
| `## Persistence (file-level survival)` | **`## Data Quality`** — coverage, demoted to footnote |
| `### Caveats` | `### Caveats` |

Code Quality opens with the one property that justifies its position, stated in the section itself: *these numbers do not move with coverage or with the `defaultMode` prior.*

## Two honesty fixes that fell out of the reordering

**The low-coverage warning was lying by one clause.** It said *"every metric below is low-confidence"* — false since step 1, because repo-level quality needs no evidence. It now scopes itself to the attribution-dependent sections and says Code Quality is unaffected. Same scoping applied to the `aida analyze` log warning and the metrics caveat.

**The old `## Persistence (file-level survival)` section is removed, not moved.** It rendered `metrics.persistence` — the **AI cohort** — under a heading that read as repo-level, with nothing saying so. That is the recurring defect class of this project's external validation (babel's automated-mode miscount, varano's assumed-cohort counts): cohort data wearing a repo-level label. Repo-level detail now lives in Code Quality fed by `metrics.repo`; cohort persistence stays in By Autonomy Level and AI vs Baseline, which say what they are. The e2e suite asserts the old heading never comes back.

## Dogfood

**varano-239** (the freshly adopted repo, the case this reframe serves): the report used to open with a coverage shortfall; it now opens with

> Average persistence: 2.77 days · median: 1 — Rework rate (7d): 70.3%

valid at its 59.3% coverage, with the evidence discussion at the bottom where it belongs. Incidentally the run showed the adoption loop working: since the last look, coverage moved **35.3% → 59.3%**, declared commits **5 → 15** — the hook from #75 is doing its job, and the run-over-run comparison I just did by hand is exactly what step 3 (`aida trend`) will automate.

**This repo**: Code Quality opens with 106 authored commits (40 automated excluded), avg persistence 47.77d, rework 62.7%.

## Tests

248 passing. e2e now asserts section presence *and order* (Code Quality before Autonomy, Data Quality after By Autonomy Level), and the absence of the old generic persistence heading. README updated where it still claimed coverage "is reported first in every output".

🤖 Generated with [Claude Code](https://claude.com/claude-code)