### PR TITLE
feat: a prior can no longer conjure a cohort overlay (#77 step 4)

### DIFF
--- a/.changeset/overlay-gating.md
+++ b/.changeset/overlay-gating.md
@@ -1,0 +1,16 @@
+---
+'@aida-dev/cli': minor
+---
+
+A prior can no longer conjure a cohort overlay out of assumption alone (#77 step 4)
+
+The last step of the quality-first migration. Earlier work made the prior's contribution *visible* — `(N assumed)` next to each cohort size. This stops it from creating an overlay at all: a cohort whose every commit was placed there by `defaultMode` is not a measurement, it is the assumption describing itself with numbers next to it.
+
+- **Per-level rows** in `By Autonomy Level` render only where at least one commit carries real evidence. `unknown` is exempt — it *is* the no-evidence bucket, and reporting its size is the honest part.
+- **The AI-vs-baseline comparison is withheld** when either side is pure prior, because a measured cohort against an assumed one yields a delta that describes the prior rather than the repo.
+- **Nothing is dropped silently.** When every cohort is gated, the section still renders and explains why, and names the prior responsible — a configured `defaultMode` doing nothing is itself worth knowing. Writing the gate surfaced this: the first implementation made the section vanish, which its own test caught.
+- **Cohort Fairness** is gated only when *neither* side has evidence. With one real cohort its age and task mix are information the repo genuinely has, so the table stays as it was.
+
+The gate is on presentation only — every cohort remains in `metrics.json`, so a consumer that wants the prior's view still has it.
+
+Dogfooded on both repos: this one (full evidence) renders the agent cohort unchanged; varano-239 renders `agent 26 (11 assumed)` because 15 commits genuinely declare `agent`, while a synthetic 0%-evidence repo with `--default-mode agent` gets the explained withholding instead of a fabricated table.

--- a/README.md
+++ b/README.md
@@ -457,6 +457,8 @@ Coverage is reported over **two windows** ([#52](https://github.com/ceccode/AIDA
 
 `defaultMode` lets a team consciously assign no-evidence commits to an autonomy level (`none` for traditional repos, `assisted`/`agent` for AI-first ones). The prior affects cohort metrics but never coverage: an assumption is not evidence, so a repo leaning on it still reports how little it actually knows, and an assumed baseline is labeled as such.
 
+**A prior can never create an overlay on its own** ([#77](https://github.com/ceccode/AIDA-Metrics/issues/77) step 4). A cohort whose every commit was placed there by `defaultMode` is the assumption describing itself, so the report withholds it — with an explanation, never silently — and says the same for an AI-vs-baseline comparison where one side is pure prior. One commit with real evidence is enough to unlock the overlay, with the prior's share still labelled `(N assumed)`. The cohorts stay in `metrics.json` either way: the gate is on presentation, not on collection.
+
 ### By Autonomy Level
 
 Merge ratio and persistence computed per autonomy mode (`agent` / `assisted` / `autocomplete` / `none`) — the comparison that stays meaningful when everything is AI-assisted ([#25](https://github.com/ceccode/AIDA-Metrics/issues/25)). Automated commits are excluded; modes with no commits are `null`.
@@ -699,6 +701,7 @@ Bitbucket is currently out of scope ([#17](https://github.com/ceccode/AIDA-Metri
 - **v0.24** ✅ `--if-git` and a documented `prepare` recipe, so hook installation reaches every clone; the low-coverage warning names a missing hook in a configured repo ([#75](https://github.com/ceccode/AIDA-Metrics/issues/75)).
 - **v0.25** ✅ Quality-first, steps 1–2 ([#77](https://github.com/ceccode/AIDA-Metrics/issues/77)): repo-level `repo` block in `metrics.json` (cohort-free persistence and rework, prior-proof), and the report reframe — Code Quality opens, the autonomy lens follows, coverage demoted to a Data Quality footnote.
 - **v0.26** ✅ Quality over time, step 3 ([#77](https://github.com/ceccode/AIDA-Metrics/issues/77)): `metrics.trend` — per-period persistence, rework and coverage derived from the commit stream in a single run, every period measured through the same observation window, immature periods reported but never compared.
+- **v0.27** ✅ Overlay gating, step 4 ([#77](https://github.com/ceccode/AIDA-Metrics/issues/77)) — cohort tables render only where real evidence backs them; a `defaultMode` prior can no longer conjure an autonomy cohort or a baseline comparison out of assumption alone. Completes the quality-first migration.
 - **Next** → Bitbucket PR comment provider ([#17](https://github.com/ceccode/AIDA-Metrics/issues/17)), cost metrics ([#27](https://github.com/ceccode/AIDA-Metrics/issues/27)).  
 - **v1.0** → Dashboard / GitHub Action for continuous tracking.  
 

--- a/packages/cli/src/commands/report-gating.test.ts
+++ b/packages/cli/src/commands/report-gating.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { execSync } from 'child_process';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import type { Command } from 'commander';
+import { createCollectCommand } from './collect.js';
+import { createAnalyzeCommand } from './analyze.js';
+import { createReportCommand } from './report.js';
+
+// Overlay gating (#77 step 4): a cohort built entirely out of the
+// `defaultMode` prior is the assumption describing itself. It must not be
+// rendered as a measurement — while the underlying data stays in
+// metrics.json, because the gate is on presentation, not on collection.
+
+let repoPath: string;
+let outDir: string;
+
+function git(cmd: string) {
+  execSync(cmd, { cwd: repoPath, env: { ...process.env, AIDA_MODE: '', CLAUDECODE: '' } });
+}
+
+// The report has an observed-counts table AND cohort overlays; assertions
+// about gating must target the overlay, since the observed table showing
+// `agent 0` is exactly right.
+function section(report: string, heading: string): string {
+  const start = report.indexOf(heading);
+  if (start === -1) return '';
+  const rest = report.slice(start + heading.length);
+  const end = rest.indexOf('\n## ');
+  return end === -1 ? rest : rest.slice(0, end);
+}
+
+function run(command: Command, args: string[]): Promise<Command> {
+  return command.parseAsync(args, { from: 'user' });
+}
+
+interface ModeCohort {
+  commits: number;
+  assumed: number;
+}
+
+async function pipeline(
+  extraArgs: string[] = []
+): Promise<{ report: string; metrics: { byMode: Record<string, ModeCohort | null> } }> {
+  await run(createCollectCommand(), ['--repo', repoPath, '--out-dir', outDir]);
+  await run(createAnalyzeCommand(), ['--out-dir', outDir, ...extraArgs]);
+  await run(createReportCommand(), ['--out-dir', outDir]);
+  return {
+    report: readFileSync(join(outDir, 'report.md'), 'utf-8'),
+    metrics: JSON.parse(readFileSync(join(outDir, 'metrics.json'), 'utf-8')),
+  };
+}
+
+beforeEach(() => {
+  repoPath = mkdtempSync(join(tmpdir(), 'aida-gate-repo-'));
+  outDir = mkdtempSync(join(tmpdir(), 'aida-gate-out-'));
+  git('git init -q -b main');
+  git('git config user.name test && git config user.email test@example.com');
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  rmSync(repoPath, { recursive: true, force: true });
+  rmSync(outDir, { recursive: true, force: true });
+});
+
+describe('overlay gating (#77 step 4)', () => {
+  it('withholds every cohort overlay when only the prior populates them', async () => {
+    // Two commits, neither declaring anything: 0% evidence
+    writeFileSync(join(repoPath, 'a.ts'), 'export const a = 1;\n');
+    git('git add -A && git commit -q -m "feat: one"');
+    writeFileSync(join(repoPath, 'a.ts'), 'export const a = 2;\n');
+    git('git add -A && git commit -q -m "feat: two"');
+
+    const { report, metrics } = await pipeline(['--default-mode', 'agent']);
+
+    // The prior would otherwise conjure a full agent cohort out of nothing
+    expect(metrics.byMode.agent).toEqual(expect.objectContaining({ commits: 2, assumed: 2 }));
+
+    // ...but no overlay row is rendered from it. Scoped to the overlay: the
+    // observed table above legitimately shows `agent 0`, which is the truth.
+    expect(section(report, '## By Autonomy Level')).not.toMatch(/\| agent \|/);
+    // Withheld with a reason, not silently dropped: a configured prior doing
+    // nothing is itself worth telling the reader about
+    expect(report).toContain('**Withheld**');
+    expect(report).toContain('the assumption describing itself');
+    expect(report).not.toContain('## Cohort Fairness');
+
+    // Repo-level quality is untouched by the gate: it never needed evidence
+    expect(report).toContain('## Code Quality');
+    expect(report).toContain('### Trend');
+  });
+
+  it('renders the overlay as soon as one commit carries real evidence', async () => {
+    writeFileSync(join(repoPath, 'a.ts'), 'export const a = 1;\n');
+    git('git add -A && git commit -q -m "feat: undeclared"');
+    writeFileSync(join(repoPath, 'b.ts'), 'export const b = 1;\n');
+    git(
+      'git add -A && git commit -q -m "feat: declared" -m "Co-Authored-By: Claude <noreply@anthropic.com>"'
+    );
+
+    const { report } = await pipeline(['--default-mode', 'agent']);
+
+    // One real agent commit backs the cohort, so it is shown — with the
+    // prior's contribution still labelled
+    expect(section(report, '## By Autonomy Level')).toMatch(/\| agent \|/);
+    expect(report).toContain('assumed)');
+  });
+
+  it('withholds the AI-vs-baseline comparison when one side is pure prior', async () => {
+    // A declared AI commit and a set of undeclared ones assumed 'none'
+    writeFileSync(join(repoPath, 'a.ts'), 'export const a = 1;\n');
+    git(
+      'git add -A && git commit -q -m "feat: ai" -m "Co-Authored-By: Claude <noreply@anthropic.com>"'
+    );
+    writeFileSync(join(repoPath, 'b.ts'), 'export const b = 1;\n');
+    git('git add -A && git commit -q -m "feat: undeclared"');
+
+    const { report } = await pipeline(['--default-mode', 'none']);
+
+    // The baseline exists only because the prior said so
+    expect(report).toContain('**Comparison withheld**');
+    expect(report).toContain('placed there by assumption');
+    expect(report).not.toContain('| Avg persistence (days) |');
+  });
+
+  it('keeps the unknown row: the no-evidence bucket is the honest part', async () => {
+    writeFileSync(join(repoPath, 'a.ts'), 'export const a = 1;\n');
+    git('git add -A && git commit -q -m "feat: undeclared"');
+
+    // No prior at all: everything stays unknown
+    const { report } = await pipeline();
+
+    expect(section(report, '## By Autonomy Level')).toMatch(/\| unknown \|/);
+    expect(report).not.toContain('**Comparison withheld**');
+  });
+});

--- a/packages/cli/src/commands/report.ts
+++ b/packages/cli/src/commands/report.ts
@@ -41,6 +41,20 @@ function generateMarkdownReport(metrics: Metrics): string {
       ? `\nCommits with no evidence are **assumed \`${a.defaultMode}\`** via \`defaultMode\` — this is a prior, not observed data, and it does not count toward coverage.\n`
       : '';
 
+  // Overlay gating (#77 step 4). A cohort whose every commit was placed
+  // there by the `defaultMode` prior is not a measurement — it is the
+  // assumption describing itself, rendered as a table with numbers in it.
+  // The earlier `(N assumed)` labelling made the prior's contribution
+  // visible; this stops it from conjuring an overlay on its own. Cohorts
+  // stay in `metrics.json` either way: the gate is on presentation, not on
+  // data, so a consumer that wants the prior's view can still have it.
+  const evidenceBacked = (stats: Metrics['byMode']['agent']) =>
+    stats !== null && stats.commits - stats.assumed > 0;
+
+  const AI_MODES = ['agent', 'assisted', 'autocomplete'] as const;
+  const aiCohortHasEvidence = AI_MODES.some((mode) => evidenceBacked(metrics.byMode[mode]));
+  const baselineHasEvidence = evidenceBacked(metrics.byMode.none);
+
   const baselineLabel = metrics.baseline?.assumed
     ? 'Human baseline (assumed)'
     : 'Human baseline';
@@ -57,7 +71,7 @@ function generateMarkdownReport(metrics: Metrics): string {
 `
     : '';
 
-  const comparisonSection = metrics.baseline && metrics.delta
+  const comparisonSection = metrics.baseline && metrics.delta && aiCohortHasEvidence && baselineHasEvidence
     ? `## AI vs Baseline
 
 | Metric | AI commits | ${baselineLabel} | Delta |
@@ -68,7 +82,15 @@ function generateMarkdownReport(metrics: Metrics): string {
 ${fairComparisonSection}`
     : `## AI vs Baseline
 
-**No baseline available** — no commits sit at autonomy level \`none\`, so there is nothing honest to compare against. If the commits with no evidence in this repo were hand-written, set \`"defaultMode": "none"\` in \`.aida.json\`.
+${
+      metrics.baseline && metrics.delta
+        ? `**Comparison withheld** — one side of it exists only because of the \`${a.defaultMode}\` prior: ${
+            aiCohortHasEvidence
+              ? 'every commit in the baseline cohort was placed there by assumption'
+              : 'every commit in the AI cohort was placed there by assumption'
+          }, not by evidence. A measured cohort against an assumed one yields a delta that describes the prior, not the repo. Install the commit hook (\`aida install-hooks\`) so commits declare their own mode — the cohorts stay in \`metrics.json\` meanwhile.`
+        : `**No baseline available** — no commits sit at autonomy level \`none\`, so there is nothing honest to compare against. If the commits with no evidence in this repo were hand-written, set \`"defaultMode": "none"\` in \`.aida.json\`.`
+    }
 `;
 
   const categories = ['source', 'tests', 'migrations', 'config', 'docs', 'generated'] as const;
@@ -100,7 +122,13 @@ ${categoryRows.join('\n')}
 `
       : '';
 
-  const fairnessSection = `## Cohort Fairness
+  // Gated only when NEITHER side has evidence — then every column would be
+  // the prior's doing. With one real cohort the table still carries its age
+  // and task mix, which is information the repo genuinely has; the empty
+  // column speaks for itself, as it did before this gate existed.
+  const fairnessSection = !(aiCohortHasEvidence || baselineHasEvidence)
+    ? ''
+    : `## Cohort Fairness
 
 Persistence comparisons are only meaningful between cohorts of similar **age** and **task mix**.
 
@@ -115,25 +143,49 @@ ${byCategorySection}`;
   const modeOrder = ['agent', 'assisted', 'autocomplete', 'none', 'unknown'] as const;
   const modeRows = modeOrder
     .map((mode) => ({ mode, stats: metrics.byMode[mode] }))
+    // Gated (#77 step 4): a row with no evidence behind it is the prior
+    // talking to itself. `unknown` is exempt — it IS the no-evidence bucket,
+    // and reporting its size is the honest part.
+    .filter((row) => row.mode === 'unknown' || evidenceBacked(row.stats))
     .filter((row) => row.stats !== null)
     .map(
       ({ mode, stats }) =>
         `| ${mode} | ${stats!.commits}${stats!.assumed > 0 ? ` (${stats!.assumed} assumed)` : ''} | ${stats!.persistence.avgDays} | ${stats!.persistence.medianDays} | ${stats!.persistence.censored} |`
     );
+  const gatedModes = modeOrder.filter(
+    (mode) => mode !== 'unknown' && metrics.byMode[mode] !== null && !evidenceBacked(metrics.byMode[mode])
+  );
+  // Three states, not two: a rendered table, an explained withholding, or
+  // nothing at all when there is genuinely no cohort data. The middle case
+  // matters — dropping the section silently would hide the fact that a prior
+  // is configured and doing nothing, which is itself worth knowing.
+  const hasAnyCohort = modeOrder.some((mode) => metrics.byMode[mode] !== null);
   const byModeSection =
     modeRows.length > 0
       ? `## By Autonomy Level
 
 The comparison that stays meaningful when everything is AI-assisted: how code holds up per autonomy level (automated commits excluded).
 
-Cohorts here include commits placed by the \`defaultMode\` prior, marked *assumed* — so these counts can exceed the observed ones above, which only ever report what the commits themselves declare.
+Cohorts here include commits placed by the \`defaultMode\` prior, marked *assumed* — so these counts can exceed the observed ones above, which only ever report what the commits themselves declare.${
+          gatedModes.length > 0
+            ? `\n\n> ${gatedModes.length === 1 ? `The \`${gatedModes[0]}\` level is` : `The \`${gatedModes.join('`, `')}\` levels are`} not shown: every commit in ${gatedModes.length === 1 ? 'it' : 'them'} is there by prior, with no evidence behind it. The data is still in \`metrics.json\`.`
+            : ''
+        }
 
 | Mode | Commits | Avg persistence (d) | Median (d) | Surviving |
 |---|---:|---:|---:|---:|
 ${modeRows.join('\n')}
 
 `
-      : '';
+      : hasAnyCohort
+        ? `## By Autonomy Level
+
+**Withheld** — every autonomy cohort in this repo exists only because of the \`${a.defaultMode}\` prior${gatedModes.length > 0 ? ` (${gatedModes.join(', ')})` : ''}: not one commit carries evidence of the level it was written at, so a table here would be the assumption describing itself. The cohorts are still in \`metrics.json\` for anyone who wants the prior's view.
+
+Install the commit hook (\`aida install-hooks\`) so commits declare their own mode — see Data Quality below.
+
+`
+        : '';
 
   const ls = metrics.lineSurvival;
   const lineSection = ls
@@ -298,7 +350,7 @@ How the code holds up, as a property of the **repo** — measured over all ${rq.
 ${trendSection}
 `;
 
-  const baselineDetail = metrics.baseline
+  const baselineDetail = metrics.baseline && baselineHasEvidence
     ? `## ${baselineLabel}
 - Persistence — commits considered: ${metrics.baseline.persistence.commitsConsidered}, avg: ${metrics.baseline.persistence.avgDays}d, median: ${metrics.baseline.persistence.medianDays}d
 


### PR DESCRIPTION
Closes #77 — the last of the four migration steps.

The `(N assumed)` labelling shipped earlier made the prior's contribution **visible**. This stops it from creating an overlay at all: a cohort whose every commit was placed there by `defaultMode` is not a measurement, it is the assumption describing itself with numbers next to it.

## What is gated

| Section | Rule |
|---|---|
| `By Autonomy Level` rows | rendered only where `commits − assumed > 0`; `unknown` exempt |
| `AI vs Baseline` | withheld when either side is pure prior |
| `Cohort Fairness` | gated only when **neither** side has evidence |
| `Code Quality` / `Trend` | untouched — they never needed evidence |

`unknown` is deliberately exempt: it *is* the no-evidence bucket, and reporting its size is the honest part, not the part to hide.

## Nothing is dropped silently

The first implementation made the section disappear when every row was gated — silent hiding, the failure mode this project keeps finding in itself. **Its own test caught it**, and the fix added a third state: the section renders, says it is withheld, and names the prior responsible. A configured `defaultMode` doing nothing is itself worth telling the reader.

The gate is on presentation only. Every cohort stays in `metrics.json`, so a consumer that wants the prior's view still has it.

## One deliberate loosening

I first gated `Cohort Fairness` alongside the comparison, and the e2e suite caught that this repo would lose its task-mix table — it has a real AI cohort and no human one. Fairness is now gated only when *neither* side has evidence: with one real cohort, its age and task mix are information the repo genuinely has, and the empty column speaks for itself as it did before.

## Dogfood

- **This repo** (full evidence): `agent 110` renders unchanged.
- **varano-239**: `agent 26 (11 assumed)` renders — 15 commits genuinely declare `agent`, so the prior's 11 ride along labelled rather than gating the row.
- **Synthetic 0%-evidence repo with `--default-mode agent`**: the prior would have produced a complete `agent 2` cohort out of nothing. Now: *"**Withheld** — every autonomy cohort in this repo exists only because of the `agent` prior… a table here would be the assumption describing itself."*

## Tests

261 passing (was 257). A new `report-gating.test.ts` drives the real `collect → analyze → report` pipeline over purpose-built repos rather than fixtures, covering all four states: pure prior withheld, one real commit unlocking the overlay, comparison withheld with one assumed side, and `unknown` surviving. Assertions are scoped to the overlay section — the observed table showing `agent 0` is correct and must keep showing it.

With this, #77's migration path is complete: repo-level quality (#78) → report reframe (#80) → quality over time (#81) → overlay gating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)