### PR TITLE
feat: quality over time — the repo compared with its own past (#77 step 3)

### DIFF
--- a/.changeset/quality-trend.md
+++ b/.changeset/quality-trend.md
@@ -1,0 +1,21 @@
+---
+'@aida-dev/metrics': minor
+'@aida-dev/cli': minor
+---
+
+Quality over time: the repo compared with its own past (#77 step 3)
+
+Once AI participates in nearly every commit, "AI vs human" has no second side left to compare against — `No baseline cohort` is the normal outcome, not bad luck. This adds the comparator that still works: the repo against its own history.
+
+`metrics.trend` slices repo-level persistence, rework and coverage by calendar period (month or quarter), **derived from the commit stream in a single run**. A team gets a trend the first time they run AIDA, rather than after months of archiving reports; comparing stored `metrics.json` files remains possible on top of this and would add only what history cannot reconstruct.
+
+**The naive version of this feature is guaranteed to lie**, and two mechanisms prevent it:
+
+- Every period is measured through the same observation window (`--trend-window`, default 30 days), reusing the age-normalization from #29 — applied to time instead of cohorts. Otherwise an older period accumulates survival simply by having existed longer.
+- A period is *mature* only once it has been over for that full window. Immature periods are computed and reported, clearly marked, and excluded from every comparison. Without this, **every report ever generated would find quality declining**, because the newest period is always the least observed.
+
+Dogfooded on this repo, where the trap is vivid: the two immature periods show rework 98.1% and 96.7% with persistence under a day — a clock artifact that reads as catastrophic. The mature comparison says the opposite, 41.4% → 27.8% rework between 2026-03 and 2026-04. On varano-239, two months old, AIDA declines to compare at all rather than draw a line through one point.
+
+Cost is negligible: 291ms for 12 periods over a synthetic 20,000-commit, 100,000-file-touch stream — the per-period passes are linear and the trend adds no measurable time to `aida analyze` at any realistic scale.
+
+New flags: `--trend-granularity`, `--trend-window`, `--trend-periods`.

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ pnpm build
 
 ## Core Metrics
 
-1. **Code Quality (repo-level)**  
-   How long code survives and how often it is reworked, as a property of the repo — no attribution evidence required, so it opens the report and means something on any repository.
+1. **Code Quality (repo-level), and its trend**  
+   How long code survives and how often it is reworked, as a property of the repo — no attribution evidence required, so it opens the report and means something on any repository. Reported over time as well as in total: the repo compared with its own past is the comparator that still works once every commit is AI-assisted.
 
 2. **Persistence**  
    How long AI-generated code survives in the codebase before being rewritten or removed (file-level survival with censoring).
@@ -207,6 +207,9 @@ aida report --out-dir ./aida-output
 - `--default-mode <value>` - Prior for commits with no evidence: `none` | `autocomplete` | `assisted` | `agent`
 - `--coverage-threshold <fraction>` - Coverage below this flags metrics as low-confidence (default: 0.7)
 - `--coverage-window <days>` - Window for the actionable coverage figure (default: 90)
+- `--trend-granularity <value>` - Trend period: `month` | `quarter` (default: month)
+- `--trend-window <days>` - Observation window applied equally to every trend period (default: 30)
+- `--trend-periods <n>` - How many recent periods to report (default: 12)
 - `--hotfix-window <days>` - Window for linking a hotfix to its likely antecedent (default: 7)
 - `--out-dir <path>` - Output directory (default: ./aida-output)
 - `--verbose` - Verbose logging
@@ -417,6 +420,19 @@ aida analyze --default-mode none --coverage-threshold 0.8
 ```
 
 ## Metrics
+
+### Quality Over Time
+
+The comparator that replaces cohorts ([#77](https://github.com/ceccode/AIDA-Metrics/issues/77) step 3). Once AI participates in nearly every commit, "AI vs human" has no second side left — `No baseline cohort` becomes the normal outcome, not bad luck. What still answers *"is this getting better or worse?"* is the repo compared with **its own past**.
+
+`metrics.trend` slices the same repo-level quality by calendar period (month or quarter), derived from the commit stream in a single run — a team gets a trend the first time they run AIDA, not after months of archiving reports.
+
+Two mechanisms keep it honest, because the naive version is guaranteed to lie:
+
+- **Every period is measured through the same observation window** (`--trend-window`, default 30 days). A period from last year would otherwise accumulate survival simply by having existed longer. This is the age-normalization of [#29](https://github.com/ceccode/AIDA-Metrics/issues/29), applied to time instead of cohorts.
+- **A period is *mature* only once it has been over for that full window.** Before then its files have had less time to be reworked than every earlier period. Immature periods are reported and marked, never compared — without this, *every report ever generated* would find quality declining, because the newest period is always the least observed.
+
+When fewer than two mature periods exist, AIDA says so instead of drawing a line through one point.
 
 ### Autonomy
 
@@ -682,6 +698,7 @@ Bitbucket is currently out of scope ([#17](https://github.com/ceccode/AIDA-Metri
 - **v0.23** ✅ Autonomy as the primary axis — involvement × evidence, with three-state attribution demoted to a derived projection; coverage measured on the evidence axis; `defaultAttribution` replaced by `defaultMode` ([#25](https://github.com/ceccode/AIDA-Metrics/issues/25)). Schema v2.
 - **v0.24** ✅ `--if-git` and a documented `prepare` recipe, so hook installation reaches every clone; the low-coverage warning names a missing hook in a configured repo ([#75](https://github.com/ceccode/AIDA-Metrics/issues/75)).
 - **v0.25** ✅ Quality-first, steps 1–2 ([#77](https://github.com/ceccode/AIDA-Metrics/issues/77)): repo-level `repo` block in `metrics.json` (cohort-free persistence and rework, prior-proof), and the report reframe — Code Quality opens, the autonomy lens follows, coverage demoted to a Data Quality footnote.
+- **v0.26** ✅ Quality over time, step 3 ([#77](https://github.com/ceccode/AIDA-Metrics/issues/77)): `metrics.trend` — per-period persistence, rework and coverage derived from the commit stream in a single run, every period measured through the same observation window, immature periods reported but never compared.
 - **Next** → Bitbucket PR comment provider ([#17](https://github.com/ceccode/AIDA-Metrics/issues/17)), cost metrics ([#27](https://github.com/ceccode/AIDA-Metrics/issues/27)).  
 - **v1.0** → Dashboard / GitHub Action for continuous tracking.  
 

--- a/packages/cli/src/commands/analyze.ts
+++ b/packages/cli/src/commands/analyze.ts
@@ -54,6 +54,15 @@ export function createAnalyzeCommand(): Command {
       'Window in days for the actionable coverage figure (default: 90)'
     )
     .option(
+      '--trend-granularity <value>',
+      'Trend period: month | quarter (default: month)'
+    )
+    .option(
+      '--trend-window <days>',
+      'Observation window applied equally to every trend period (default: 30)'
+    )
+    .option('--trend-periods <n>', 'How many recent periods to report (default: 12)')
+    .option(
       '--hotfix-window <days>',
       'Window in days for linking a hotfix to its likely antecedent (default: 7)'
     )
@@ -149,8 +158,32 @@ export function createAnalyzeCommand(): Command {
           );
         }
 
+        const trendGranularity = options.trendGranularity ?? 'month';
+        if (!['month', 'quarter'].includes(trendGranularity)) {
+          throw new Error(
+            `Invalid --trend-granularity "${trendGranularity}": expected month or quarter`
+          );
+        }
+        const trendWindow = options.trendWindow ? Number(options.trendWindow) : undefined;
+        if (trendWindow !== undefined && (!Number.isInteger(trendWindow) || trendWindow <= 0)) {
+          throw new Error(
+            `Invalid --trend-window "${options.trendWindow}": expected a positive integer`
+          );
+        }
+        const trendPeriods = options.trendPeriods ? Number(options.trendPeriods) : undefined;
+        if (trendPeriods !== undefined && (!Number.isInteger(trendPeriods) || trendPeriods <= 0)) {
+          throw new Error(
+            `Invalid --trend-periods "${options.trendPeriods}": expected a positive integer`
+          );
+        }
+
         const metrics = calculateMetrics(commitStream, {
           defaultMode,
+          trend: {
+            granularity: trendGranularity as 'month' | 'quarter',
+            observationDays: trendWindow,
+            maxPeriods: trendPeriods,
+          },
           coverageThreshold,
           coverageWindowDays,
           prStream,
@@ -184,6 +217,15 @@ export function createAnalyzeCommand(): Command {
               : `Coverage is below ${threshold}%: attribution-dependent metrics are low-confidence (repo-level quality is unaffected). Install the commit hook (aida install-hooks), or set defaultMode in .aida.json.`
           );
         }
+        const lc = metrics.trend.latestComparison;
+        logger.info(
+          lc
+            ? `Trend ${lc.from} -> ${lc.to}: persistence ${lc.avgPersistenceDays.from}d -> ${lc.avgPersistenceDays.to}d` +
+                (lc.reworkRate
+                  ? `, rework ${(lc.reworkRate.from * 100).toFixed(1)}% -> ${(lc.reworkRate.to * 100).toFixed(1)}%`
+                  : '')
+            : `Trend: fewer than two mature periods (${metrics.trend.observationDays}d window) — no comparison yet`
+        );
         logger.info(`Average persistence: ${metrics.persistence.avgDays} days`);
         if (metrics.lineSurvival) {
           const ls = metrics.lineSurvival;

--- a/packages/cli/src/commands/e2e.test.ts
+++ b/packages/cli/src/commands/e2e.test.ts
@@ -83,6 +83,10 @@ describe('collect → analyze → report end to end', () => {
     expect(metrics.persistence).toHaveProperty('censored');
     expect(metrics.cohorts.ai.taskMix).not.toBeNull();
     expect(metrics.byMode.agent).not.toBeNull();
+    // Trend is always present, and refuses to compare immature periods (#77)
+    expect(metrics.trend.periods.length).toBeGreaterThan(0);
+    expect(metrics.trend.periods.every((p: { mature: boolean }) => !p.mature)).toBe(true);
+    expect(metrics.trend.latestComparison).toBeNull();
     // No human-attributed commits → no invented comparison
     expect(metrics.baseline).toBeNull();
     expect(metrics.delta).toBeNull();
@@ -106,6 +110,12 @@ describe('collect → analyze → report end to end', () => {
     expect(report).toContain('| Autonomy level | Commits |');
     expect(report).toContain('*Three-state view:*');
     expect(report).toContain('## By Autonomy Level');
+    // Quality over time (#77 step 3) lives inside Code Quality
+    expect(report).toContain('### Trend (monthly, 30-day observation window)');
+    // Every commit in this fixture was made moments ago, so no period can be
+    // mature: the report must decline to compare rather than invent a trend
+    expect(report).toContain('**No comparison yet**');
+    expect(report).toContain('Too recent to judge');
     expect(report).toContain('## Cohort Fairness');
     // The old generic-looking persistence section rendered the AI cohort's
     // numbers under a repo-level label; Code Quality replaced it (#77)

--- a/packages/cli/src/commands/report.ts
+++ b/packages/cli/src/commands/report.ts
@@ -11,6 +11,10 @@ import { join } from 'path';
 import { promises as fs } from 'fs';
 import { CLIConfig } from '../schema/config.js';
 
+function round1(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
 function formatDelta(value: number, suffix: string): string {
   const sign = value > 0 ? '+' : '';
   return `${sign}${value}${suffix}`;
@@ -241,6 +245,41 @@ ${[
   // cohort data wearing a repo-level label.
   const rq = metrics.repo;
   const rqp = rq.persistence;
+
+  // Quality over time (#77 step 3). The headline of a quality-first report is
+  // the direction of travel, not the snapshot — and the direction is only
+  // readable between periods that have had the same amount of time to be
+  // reworked, hence the maturity marker below.
+  const tr = metrics.trend;
+  const lc = tr.latestComparison;
+  const trendHeadline = lc
+    ? `**${lc.from} → ${lc.to}:** average persistence ${lc.avgPersistenceDays.from}d → **${lc.avgPersistenceDays.to}d** (${formatDelta(lc.avgPersistenceDays.delta, 'd')})${
+        lc.reworkRate
+          ? `, rework ${(lc.reworkRate.from * 100).toFixed(1)}% → **${(lc.reworkRate.to * 100).toFixed(1)}%** (${formatDelta(round1(lc.reworkRate.delta * 100), 'pt')})`
+          : ''
+      }.`
+    : `**No comparison yet** — fewer than two periods have been over for the full ${tr.observationDays}-day observation window. A trend needs two points that have had the same amount of time.`;
+
+  const immature = tr.periods.filter((p) => !p.mature).length;
+  const trendRows = tr.periods.map((p) => {
+    const persistence = p.persistence;
+    return `| ${p.label}${p.mature ? '' : ' *(immature)*'} | ${p.commitsAuthored} | ${persistence ? persistence.avgDays : '—'} | ${persistence?.rework ? `${(persistence.rework.rate * 100).toFixed(1)}%` : '—'} | ${p.coverage === null ? '—' : `${(p.coverage * 100).toFixed(0)}%`} |`;
+  });
+
+  const trendSection =
+    tr.periods.length > 0
+      ? `
+### Trend (${tr.granularity}ly, ${tr.observationDays}-day observation window)
+
+${trendHeadline}
+
+Every period is measured through the same ${tr.observationDays}-day window, so no period gets credit for time the others have not had.
+
+| Period | Commits | Avg persistence (d) | Rework | Coverage |
+|---|---:|---:|---:|---:|
+${trendRows.join('\n')}
+${immature > 0 ? `\n*(immature)* — Too recent to judge: the period has not been over for the full ${tr.observationDays}-day window, so its files have had less time to be reworked than every period above. Shown for completeness, excluded from the comparison — otherwise every report would find quality declining.\n` : ''}`
+      : '';
   const codeQualitySection = `## Code Quality
 
 How the code holds up, as a property of the **repo** — measured over all ${rq.commitsAuthored} authored commits (${rq.commitsAutomated} automated excluded). No attribution evidence required: these numbers do not move with coverage or with the \`defaultMode\` prior.
@@ -256,7 +295,7 @@ How the code holds up, as a property of the **repo** — measured over all ${rq.
 | 0–1d | 2–7d | 8–30d | 31–90d | 90d+ |
 |---:|---:|---:|---:|---:|
 | ${rqp.buckets.d0_1} | ${rqp.buckets.d2_7} | ${rqp.buckets.d8_30} | ${rqp.buckets.d31_90} | ${rqp.buckets.d90_plus} |
-
+${trendSection}
 `;
 
   const baselineDetail = metrics.baseline

--- a/packages/metrics/src/index.ts
+++ b/packages/metrics/src/index.ts
@@ -12,6 +12,7 @@ import { calculateBaselinePersistence, calculatePersistence } from './persistenc
 import { calculateLineSurvival } from './line-survival.js';
 import { calculateOutcomeCorrelation } from './outcome-correlation.js';
 import { calculatePRAcceptance } from './pr-acceptance.js';
+import { calculateTrend, TrendOptions } from './trend.js';
 import {
   Attribution,
   ByCategory,
@@ -29,6 +30,7 @@ export * from './persistence.js';
 export * from './pr-acceptance.js';
 export * from './line-survival.js';
 export * from './outcome-correlation.js';
+export * from './trend.js';
 
 export const DEFAULT_COVERAGE_WINDOW_DAYS = 90;
 
@@ -45,6 +47,8 @@ export interface MetricsOptions {
   blameStream?: BlameStream | null;
   // Window for linking a hotfix to its likely antecedent (#26)
   hotfixWindowDays?: number;
+  // Quality-over-time series (#77 step 3)
+  trend?: TrendOptions;
 }
 
 function round(value: number, decimals: number): number {
@@ -63,6 +67,7 @@ export function calculateMetrics(
     prStream = null,
     blameStream = null,
     hotfixWindowDays,
+    trend: trendOptions,
   } = options;
 
   const counts = { ai: 0, human: 0, automated: 0, unknown: 0 };
@@ -159,6 +164,11 @@ export function calculateMetrics(
     commitsAutomated: total - authoredCount,
     persistence: calculatePersistence(commitStream, isAuthored),
   };
+
+  // Quality over time (#77 step 3): the same repo-level measurement, sliced
+  // by period, so the repo can be compared with its own past instead of with
+  // a cohort that no longer exists.
+  const trend = calculateTrend(commitStream, trendOptions);
 
   const persistence = calculatePersistence(commitStream, isAI);
 
@@ -350,6 +360,7 @@ export function calculateMetrics(
     defaultBranch: commitStream.defaultBranch,
     attribution,
     repo,
+    trend,
     persistence,
     cohorts,
     byMode,

--- a/packages/metrics/src/schema/metrics.ts
+++ b/packages/metrics/src/schema/metrics.ts
@@ -334,6 +334,54 @@ export const RepoQuality = z.object({
   persistence: Persistence,
 });
 
+// Quality over time (#77, step 3): the comparator that replaces cohorts
+// once "AI vs human" has no second side left. Derived from the commit stream
+// in one run, so a trend exists on first use rather than after months of
+// archived runs.
+export const TrendGranularity = z.enum(['month', 'quarter']);
+
+export const TrendPeriod = z.object({
+  label: z.string(), // '2026-06' or '2026-Q2'
+  start: z.string().datetime(),
+  end: z.string().datetime(), // exclusive
+  // Both denominators, stated: coverage spans every commit (automation has
+  // known provenance), quality spans authored ones only.
+  commitsTotal: z.number().int().nonnegative(),
+  commitsAuthored: z.number().int().nonnegative(),
+  // Null when the period contains no commits at all
+  coverage: z.number().min(0).max(1).nullable(),
+  // Null when the period has no authored commits. Every period is measured
+  // through the same observation window, so periods are comparable with each
+  // other rather than with the clock.
+  persistence: Persistence.nullable(),
+  // False until the period has been over for `observationDays`: its files
+  // have not all had the full window yet, so it is reported but never
+  // compared. Without this every report would find quality "declining".
+  mature: z.boolean(),
+});
+
+export const TrendDelta = z.object({
+  from: z.number(),
+  to: z.number(),
+  delta: z.number(),
+});
+
+export const Trend = z.object({
+  granularity: TrendGranularity,
+  observationDays: z.number().int().positive(),
+  periods: z.array(TrendPeriod),
+  // The two most recent MATURE periods. Null when fewer than two exist —
+  // a young repo gets no trend rather than a trend built on one point.
+  latestComparison: z
+    .object({
+      from: z.string(),
+      to: z.string(),
+      avgPersistenceDays: TrendDelta,
+      reworkRate: TrendDelta.nullable(),
+    })
+    .nullable(),
+});
+
 export const Metrics = z.object({
   // Bumped when a field is removed or changes meaning (#53)
   schemaVersion: z.number().int().positive(),
@@ -347,6 +395,8 @@ export const Metrics = z.object({
   attribution: Attribution,
   // Repo-level quality (#77): cohort-free, prior-free, the primary object
   repo: RepoQuality,
+  // The same quality, over time (#77 step 3)
+  trend: Trend,
   persistence: Persistence,
   // Fairness context (#29, #36): age and task mix per cohort, so consumers
   // can judge whether the AI-vs-baseline comparison is apples-to-apples.
@@ -399,4 +449,7 @@ export type Persistence = z.infer<typeof Persistence>;
 export type RepoQuality = z.infer<typeof RepoQuality>;
 export type Baseline = z.infer<typeof Baseline>;
 export type Delta = z.infer<typeof Delta>;
+export type TrendGranularity = z.infer<typeof TrendGranularity>;
+export type TrendPeriod = z.infer<typeof TrendPeriod>;
+export type Trend = z.infer<typeof Trend>;
 export type Metrics = z.infer<typeof Metrics>;

--- a/packages/metrics/src/trend.test.ts
+++ b/packages/metrics/src/trend.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect } from 'vitest';
+import { Commit, CommitStream } from '@aida-dev/core';
+import { calculateTrend } from './trend.js';
+
+const NOW = new Date('2026-07-15T00:00:00.000Z');
+
+function at(date: string): string {
+  return new Date(date).toISOString();
+}
+
+function makeCommit(hash: string, date: string, files: string[], automated = false): Commit {
+  return {
+    hash,
+    authorName: 'Test',
+    authorEmail: 'test@example.com',
+    authorDate: at(date),
+    committerName: 'Test',
+    committerEmail: 'test@example.com',
+    committerDate: at(date),
+    message: 'commit',
+    parents: [],
+    inDefaultBranchAncestry: true,
+    revertsCommit: null,
+    tags: {
+      attribution: automated ? 'automated' : 'unknown',
+      automated,
+      mode: automated ? 'none' : 'unknown',
+      evidence: automated ? 'inferred' : 'none',
+      level: 'none',
+      sources: [],
+    },
+    stats: {
+      totalAdditions: files.length,
+      totalDeletions: 0,
+      files: files.map((path) => ({ path, status: 'modified' as const, additions: 1, deletions: 0 })),
+    },
+  };
+}
+
+function makeStream(commits: Commit[]): CommitStream {
+  return {
+    schemaVersion: 2,
+    repoPath: '/test',
+    defaultBranch: 'main',
+    generatedAt: NOW.toISOString(),
+    aiPatterns: [],
+    commits,
+  };
+}
+
+describe('calculateTrend', () => {
+  it('buckets authored commits into calendar periods, keeping empty ones', () => {
+    const trend = calculateTrend(
+      makeStream([
+        makeCommit('a', '2026-03-05T00:00:00Z', ['src/a.ts']),
+        // nothing in April
+        makeCommit('b', '2026-05-05T00:00:00Z', ['src/b.ts']),
+      ]),
+      { observationEnd: NOW }
+    );
+
+    expect(trend.periods.map((p) => p.label)).toEqual([
+      '2026-03',
+      '2026-04',
+      '2026-05',
+      '2026-06',
+      '2026-07',
+    ]);
+    // A month nobody committed in is signal, and dropping it would misspace
+    // the series
+    const april = trend.periods.find((p) => p.label === '2026-04')!;
+    expect(april.commitsAuthored).toBe(0);
+    expect(april.persistence).toBeNull();
+  });
+
+  // The defect this feature is built around: without an equal window and a
+  // maturity gate, the newest period has had the least time to be reworked,
+  // so every report ever generated would find quality "declining".
+  it('marks a period immature until it has been over for the full window', () => {
+    const trend = calculateTrend(
+      makeStream([
+        makeCommit('old', '2026-03-05T00:00:00Z', ['src/a.ts']),
+        makeCommit('recent', '2026-07-05T00:00:00Z', ['src/b.ts']),
+      ]),
+      { observationEnd: NOW, observationDays: 30 }
+    );
+
+    // March ended 2026-04-01, more than 30 days before 2026-07-15
+    expect(trend.periods.find((p) => p.label === '2026-03')!.mature).toBe(true);
+    // June ended 2026-07-01, only 14 days ago
+    expect(trend.periods.find((p) => p.label === '2026-06')!.mature).toBe(false);
+    // July has not even ended
+    expect(trend.periods.find((p) => p.label === '2026-07')!.mature).toBe(false);
+  });
+
+  it('never compares an immature period, however much data it holds', () => {
+    // Two periods with data, but the later one is too recent to judge
+    const trend = calculateTrend(
+      makeStream([
+        makeCommit('a1', '2026-03-05T00:00:00Z', ['src/a.ts']),
+        makeCommit('a2', '2026-03-20T00:00:00Z', ['src/a.ts']),
+        makeCommit('b1', '2026-07-02T00:00:00Z', ['src/b.ts']),
+        makeCommit('b2', '2026-07-04T00:00:00Z', ['src/b.ts']),
+      ]),
+      { observationEnd: NOW, observationDays: 30 }
+    );
+
+    // Only March is mature, so there is no second point: no comparison at all
+    // rather than a comparison against an unfinished period
+    expect(trend.latestComparison).toBeNull();
+    expect(trend.periods.find((p) => p.label === '2026-07')!.persistence).not.toBeNull();
+  });
+
+  it('compares the two most recent mature periods', () => {
+    const commits: Commit[] = [];
+    // January: files reworked fast (1 day)
+    commits.push(makeCommit('j1', '2026-01-05T00:00:00Z', ['src/jan.ts']));
+    commits.push(makeCommit('j2', '2026-01-06T00:00:00Z', ['src/jan.ts']));
+    // February: files never touched again -> survive the full window
+    commits.push(makeCommit('f1', '2026-02-05T00:00:00Z', ['src/feb.ts']));
+
+    const trend = calculateTrend(makeStream(commits), {
+      observationEnd: NOW,
+      observationDays: 30,
+    });
+
+    expect(trend.latestComparison).not.toBeNull();
+    expect(trend.latestComparison!.from).toBe('2026-01');
+    expect(trend.latestComparison!.to).toBe('2026-02');
+    // February's file survived the whole capped window, January's lasted a day
+    expect(trend.latestComparison!.avgPersistenceDays.delta).toBeGreaterThan(0);
+  });
+
+  // Age-normalization (#29) applied to time instead of cohorts: an old period
+  // must not win simply for having existed longer.
+  it('caps every period to the same observation window', () => {
+    const trend = calculateTrend(
+      makeStream([
+        makeCommit('old', '2026-01-05T00:00:00Z', ['src/old.ts']),
+        makeCommit('new', '2026-05-05T00:00:00Z', ['src/new.ts']),
+      ]),
+      { observationEnd: NOW, observationDays: 30 }
+    );
+
+    const jan = trend.periods.find((p) => p.label === '2026-01')!.persistence!;
+    const may = trend.periods.find((p) => p.label === '2026-05')!.persistence!;
+    // Neither file was ever touched again: both are censored at exactly the
+    // window, not at their real age (191 days vs 71)
+    expect(jan.avgDays).toBe(30);
+    expect(may.avgDays).toBe(30);
+  });
+
+  it('reports both denominators: coverage over all commits, quality over authored', () => {
+    const trend = calculateTrend(
+      makeStream([
+        makeCommit('a', '2026-03-05T00:00:00Z', ['src/a.ts']),
+        makeCommit('m', '2026-03-06T00:00:00Z', ['src/a.ts'], true), // automated
+      ]),
+      { observationEnd: NOW }
+    );
+
+    const march = trend.periods.find((p) => p.label === '2026-03')!;
+    expect(march.commitsTotal).toBe(2);
+    expect(march.commitsAuthored).toBe(1);
+    // The automated commit carries inferred evidence, so coverage is 1/2
+    expect(march.coverage).toBe(0.5);
+    // ...while quality counts the authored commit only
+    expect(march.persistence!.commitsConsidered).toBe(1);
+  });
+
+  it('caps the series so a decade-old repo does not render a hundred rows', () => {
+    const commits = Array.from({ length: 24 }, (_, i) =>
+      makeCommit(`c${i}`, `2024-${String((i % 12) + 1).padStart(2, '0')}-05T00:00:00Z`, ['src/a.ts'])
+    );
+    const trend = calculateTrend(makeStream(commits), { observationEnd: NOW, maxPeriods: 6 });
+
+    expect(trend.periods).toHaveLength(6);
+    // The most recent periods are the ones kept
+    expect(trend.periods[trend.periods.length - 1].label).toBe('2026-07');
+  });
+
+  it('supports quarterly granularity', () => {
+    const trend = calculateTrend(
+      makeStream([makeCommit('a', '2026-02-05T00:00:00Z', ['src/a.ts'])]),
+      { observationEnd: NOW, granularity: 'quarter' }
+    );
+
+    expect(trend.periods.map((p) => p.label)).toEqual(['2026-Q1', '2026-Q2', '2026-Q3']);
+  });
+
+  it('returns an empty trend rather than inventing one for a repo with no authored commits', () => {
+    const trend = calculateTrend(
+      makeStream([makeCommit('m', '2026-03-05T00:00:00Z', ['src/a.ts'], true)]),
+      { observationEnd: NOW }
+    );
+
+    expect(trend.periods).toEqual([]);
+    expect(trend.latestComparison).toBeNull();
+  });
+});

--- a/packages/metrics/src/trend.ts
+++ b/packages/metrics/src/trend.ts
@@ -1,0 +1,181 @@
+import { Commit, CommitStream } from '@aida-dev/core';
+import { calculatePersistence } from './persistence.js';
+import { Trend, TrendGranularity, TrendPeriod } from './schema/metrics.js';
+
+// Quality over time (#77, step 3). The comparator that replaces cohorts.
+//
+// Once AI participates in nearly every commit, "AI vs human" has no second
+// side left to compare against — `No baseline cohort` is the normal outcome,
+// not bad luck. What still answers "is this getting better or worse?" is the
+// repo compared with its own past: is rework rising since we raised agent
+// autonomy, did persistence degrade after switching models.
+//
+// Derived from the commit stream in a single run rather than from stored
+// snapshots: a team gets a trend the first time they run AIDA, instead of
+// after months of collecting runs. Comparing archived `metrics.json` files
+// remains possible on top of this and adds only what history cannot
+// reconstruct.
+//
+// THE TRAP THIS IS BUILT AROUND: a period that ended yesterday has had one
+// day to be reworked, while a period from last year has had a year. Compare
+// them raw and every report ever generated says quality is collapsing — an
+// artifact of the clock, stated as a finding. Two mechanisms prevent it:
+//
+//   1. Every period is measured through the SAME observation window
+//      (`observationDays`, via the age-normalization from #29), so no period
+//      gets credit for time the others did not have.
+//   2. A period is `mature` only once it ended at least `observationDays`
+//      ago — before that, its files have not all had the full window. The
+//      most recent periods are always immature; they are reported, marked,
+//      and deliberately excluded from every comparison.
+
+export const DEFAULT_TREND_OBSERVATION_DAYS = 30;
+export const DEFAULT_TREND_MAX_PERIODS = 12;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export interface TrendOptions {
+  granularity?: TrendGranularity;
+  // Equal observation window applied to every period (#29's mechanism)
+  observationDays?: number;
+  // Periods kept, most recent first. A 15-year repo has 180 months; a
+  // hundred-row table is not a trend anyone reads.
+  maxPeriods?: number;
+  observationEnd?: Date;
+}
+
+function periodStart(date: Date, granularity: TrendGranularity): Date {
+  const year = date.getUTCFullYear();
+  const month = date.getUTCMonth();
+  return granularity === 'quarter'
+    ? new Date(Date.UTC(year, Math.floor(month / 3) * 3, 1))
+    : new Date(Date.UTC(year, month, 1));
+}
+
+function nextPeriodStart(start: Date, granularity: TrendGranularity): Date {
+  const year = start.getUTCFullYear();
+  const month = start.getUTCMonth();
+  return new Date(Date.UTC(year, month + (granularity === 'quarter' ? 3 : 1), 1));
+}
+
+function periodLabel(start: Date, granularity: TrendGranularity): string {
+  const year = start.getUTCFullYear();
+  const month = start.getUTCMonth();
+  return granularity === 'quarter'
+    ? `${year}-Q${Math.floor(month / 3) + 1}`
+    : `${year}-${String(month + 1).padStart(2, '0')}`;
+}
+
+function round(value: number, decimals: number): number {
+  const factor = 10 ** decimals;
+  return Math.round(value * factor) / factor;
+}
+
+export function calculateTrend(commitStream: CommitStream, options: TrendOptions = {}): Trend {
+  const {
+    granularity = 'month',
+    observationDays = DEFAULT_TREND_OBSERVATION_DAYS,
+    maxPeriods = DEFAULT_TREND_MAX_PERIODS,
+    observationEnd = new Date(commitStream.generatedAt),
+  } = options;
+
+  const empty: Trend = {
+    granularity,
+    observationDays,
+    periods: [],
+    latestComparison: null,
+  };
+
+  const authored = commitStream.commits.filter((commit) => !commit.tags.automated);
+  if (authored.length === 0) return empty;
+
+  const earliest = new Date(
+    Math.min(...authored.map((commit) => new Date(commit.authorDate).getTime()))
+  );
+
+  // Every calendar period from the first authored commit to the collection
+  // time, including empty ones: a month nobody committed in is signal, and a
+  // series with gaps closed up would misrepresent the spacing of the trend.
+  const starts: Date[] = [];
+  const lastStart = periodStart(observationEnd, granularity);
+  for (
+    let cursor = periodStart(earliest, granularity);
+    cursor.getTime() <= lastStart.getTime();
+    cursor = nextPeriodStart(cursor, granularity)
+  ) {
+    starts.push(cursor);
+  }
+
+  const periods: TrendPeriod[] = starts.slice(-maxPeriods).map((start) => {
+    const end = nextPeriodStart(start, granularity);
+
+    const inPeriod = (commit: Commit) => {
+      const date = new Date(commit.authorDate);
+      return date.getTime() >= start.getTime() && date.getTime() < end.getTime();
+    };
+    const isTarget = (commit: Commit) => !commit.tags.automated && inPeriod(commit);
+
+    const periodCommits = commitStream.commits.filter(inPeriod);
+    const authoredCommits = periodCommits.filter((commit) => !commit.tags.automated);
+
+    // Both denominators are reported, because they differ: coverage is the
+    // evidence axis over every commit (automation carries known provenance),
+    // while quality is measured over authored code only. Two counts under
+    // one heading with the difference left implicit is the defect this
+    // project keeps finding in its own reports.
+    const withEvidence = periodCommits.filter((commit) => commit.tags.evidence !== 'none').length;
+
+    return {
+      label: periodLabel(start, granularity),
+      start: start.toISOString(),
+      end: end.toISOString(),
+      commitsTotal: periodCommits.length,
+      commitsAuthored: authoredCommits.length,
+      coverage:
+        periodCommits.length > 0 ? round(withEvidence / periodCommits.length, 4) : null,
+      persistence:
+        authoredCommits.length > 0
+          ? calculatePersistence(commitStream, isTarget, {
+              observationEnd,
+              maxObservationDays: observationDays,
+            })
+          : null,
+      // Not "has enough data" but "has had enough time": every file first
+      // touched in a mature period has been observable for the full window.
+      mature: observationEnd.getTime() - end.getTime() >= observationDays * DAY_MS,
+    };
+  });
+
+  // The headline: the two most recent periods that can honestly be compared.
+  // Immature periods are excluded here even though they are reported above —
+  // showing them is informative, comparing them is not.
+  const comparable = periods.filter((period) => period.mature && period.persistence !== null);
+  const previous = comparable[comparable.length - 2];
+  const latest = comparable[comparable.length - 1];
+
+  const latestComparison =
+    previous && latest
+      ? {
+          from: previous.label,
+          to: latest.label,
+          avgPersistenceDays: {
+            from: previous.persistence!.avgDays,
+            to: latest.persistence!.avgDays,
+            delta: round(latest.persistence!.avgDays - previous.persistence!.avgDays, 2),
+          },
+          reworkRate:
+            previous.persistence!.rework && latest.persistence!.rework
+              ? {
+                  from: previous.persistence!.rework.rate,
+                  to: latest.persistence!.rework.rate,
+                  delta: round(
+                    latest.persistence!.rework.rate - previous.persistence!.rework.rate,
+                    4
+                  ),
+                }
+              : null,
+        }
+      : null;
+
+  return { granularity, observationDays, periods, latestComparison };
+}


### PR DESCRIPTION
Step 3 of #77's migration path, and the gap the issue called the biggest in the tool: AIDA has been a snapshot instrument with no memory.

Once AI participates in nearly every commit, *"AI vs human"* has no second side left — `No baseline cohort` fires on every repo we touch, which is the assumption working, not bad luck. This adds the comparator that survives it: **the repo against its own history**.

## Derived, not archived

`metrics.trend` slices repo-level persistence, rework and coverage by calendar period (month or quarter), computed **from the commit stream in a single run**. A team gets a trend the first time they run AIDA instead of after months of collecting reports. Comparing stored `metrics.json` files stays possible on top of this later, and would add only what history genuinely cannot reconstruct.

## The naive version of this feature is guaranteed to lie

A period that ended yesterday has had one day to be reworked; a period from last year has had a year. Compare them raw and **every report ever generated says quality is collapsing** — a clock artifact stated as a finding. Two mechanisms carry the design:

1. **Equal observation window.** Every period is measured through the same `--trend-window` (default 30 days), reusing #29's age-normalization applied to time instead of cohorts. No period gets credit for time the others have not had.
2. **Maturity gate.** A period is `mature` only once it has been over for that full window. Immature periods are computed and reported — hiding them would conceal real recent data — but marked and excluded from every comparison.

When fewer than two mature periods exist, AIDA says so rather than drawing a line through one point.

## Dogfood — the trap is vivid on this repo

| Period | Commits | Avg persistence (d) | Rework |
|---|---:|---:|---:|
| 2026-03 | 27 | 14.03 | 41.4% |
| 2026-04 | 5 | 22 | 27.8% |
| 2026-07 *(immature)* | 36 | 0.79 | **98.1%** |
| 2026-08 *(immature)* | 30 | 0.7 | **96.7%** |

Read naively, rework tripled and persistence fell off a cliff. Both of those periods are simply too young to judge. The headline reports the only honest comparison available — **41.4% → 27.8% rework, 14.03d → 22d persistence** between the two mature periods, i.e. improving.

**varano-239** (two months old): `No comparison yet — fewer than two periods have been over for the full 30-day observation window.` A young repo gets no fabricated trend.

## Cost

Measured, because the trend runs one persistence pass per period: **291ms for 12 periods** over a synthetic 20,000-commit / 100,000-file-touch stream (38ms for a single period — linear, as expected). No optimization needed at any realistic scale, so the trend is computed by default rather than hidden behind a flag.

## Tests

257 passing (was 248). Nine new trend tests, each pinned to a fixed `observationEnd` so none of them can drift with the calendar — including the maturity gate in both directions, the equal-window property (two files of very different real age both censored at exactly 30d), both denominators being reported separately, and empty periods surviving so the series stays evenly spaced. The e2e suite asserts that a repo whose commits were all made moments ago declines to compare.

New flags: `--trend-granularity`, `--trend-window`, `--trend-periods`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)